### PR TITLE
Fix macOS release entitlements and app name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,9 @@ val andyDebugDistribution = providers.gradleProperty("andy.debugDistribution")
     .orElse(providers.environmentVariable("ANDY_DEBUG_DISTRIBUTION"))
     .map(String::toBoolean)
     .orElse(false)
+val andyAppName = "Andy"
 val andyPackageId = if (andyDebugDistribution.get()) "com.joetr.andy.debug" else "com.joetr.andy"
+val andyMacEntitlementsFile = layout.projectDirectory.file("packaging/macos/entitlements.plist")
 
 val andyJpackagePackageVersion = run {
     val parts = andyVersionName.split(".")
@@ -138,13 +140,14 @@ compose.desktop {
                 org.jetbrains.compose.desktop.application.dsl.TargetFormat.Msi,
                 org.jetbrains.compose.desktop.application.dsl.TargetFormat.Deb,
             )
-            packageName = andyPackageId
+            packageName = andyAppName
             packageVersion = andyJpackagePackageVersion
             description = "Android emulator and device companion"
             vendor = "Andy"
             macOS {
                 bundleID = andyPackageId
                 iconFile.set(project.file("src/desktopMain/resources/icons/andy.icns"))
+                entitlementsFile.set(andyMacEntitlementsFile)
                 signing {
                     identity.set(
                         providers.gradleProperty("compose.desktop.mac.signing.identity")
@@ -159,6 +162,7 @@ compose.desktop {
                 iconFile.set(project.file("src/desktopMain/resources/icons/andy.ico"))
             }
             linux {
+                packageName = andyPackageId
                 iconFile.set(project.file("src/desktopMain/resources/icons/andy.png"))
             }
         }
@@ -252,6 +256,8 @@ val resignMacReleaseApp by tasks.registering {
                     "--deep",
                     "--options",
                     "runtime",
+                    "--entitlements",
+                    andyMacEntitlementsFile.asFile.absolutePath,
                     "--timestamp",
                     "--sign",
                     identity,

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+    </dict>
+</plist>


### PR DESCRIPTION
## Summary
- package the desktop app as `Andy` while keeping the macOS bundle id as `com.joetr.andy`
- add explicit macOS code-signing entitlements required by the JVM/Skiko native runtime
- preserve those entitlements in the custom release re-sign step

## Why
The current macOS release is signed with the hardened runtime but no entitlements. On Apple Silicon, HotSpot traps during JVM startup in `pthread_jit_write_protect_np`, producing an `EXC_BREAKPOINT / SIGTRAP` crash before app code runs.

## Verification
- `./gradlew createReleaseDistributable --stacktrace`
- verified generated app is `build/compose/binaries/main-release/app/Andy.app`
- verified generated `Info.plist` has `CFBundleName = Andy`, `CFBundleExecutable = Andy`, and `CFBundleIdentifier = com.joetr.andy`
- verified generated app entitlements include `com.apple.security.cs.allow-jit`
- `./gradlew check`
