### PR TITLE
Preserve CA trust after clearing traffic

### DIFF
--- a/src/commonMain/kotlin/app/andy/App.kt
+++ b/src/commonMain/kotlin/app/andy/App.kt
@@ -2981,6 +2981,8 @@ private fun NetworkScreen(
 
     var caInstalled by remember { mutableStateOf(false) }
     var proxyConfigured by remember { mutableStateOf(false) }
+    var userCaVerifiedByTrafficForDevice by remember { mutableStateOf(false) }
+    var proxyTrafficObservedForDevice by remember { mutableStateOf(false) }
     val latestRules by rememberUpdatedState(rules)
 
     LaunchedEffect(Unit) {
@@ -3017,6 +3019,10 @@ private fun NetworkScreen(
             status = it
         }
     }
+    LaunchedEffect(userCaVerifiedByTraffic, proxyTrafficObserved) {
+        if (userCaVerifiedByTraffic) userCaVerifiedByTrafficForDevice = true
+        if (proxyTrafficObserved) proxyTrafficObservedForDevice = true
+    }
     LaunchedEffect(serial, currentPort) {
         if (serial == null) {
             caInstalled = false
@@ -3033,6 +3039,8 @@ private fun NetworkScreen(
         }
     }
     LaunchedEffect(serial) {
+        userCaVerifiedByTrafficForDevice = false
+        proxyTrafficObservedForDevice = false
         proxyHost = serial?.let { selectedSerial ->
             val activation = proxy.activatePersistedCertificateAuthority(selectedSerial)
             if (activation.isSuccess && activation.stdout.isNotBlank()) {
@@ -3218,8 +3226,8 @@ private fun NetworkScreen(
                 val caText = when {
                     serial == null -> "Select a device first"
                     caInstalled -> "System CA installed"
-                    userCaVerifiedByTraffic -> "User CA verified by HTTPS traffic"
-                    proxyTrafficObserved -> "Traffic observed"
+                    userCaVerifiedByTrafficForDevice -> "User CA verified by HTTPS traffic"
+                    proxyTrafficObservedForDevice -> "Traffic observed"
                     else -> "Use System CA or Prepare phone CA"
                 }
                 val configText = when {
@@ -3242,7 +3250,7 @@ private fun NetworkScreen(
                         hint = if (proxyStarted) "Listening on port $currentPort" else "Click 'Start' to start"
                     )
                     StatusIndicator(
-                        isOk = serial != null && (caInstalled || proxyTrafficObserved),
+                        isOk = serial != null && (caInstalled || proxyTrafficObservedForDevice),
                         label = "CA Trust",
                         hint = caText
                     )

--- a/src/commonMain/kotlin/app/andy/App.kt
+++ b/src/commonMain/kotlin/app/andy/App.kt
@@ -2974,15 +2974,12 @@ private fun NetworkScreen(
     val visibleTrafficRows = remember(trafficTree, expandedTrafficKeys.toMap()) {
         flattenNetworkTrafficTree(trafficTree, expandedTrafficKeys)
     }
-    val userCaVerifiedByTraffic = remember(exchanges) {
-        exchanges.any { it.tlsStatus == "tls" && it.error == null }
-    }
-    val proxyTrafficObserved = exchanges.isNotEmpty()
-
     var caInstalled by remember { mutableStateOf(false) }
     var proxyConfigured by remember { mutableStateOf(false) }
     var userCaVerifiedByTrafficForDevice by remember { mutableStateOf(false) }
     var proxyTrafficObservedForDevice by remember { mutableStateOf(false) }
+    var trafficEvidenceSerial by remember { mutableStateOf<String?>(null) }
+    var flowIdsAtSerialChange by remember { mutableStateOf(emptySet<String>()) }
     val latestRules by rememberUpdatedState(rules)
 
     LaunchedEffect(Unit) {
@@ -3019,9 +3016,19 @@ private fun NetworkScreen(
             status = it
         }
     }
-    LaunchedEffect(userCaVerifiedByTraffic, proxyTrafficObserved) {
-        if (userCaVerifiedByTraffic) userCaVerifiedByTrafficForDevice = true
-        if (proxyTrafficObserved) proxyTrafficObservedForDevice = true
+    LaunchedEffect(serial, exchanges) {
+        if (serial != trafficEvidenceSerial) {
+            trafficEvidenceSerial = serial
+            flowIdsAtSerialChange = exchanges.map { it.flowId }.toSet()
+            userCaVerifiedByTrafficForDevice = false
+            proxyTrafficObservedForDevice = false
+        } else {
+            val newExchanges = exchanges.filter { it.flowId !in flowIdsAtSerialChange }
+            if (newExchanges.isNotEmpty()) proxyTrafficObservedForDevice = true
+            if (newExchanges.any { it.tlsStatus == "tls" && it.error == null }) {
+                userCaVerifiedByTrafficForDevice = true
+            }
+        }
     }
     LaunchedEffect(serial, currentPort) {
         if (serial == null) {
@@ -3039,8 +3046,6 @@ private fun NetworkScreen(
         }
     }
     LaunchedEffect(serial) {
-        userCaVerifiedByTrafficForDevice = false
-        proxyTrafficObservedForDevice = false
         proxyHost = serial?.let { selectedSerial ->
             val activation = proxy.activatePersistedCertificateAuthority(selectedSerial)
             if (activation.isSuccess && activation.stdout.isNotBlank()) {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -10,10 +10,10 @@ import java.nio.file.Files
 
 internal class MockAndroidDeviceEnvironment {
     private val sdkRoot = Files.createTempDirectory("andy-mock-sdk").toFile()
-    private val adb = executable("platform-tools/adb")
-    private val emulator = executable("emulator/emulator")
-    private val sdkManager = executable("cmdline-tools/latest/bin/sdkmanager")
-    private val avdManager = executable("cmdline-tools/latest/bin/avdmanager")
+    private val adb = executable("platform-tools/${toolName("adb", windowsExtension = "exe")}")
+    private val emulator = executable("emulator/${toolName("emulator", windowsExtension = "bat")}")
+    private val sdkManager = executable("cmdline-tools/latest/bin/${toolName("sdkmanager", windowsExtension = "bat")}")
+    private val avdManager = executable("cmdline-tools/latest/bin/${toolName("avdmanager", windowsExtension = "bat")}")
     private val avdHome = File(sdkRoot, "avd")
 
     val store = InMemoryWorkspaceStore(WorkspaceState(selectedSdkPath = sdkRoot.absolutePath))
@@ -80,10 +80,19 @@ internal class MockAndroidDeviceEnvironment {
         return commands.any { command -> command.windowed(tokens.size).any { it == tokens.toList() } }
     }
 
+    private fun toolName(name: String, windowsExtension: String): String {
+        val os = System.getProperty("os.name")
+        return if (os.startsWith("Windows", ignoreCase = true)) "$name.$windowsExtension" else name
+    }
+
     private fun executable(relativePath: String): File {
         val file = File(sdkRoot, relativePath)
         file.parentFile.mkdirs()
-        file.writeText("#!/bin/sh\nexit 0\n")
+        if (file.extension.equals("bat", ignoreCase = true)) {
+            file.writeText("@echo off\r\nexit /b 0\r\n")
+        } else {
+            file.writeText("#!/bin/sh\nexit 0\n")
+        }
         file.setExecutable(true)
         return file
     }


### PR DESCRIPTION
## Summary
- keep CA trust status green after Clear traffic by tracking observed trust evidence separately from the visible exchange list
- reset the remembered traffic evidence when the selected device changes

## Tests
- ./gradlew compileKotlinDesktop
- ./gradlew desktopTest