### PR TITLE
Address MCP action runner review feedback

### DIFF
--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -7,7 +7,6 @@ import app.andy.model.RunningAction
 import app.andy.service.ActionRunService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,7 +21,6 @@ class DesktopActionRunService(
 ) : ActionRunService {
     private data class RunHandle(
         val process: Process?,
-        val readerJob: Job?,
         val output: MutableStateFlow<List<String>>,
     )
 
@@ -68,18 +66,17 @@ class DesktopActionRunService(
                 .start()
         }.fold(
             onSuccess = { process ->
-                val job = scope.launch(Dispatchers.IO) {
+                handles[runId] = RunHandle(process, output)
+                scope.launch(Dispatchers.IO) {
                     runCatching { readProcessOutput(process, output) }
                     val exitCode = runCatching { process.waitFor() }.getOrElse { -1 }
                     markComplete(runId, if (exitCode == 0) ActionRunStatus.Exited else ActionRunStatus.Failed, exitCode)
-                    handles[runId] = handles[runId]?.copy(readerJob = null) ?: RunHandle(process, null, output)
                 }
-                handles[runId] = RunHandle(process, job, output)
             },
             onFailure = { error ->
                 output.update { it + "failed to start: ${error.message ?: error::class.simpleName.orEmpty()}" }
                 markComplete(runId, ActionRunStatus.Failed, null)
-                handles[runId] = RunHandle(null, null, output)
+                handles[runId] = RunHandle(null, output)
             },
         )
         return runId
@@ -89,7 +86,6 @@ class DesktopActionRunService(
         val handle = handles[runId] ?: return
         scope.launch(Dispatchers.IO) {
             handle.process?.let(::killTree)
-            handle.readerJob?.cancel()
             markComplete(runId, ActionRunStatus.Stopped, null)
         }
     }
@@ -137,13 +133,15 @@ class DesktopActionRunService(
     }
 
     private fun shellCommand(command: String): List<String> {
-        val osName = System.getProperty("os.name").lowercase()
+        val osName = System.getProperty("os.name")?.lowercase().orEmpty()
         return if (osName.contains("win")) {
             val shell = System.getenv("COMSPEC")?.takeIf { it.isNotBlank() } ?: "cmd.exe"
             listOf(shell, "/c", command)
         } else {
             val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: "/bin/sh"
-            listOf(shell, "-lc", command)
+            val shellName = shell.replace('\\', '/').substringAfterLast('/')
+            val flag = if (shellName == "sh") "-c" else "-lc"
+            listOf(shell, flag, command)
         }
     }
 

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -58,8 +58,7 @@ class DesktopActionRunService(
         _running.update { it + snapshot }
 
         runCatching {
-            val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: "/bin/sh"
-            ProcessBuilder(shell, "-lc", action.command)
+            ProcessBuilder(shellCommand(action.command))
                 .directory(File(cwd))
                 .redirectErrorStream(true)
                 .apply {
@@ -70,8 +69,8 @@ class DesktopActionRunService(
         }.fold(
             onSuccess = { process ->
                 val job = scope.launch(Dispatchers.IO) {
-                    readProcessOutput(process, output)
-                    val exitCode = process.waitFor()
+                    runCatching { readProcessOutput(process, output) }
+                    val exitCode = runCatching { process.waitFor() }.getOrElse { -1 }
                     markComplete(runId, if (exitCode == 0) ActionRunStatus.Exited else ActionRunStatus.Failed, exitCode)
                     handles[runId] = handles[runId]?.copy(readerJob = null) ?: RunHandle(process, null, output)
                 }
@@ -128,8 +127,23 @@ class DesktopActionRunService(
     private fun markComplete(runId: String, status: ActionRunStatus, exitCode: Int?) {
         _running.update { runs ->
             runs.map { run ->
-                if (run.runId == runId) run.copy(status = status, exitCode = exitCode) else run
+                if (run.runId == runId && run.status == ActionRunStatus.Running) {
+                    run.copy(status = status, exitCode = exitCode)
+                } else {
+                    run
+                }
             }
+        }
+    }
+
+    private fun shellCommand(command: String): List<String> {
+        val osName = System.getProperty("os.name").lowercase()
+        return if (osName.contains("win")) {
+            val shell = System.getenv("COMSPEC")?.takeIf { it.isNotBlank() } ?: "cmd.exe"
+            listOf(shell, "/c", command)
+        } else {
+            val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: "/bin/sh"
+            listOf(shell, "-lc", command)
         }
     }
 

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
@@ -17,6 +17,8 @@ import io.modelcontextprotocol.kotlin.sdk.server.mcp
 import io.modelcontextprotocol.kotlin.sdk.types.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
 import java.io.File
 import java.util.Base64
@@ -38,19 +40,20 @@ class DesktopMcpServerService(
 
     private var serverEngine: EmbeddedServer<*, *>? = null
     private var runningPort: Int? = null
+    private val serverMutex = Mutex()
 
-    override suspend fun start(port: Int): CommandResult = withContext(Dispatchers.IO) {
+    override suspend fun start(port: Int): CommandResult = withContext(Dispatchers.IO) { serverMutex.withLock {
         if (serverEngine != null) {
             if (runningPort == port) {
-                return@withContext CommandResult.success("Already running")
+                return@withLock CommandResult.success("Already running")
             }
-            stop()
+            stopEngine()
         }
 
         if (!isPortAvailable(port)) {
             status.value = "error: port $port already in use"
             running.value = false
-            return@withContext CommandResult.failure("Port $port is already in use")
+            return@withLock CommandResult.failure("Port $port is already in use")
         }
 
         try {
@@ -83,9 +86,14 @@ class DesktopMcpServerService(
             runningPort = null
             CommandResult.failure("Failed to start server: ${e.message}")
         }
-    }
+    } }
 
-    override suspend fun stop(): CommandResult = withContext(Dispatchers.IO) {
+    override suspend fun stop(): CommandResult = withContext(Dispatchers.IO) { serverMutex.withLock {
+        stopEngine()
+        CommandResult.success("Server stopped")
+    } }
+
+    private fun stopEngine() {
         val engine = serverEngine
         if (engine != null) {
             try {
@@ -98,7 +106,6 @@ class DesktopMcpServerService(
         runningPort = null
         status.value = "stopped"
         running.value = false
-        CommandResult.success("Server stopped")
     }
 
     override fun getSnippet(clientName: String, port: Int): String {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
@@ -37,10 +37,14 @@ class DesktopMcpServerService(
     override val running = MutableStateFlow(false)
 
     private var serverEngine: EmbeddedServer<*, *>? = null
+    private var runningPort: Int? = null
 
     override suspend fun start(port: Int): CommandResult = withContext(Dispatchers.IO) {
         if (serverEngine != null) {
-            return@withContext CommandResult.success("Already running")
+            if (runningPort == port) {
+                return@withContext CommandResult.success("Already running")
+            }
+            stop()
         }
 
         if (!isPortAvailable(port)) {
@@ -66,6 +70,7 @@ class DesktopMcpServerService(
 
             serverEngine = engine
             engine.start(wait = false)
+            runningPort = port
 
             status.value = "running on 127.0.0.1:$port"
             running.value = true
@@ -75,6 +80,7 @@ class DesktopMcpServerService(
             status.value = "error: ${e.message ?: "start failed"}"
             running.value = false
             serverEngine = null
+            runningPort = null
             CommandResult.failure("Failed to start server: ${e.message}")
         }
     }
@@ -89,6 +95,7 @@ class DesktopMcpServerService(
             }
             serverEngine = null
         }
+        runningPort = null
         status.value = "stopped"
         running.value = false
         CommandResult.success("Server stopped")

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpClientConfig.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpClientConfig.kt
@@ -68,7 +68,7 @@ object McpClientConfig {
             ClientType.Cursor -> File(home, ".cursor/mcp.json")
             ClientType.Codex -> File(home, ".codex/config.toml")
             ClientType.ClaudeDesktop -> {
-                val osName = System.getProperty("os.name").lowercase()
+                val osName = System.getProperty("os.name")?.lowercase().orEmpty()
                 if (osName.contains("win")) {
                     val appData = System.getenv("APPDATA")?.takeIf { it.isNotBlank() }
                         ?: File(home, "AppData/Roaming").absolutePath

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpClientConfig.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpClientConfig.kt
@@ -67,7 +67,16 @@ object McpClientConfig {
             ClientType.ClaudeCode -> File(home, ".claude.json")
             ClientType.Cursor -> File(home, ".cursor/mcp.json")
             ClientType.Codex -> File(home, ".codex/config.toml")
-            ClientType.ClaudeDesktop -> File(home, "Library/Application Support/Claude/claude_desktop_config.json")
+            ClientType.ClaudeDesktop -> {
+                val osName = System.getProperty("os.name").lowercase()
+                if (osName.contains("win")) {
+                    val appData = System.getenv("APPDATA")?.takeIf { it.isNotBlank() }
+                        ?: File(home, "AppData/Roaming").absolutePath
+                    File(appData, "Claude/claude_desktop_config.json")
+                } else {
+                    File(home, "Library/Application Support/Claude/claude_desktop_config.json")
+                }
+            }
             else -> null
         }
     }
@@ -104,7 +113,7 @@ object McpClientConfig {
 
     private fun mergeJson(client: ClientType, content: String, port: Int): String {
         val json = runCatching { Json.parseToJsonElement(content).jsonObject }.getOrNull() ?: JsonObject(emptyMap())
-        val mcpServers = json["mcpServers"]?.jsonObject?.toMutableMap() ?: mutableMapOf()
+        val mcpServers = (json["mcpServers"] as? JsonObject)?.toMutableMap() ?: mutableMapOf()
         val usesLegacySse = client == ClientType.ClaudeDesktop
         mcpServers["andy"] = buildJsonObject {
             put("type", if (usesLegacySse) "sse" else "http")

--- a/src/desktopTest/kotlin/app/andy/desktop/service/McpClientConfigTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/McpClientConfigTest.kt
@@ -1,0 +1,52 @@
+package app.andy.desktop.service
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class McpClientConfigTest {
+    @Test
+    fun claudeDesktopConfigPathUsesWindowsAppDataLocation() {
+        val originalOsName = System.getProperty("os.name")
+        val originalHome = System.getProperty("user.home")
+        val testHome = kotlin.io.path.createTempDirectory("andy-mcp-home").toFile()
+        try {
+            System.setProperty("os.name", "Windows 11")
+            System.setProperty("user.home", testHome.absolutePath)
+
+            val file = McpClientConfig.getConfigFile(McpClientConfig.ClientType.ClaudeDesktop)
+
+            assertEquals(
+                File(testHome, "AppData/Roaming/Claude/claude_desktop_config.json").absolutePath,
+                file?.absolutePath,
+            )
+        } finally {
+            System.setProperty("os.name", originalOsName)
+            System.setProperty("user.home", originalHome)
+            testHome.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun jsonMergeReplacesInvalidMcpServersValue() {
+        val originalHome = System.getProperty("user.home")
+        val testHome = kotlin.io.path.createTempDirectory("andy-mcp-home").toFile()
+        try {
+            System.setProperty("user.home", testHome.absolutePath)
+            val file = File(testHome, ".claude.json")
+            file.writeText("""{"mcpServers": false, "keep": "value"}""")
+
+            val written = McpClientConfig.writeConfig(McpClientConfig.ClientType.ClaudeCode, 4987)
+
+            assertTrue(written)
+            val content = file.readText()
+            assertTrue(content.contains(""""keep": "value""""))
+            assertTrue(content.contains(""""andy""""))
+            assertTrue(content.contains(""""url": "http://127.0.0.1:4987/mcp-http""""))
+        } finally {
+            System.setProperty("user.home", originalHome)
+            testHome.deleteRecursively()
+        }
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/McpClientConfigTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/McpClientConfigTest.kt
@@ -16,9 +16,11 @@ class McpClientConfigTest {
             System.setProperty("user.home", testHome.absolutePath)
 
             val file = McpClientConfig.getConfigFile(McpClientConfig.ClientType.ClaudeDesktop)
+            val appData = System.getenv("APPDATA")?.takeIf { it.isNotBlank() }
+                ?: File(testHome, "AppData/Roaming").absolutePath
 
             assertEquals(
-                File(testHome, "AppData/Roaming/Claude/claude_desktop_config.json").absolutePath,
+                File(appData, "Claude/claude_desktop_config.json").absolutePath,
                 file?.absolutePath,
             )
         } finally {


### PR DESCRIPTION
## Summary
- make action command execution resolve the host shell cross-platform
- keep action runs from getting stuck or overwritten after stop/process-reader failures
- restart the MCP server when the configured port changes
- make Claude Desktop config path OS-aware and JSON config merging resilient to malformed mcpServers values

Addresses review feedback from #3.

## Tests
- ./gradlew desktopTest