### PR TITLE
Improve emulator mirror diagnostics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,10 @@ kotlin {
                 implementation("io.ktor:ktor-server-netty:3.0.1")
                 implementation("io.ktor:ktor-server-sse:3.0.1")
                 implementation("io.ktor:ktor-server-double-receive:3.0.1")
+                implementation("io.grpc:grpc-api:1.69.0")
+                implementation("io.grpc:grpc-core:1.69.0")
+                implementation("io.grpc:grpc-netty-shaded:1.69.0")
+                implementation("io.grpc:grpc-stub:1.69.0")
 
                 // Add the base JavaCV library
                 implementation("org.bytedeco:javacv:1.5.11")

--- a/src/commonMain/kotlin/app/andy/App.kt
+++ b/src/commonMain/kotlin/app/andy/App.kt
@@ -114,6 +114,7 @@ import app.andy.andy.generated.resources.intellij_node_folder_dark
 import app.andy.model.*
 import app.andy.service.*
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
@@ -361,7 +362,13 @@ private fun rememberMirrorInputSender(
                 return@collectLatest
             }
             while (true) {
-                latestAccessibilityRoot = services.accessibility.dump(activeSerial)
+                latestAccessibilityRoot = try {
+                    services.accessibility.dump(activeSerial)
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (_: Exception) {
+                    null
+                }
                 delay(BugAccessibilitySnapshotMillis)
             }
         }
@@ -416,7 +423,15 @@ private fun rememberMirrorInputSender(
                                     val lookup = tapAccessibilityLookup
                                     tapAccessibilityLookup = null
                                     scope.launch {
-                                        val root = lookup?.let { withTimeoutOrNull(BugTapAccessibilityLookupMillis) { it.await() } }
+                                        val root = lookup?.let {
+                                            try {
+                                                withTimeoutOrNull(BugTapAccessibilityLookupMillis) { it.await() }
+                                            } catch (cancelled: CancellationException) {
+                                                throw cancelled
+                                            } catch (_: Exception) {
+                                                null
+                                            }
+                                        }
                                             ?: currentAccessibilityRoot
                                         val (tapLabel, tapDetail) = mirrorTapBugText(input.x, input.y, root)
                                         services.bugs.recordAction("input", tapLabel, tapDetail)

--- a/src/commonMain/kotlin/app/andy/App.kt
+++ b/src/commonMain/kotlin/app/andy/App.kt
@@ -7396,7 +7396,8 @@ private fun activeBugPointerEvent(actions: List<BugAction>, playbackMillis: Long
 
 private fun parseBugActionPoint(action: BugAction): Pair<Int, Int>? {
     if (action.kind != "input") return null
-    val match = Regex("""(\d+),(\d+)""").find(action.label) ?: return null
+    val text = listOfNotNull(action.label, action.detail).joinToString(" ")
+    val match = Regex("""(\d+),(\d+)""").find(text) ?: return null
     val x = match.groupValues.getOrNull(1)?.toIntOrNull() ?: return null
     val y = match.groupValues.getOrNull(2)?.toIntOrNull() ?: return null
     return x to y

--- a/src/commonMain/kotlin/app/andy/App.kt
+++ b/src/commonMain/kotlin/app/andy/App.kt
@@ -3,6 +3,10 @@ package app.andy
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.BorderStroke
@@ -109,7 +113,10 @@ import app.andy.andy.generated.resources.intellij_filetype_yaml_dark
 import app.andy.andy.generated.resources.intellij_node_folder_dark
 import app.andy.model.*
 import app.andy.service.*
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -119,6 +126,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.animation.core.*
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
@@ -339,7 +347,25 @@ private fun rememberMirrorInputSender(
     val currentSerial by rememberUpdatedState(serial)
     val currentEnabled by rememberUpdatedState(enabled)
     val currentRecordActions by rememberUpdatedState(recordActions)
+    var latestAccessibilityRoot by remember { mutableStateOf<AccessibilityNode?>(null) }
+    val currentAccessibilityRoot by rememberUpdatedState(latestAccessibilityRoot)
+    var touchGesture by remember { mutableStateOf<BugTouchGesture?>(null) }
+    var tapAccessibilityLookup by remember { mutableStateOf<Deferred<AccessibilityNode?>?>(null) }
+    val scope = rememberCoroutineScope()
     val channel = remember(services.mirror) { Channel<MirrorInput>(Channel.UNLIMITED) }
+    LaunchedEffect(services.bugs, services.accessibility, serial) {
+        services.bugs.status.collectLatest { status ->
+            val activeSerial = serial
+            if (!status.active || status.deviceSerial != activeSerial || activeSerial == null) {
+                latestAccessibilityRoot = null
+                return@collectLatest
+            }
+            while (true) {
+                latestAccessibilityRoot = services.accessibility.dump(activeSerial)
+                delay(BugAccessibilitySnapshotMillis)
+            }
+        }
+    }
     LaunchedEffect(channel, services.mirror) {
         for (input in channel) {
             if (currentEnabled && currentSerial != null) {
@@ -353,24 +379,142 @@ private fun rememberMirrorInputSender(
     return remember(channel) {
         { input ->
             if (currentEnabled && currentSerial != null && currentRecordActions) {
-                val (label, detail) = mirrorInputBugText(input)
-                services.bugs.recordAction("input", label, detail)
+                when (input) {
+                    is MirrorInput.Touch -> {
+                        val now = System.currentTimeMillis()
+                        when (input.action) {
+                            MirrorTouchAction.Down -> {
+                                touchGesture = BugTouchGesture(input.x, input.y, input.x, input.y, now)
+                                tapAccessibilityLookup?.cancel()
+                                tapAccessibilityLookup = scope.async {
+                                    val activeSerial = currentSerial ?: return@async null
+                                    services.accessibility.dump(activeSerial)
+                                }
+                            }
+                            MirrorTouchAction.Move -> {
+                                touchGesture = touchGesture?.copy(lastX = input.x, lastY = input.y, moved = true)
+                            }
+                            MirrorTouchAction.Up -> {
+                                val gesture = touchGesture
+                                touchGesture = null
+                                val (label, detail) = if (gesture != null && gesture.isSwipeTo(input.x, input.y)) {
+                                    tapAccessibilityLookup?.cancel()
+                                    tapAccessibilityLookup = null
+                                    mirrorSwipeBugText(
+                                        startX = gesture.startX,
+                                        startY = gesture.startY,
+                                        endX = input.x,
+                                        endY = input.y,
+                                        durationMillis = (now - gesture.startedAtMillis).toInt().coerceAtLeast(0),
+                                    )
+                                } else {
+                                    null to null
+                                }
+                                if (label != null) {
+                                    services.bugs.recordAction("input", label, detail)
+                                } else {
+                                    val lookup = tapAccessibilityLookup
+                                    tapAccessibilityLookup = null
+                                    scope.launch {
+                                        val root = lookup?.let { withTimeoutOrNull(BugTapAccessibilityLookupMillis) { it.await() } }
+                                            ?: currentAccessibilityRoot
+                                        val (tapLabel, tapDetail) = mirrorTapBugText(input.x, input.y, root)
+                                        services.bugs.recordAction("input", tapLabel, tapDetail)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else -> {
+                        val (label, detail) = mirrorInputBugText(input, currentAccessibilityRoot)
+                        services.bugs.recordAction("input", label, detail)
+                    }
+                }
             }
             if (channel.trySend(input).isFailure) Unit
         }
     }
 }
 
-private fun mirrorInputBugText(input: MirrorInput): Pair<String, String?> = when (input) {
+private data class BugTouchGesture(
+    val startX: Int,
+    val startY: Int,
+    val lastX: Int,
+    val lastY: Int,
+    val startedAtMillis: Long,
+    val moved: Boolean = false,
+) {
+    fun isSwipeTo(endX: Int, endY: Int): Boolean {
+        val dx = endX - startX
+        val dy = endY - startY
+        return moved && dx * dx + dy * dy >= BugTapMaxDistancePx * BugTapMaxDistancePx
+    }
+}
+
+private const val BugAccessibilitySnapshotMillis = 1_500L
+private const val BugTapAccessibilityLookupMillis = 350L
+private const val BugTapMaxDistancePx = 24
+
+private fun mirrorInputBugText(input: MirrorInput, accessibilityRoot: AccessibilityNode?): Pair<String, String?> = when (input) {
     is MirrorInput.Touch -> "${input.action.name} ${input.x},${input.y}" to null
-    is MirrorInput.Tap -> "Tap ${input.x},${input.y}" to null
-    is MirrorInput.Swipe -> "Swipe ${input.startX},${input.startY} -> ${input.endX},${input.endY}" to "${input.durationMillis}ms"
+    is MirrorInput.Tap -> mirrorTapBugText(input.x, input.y, accessibilityRoot)
+    is MirrorInput.Swipe -> mirrorSwipeBugText(input.startX, input.startY, input.endX, input.endY, input.durationMillis)
     is MirrorInput.Key -> "Key ${input.keyCode}" to androidKeyLabel(input.keyCode)
     is MirrorInput.Text -> "Text input" to input.value.take(80)
     MirrorInput.Back -> "Back" to null
     MirrorInput.Home -> "Home" to null
     MirrorInput.Recents -> "Recents" to null
     MirrorInput.Power -> "Power" to null
+}
+
+private fun mirrorTapBugText(x: Int, y: Int, accessibilityRoot: AccessibilityNode?): Pair<String, String?> {
+    val node = accessibilityRoot?.findBestNodeAt(x, y) ?: return "Tap $x,$y" to null
+    val label = node.accessibilityBugLabel()
+    val className = node.className?.substringAfterLast('.')?.takeIf { it.isNotBlank() }
+    val title = buildString {
+        append("Tap")
+        if (label != null) append(" \"").append(label.take(80)).append("\"")
+        if (className != null) append(" [").append(className).append("]")
+    }
+    val detail = buildList {
+        add("$x,$y")
+        node.resourceId?.takeIf { it.isNotBlank() }?.let(::add)
+        node.packageName?.takeIf { it.isNotBlank() }?.let(::add)
+        node.bounds?.takeIf { it.isNotBlank() }?.let(::add)
+        node.accessibilityStateSummary()?.let(::add)
+    }.joinToString(" · ")
+    return title to detail
+}
+
+private fun mirrorSwipeBugText(startX: Int, startY: Int, endX: Int, endY: Int, durationMillis: Int): Pair<String, String?> {
+    val dx = endX - startX
+    val dy = endY - startY
+    val distance = kotlin.math.sqrt((dx * dx + dy * dy).toDouble()).toInt()
+    val direction = when {
+        kotlin.math.abs(dx) > kotlin.math.abs(dy) && dx > 0 -> "right"
+        kotlin.math.abs(dx) > kotlin.math.abs(dy) -> "left"
+        dy > 0 -> "down"
+        else -> "up"
+    }
+    return "Swipe $direction" to "${distance}px · ${durationMillis}ms · $startX,$startY -> $endX,$endY"
+}
+
+private fun AccessibilityNode.accessibilityBugLabel(): String? {
+    return listOf(text, contentDescription, hint, resourceId)
+        .firstOrNull { !it.isNullOrBlank() }
+        ?.trim()
+}
+
+private fun AccessibilityNode.accessibilityStateSummary(): String? {
+    val values = buildList {
+        if (clickable) add("clickable")
+        if (focusable) add("focusable")
+        if (scrollable) add("scrollable")
+        if (selected) add("selected")
+        if (checked) add("checked")
+        if (!enabled) add("disabled")
+    }
+    return values.takeIf { it.isNotEmpty() }?.joinToString(",")
 }
 
 private fun androidKeyLabel(keyCode: Int): String? = when (keyCode) {
@@ -380,13 +524,31 @@ private fun androidKeyLabel(keyCode: Int): String? = when (keyCode) {
 }
 
 @Composable
-private fun MirrorFrameContent(mirror: MirrorEngine, resetKey: Any?, content: @Composable (MirrorFrame?) -> Unit) {
+private fun MirrorFrameContent(mirror: MirrorEngine, resetKey: Any?, content: @Composable (Flow<MirrorFrame>, MirrorFrame?) -> Unit) {
     var frame by remember(mirror, resetKey) { mutableStateOf<MirrorFrame?>(null) }
     LaunchedEffect(mirror, resetKey) {
-        mirror.frames.collectLatest { frame = it.takeIf { it.width > 1 && it.height > 1 } }
+        mirror.frames.collectLatest { next ->
+            if (next.width <= 1 || next.height <= 1) {
+                // connect()/disconnect() push a 1x1 sentinel; clear the frame so the
+                // surface releases its last image instead of freezing on it.
+                frame = null
+                return@collectLatest
+            }
+            val previous = frame
+            if (
+                previous == null ||
+                previous.width != next.width ||
+                previous.height != next.height ||
+                next.frameNumber % MirrorMetadataFrameInterval == 0L
+            ) {
+                frame = next
+            }
+        }
     }
-    content(frame)
+    content(mirror.frames, frame)
 }
+
+private const val MirrorMetadataFrameInterval = 30L
 
 @Composable
 fun AndyApp(
@@ -459,12 +621,13 @@ fun AndyMirrorPopOut(
             }
         }
         Box(Modifier.fillMaxSize().background(Color.Black).padding(popOutPadding)) {
-            MirrorFrameContent(services.mirror, serial) { frame ->
+            MirrorFrameContent(services.mirror, serial) { frameFlow, frame ->
                 LiveDevicePane(
                     serial = serial,
                     device = null,
                     displayName = deviceName,
                     frame = frame,
+                    frameFlow = frameFlow,
                     mirrorStatus = mirrorStatus,
                     connectResult = connectResult,
                     modifier = Modifier.fillMaxSize(),
@@ -516,8 +679,11 @@ private fun AndyShell(
     var workspaceState by remember { mutableStateOf(WorkspaceState()) }
     var networkRulesVisible by remember { mutableStateOf(false) }
     var networkLiveVisible by remember { mutableStateOf(false) }
+    var performanceLiveVisible by remember { mutableStateOf(false) }
     var stoppingEmulatorSerial by remember { mutableStateOf<String?>(null) }
     var emulatorStopStatus by remember { mutableStateOf("") }
+    var startingEmulatorName by remember { mutableStateOf<String?>(null) }
+    var emulatorStartStatus by remember { mutableStateOf("") }
     var actionsConfig by remember { mutableStateOf(ActionsConfig()) }
     var activeRunId by remember { mutableStateOf<String?>(null) }
     val runningActions by services.actionRuns.running.collectAsState()
@@ -563,8 +729,10 @@ private fun AndyShell(
         }
     }
 
-    fun openStartedEmulator(previousSerials: Set<String>) {
+    fun openStartedEmulator(previousSerials: Set<String>, avdName: String) {
         scope.launch {
+            startingEmulatorName = avdName
+            emulatorStartStatus = "Starting $avdName..."
             repeat(60) {
                 val currentDevices = refreshDevicesNow()
                 val started = currentDevices.firstOrNull {
@@ -577,10 +745,15 @@ private fun AndyShell(
                 if (started != null) {
                     selectedSerial = started.serial
                     destination = AndyDestination.Live
+                    emulatorStartStatus = "${started.displayName} is online"
+                    startingEmulatorName = null
                     return@launch
                 }
+                emulatorStartStatus = "Starting $avdName... waiting for boot (${it + 1}/60)"
                 delay(1_000)
             }
+            emulatorStartStatus = "$avdName is still starting. Refresh devices when it finishes booting."
+            startingEmulatorName = null
         }
     }
 
@@ -666,6 +839,9 @@ private fun AndyShell(
                             Spacer(Modifier.width(8.dp))
                             FilterPill("Live", networkLiveVisible, Cyan) { networkLiveVisible = !networkLiveVisible }
                             Spacer(Modifier.width(10.dp))
+                        } else if (destination == AndyDestination.Performance) {
+                            FilterPill("Live", performanceLiveVisible, Cyan) { performanceLiveVisible = !performanceLiveVisible }
+                            Spacer(Modifier.width(10.dp))
                         }
                     },
                 )
@@ -676,12 +852,24 @@ private fun AndyShell(
                         .padding(horizontal = 18.dp, vertical = 16.dp)
                 ) {
                     when (destination) {
-                        AndyDestination.Devices -> DevicesScreen(services, devices, sdk, onRefresh = { refreshDevices() }, onLive = {
-                            selectedSerial = it
-                            destination = AndyDestination.Live
-                        }, onEmulatorStarted = { previousSerials ->
-                            openStartedEmulator(previousSerials)
-                        }, onStopEmulator = { stopEmulator(it) }, stoppingEmulatorSerial = stoppingEmulatorSerial, stopStatus = emulatorStopStatus)
+                        AndyDestination.Devices -> DevicesScreen(
+                            services,
+                            devices,
+                            sdk,
+                            onRefresh = { refreshDevices() },
+                            onLive = {
+                                selectedSerial = it
+                                destination = AndyDestination.Live
+                            },
+                            onEmulatorStarted = { previousSerials, avdName ->
+                                openStartedEmulator(previousSerials, avdName)
+                            },
+                            onStopEmulator = { stopEmulator(it) },
+                            stoppingEmulatorSerial = stoppingEmulatorSerial,
+                            stopStatus = emulatorStopStatus,
+                            startingEmulatorName = startingEmulatorName,
+                            startStatus = emulatorStartStatus,
+                        )
                         AndyDestination.Catalog -> CatalogScreen(services.avd)
                         AndyDestination.Live -> LiveScreen(
                             services = services,
@@ -749,10 +937,15 @@ private fun AndyShell(
                         AndyDestination.Snapshots -> SnapshotsScreen(services.avd)
                         AndyDestination.Controls -> ControlsScreen(services.devices, services.mirror, selectedSerial)
                         AndyDestination.Performance -> PerformanceScreen(
-                            services.metrics,
-                            selectedSerial,
-                            workspaceState.performanceProcessesPaneWidth,
+                            services = services,
+                            serial = selectedSerial,
+                            device = devices.firstOrNull { it.serial == selectedSerial },
+                            processesPaneWidth = workspaceState.performanceProcessesPaneWidth,
                             onProcessesPaneWidthChange = { width -> updateWorkspace { it.copy(performanceProcessesPaneWidth = width) } },
+                            liveVisible = performanceLiveVisible,
+                            onLiveVisibleChange = { performanceLiveVisible = it },
+                            livePaneWidth = workspaceState.performanceLivePaneWidth,
+                            onLivePaneWidthChange = { width -> updateWorkspace { it.copy(performanceLivePaneWidth = width) } },
                         )
                         AndyDestination.Design -> DesignScreen(
                             services,
@@ -1166,10 +1359,12 @@ private fun DevicesScreen(
     sdk: SdkDiscovery,
     onRefresh: () -> Unit,
     onLive: (String) -> Unit,
-    onEmulatorStarted: (Set<String>) -> Unit,
+    onEmulatorStarted: (Set<String>, String) -> Unit,
     onStopEmulator: (AndroidDevice) -> Unit,
     stoppingEmulatorSerial: String?,
     stopStatus: String,
+    startingEmulatorName: String?,
+    startStatus: String,
 ) {
     val scope = rememberCoroutineScope()
     var avds by remember { mutableStateOf<List<VirtualDevice>>(emptyList()) }
@@ -1235,6 +1430,12 @@ private fun DevicesScreen(
         }
         PanelCard {
             Text("Created emulators", color = TextPrimary, fontWeight = FontWeight.Bold)
+            if (startStatus.isNotBlank()) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (startingEmulatorName != null) CircularProgressIndicator(Modifier.size(14.dp), strokeWidth = 2.dp, color = Rust)
+                    Text(startStatus, color = if (startingEmulatorName != null) Rust else TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                }
+            }
             if (avdStatus.isNotBlank()) Text(avdStatus, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
             if (stopStatus.isNotBlank()) Text(stopStatus, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
             if (filteredAvds.isEmpty()) {
@@ -1275,13 +1476,14 @@ private fun DevicesScreen(
                                         avdStatus = if (result.isSuccess) result.stdout else result.stderr.ifBlank { result.stdout }
                                         startingAvd = null
                                         refreshAvds()
-                                        if (result.isSuccess) onEmulatorStarted(before)
+                                        if (result.isSuccess) onEmulatorStarted(before, avd.name)
                                     }
                                 },
-                                enabled = startingAvd == null,
+                                enabled = startingAvd == null && startingEmulatorName == null,
                             ) {
                                 Text(
                                     when {
+                                        startingEmulatorName == avd.name -> "Booting"
                                         startingAvd == avd.name -> "Starting"
                                         runningDevice != null -> "Live"
                                         else -> "Start"
@@ -1297,15 +1499,16 @@ private fun DevicesScreen(
                                 }
                             }
                             AvdActionsMenu(
-                                enabled = startingAvd == null,
+                                enabled = startingAvd == null && startingEmulatorName == null,
                                 onColdBoot = {
+                                    val before = devices.map { it.serial }.toSet()
                                     scope.launch {
                                         startingAvd = avd.name
                                         val result = services.avd.coldBootVirtualDevice(avd.name)
                                         avdStatus = if (result.isSuccess) result.stdout else result.stderr.ifBlank { result.stdout }
                                         startingAvd = null
                                         refreshAvds()
-                                        if (result.isSuccess) onEmulatorStarted(devices.map { it.serial }.toSet())
+                                        if (result.isSuccess) onEmulatorStarted(before, avd.name)
                                     }
                                 },
                                 onWipe = {
@@ -2309,7 +2512,6 @@ private fun LiveScreen(
     var clipDialogVisible by remember { mutableStateOf(false) }
     var localDevicePaneWidth by remember(devicePaneWidth) { mutableStateOf(devicePaneWidth.coerceAtLeast(680f)) }
     var localControlsPaneHeight by remember(controlsPaneHeight) { mutableStateOf(controlsPaneHeight.coerceIn(170f, 360f)) }
-    val bugCaptureStatus by services.bugs.status.collectAsState(BugCaptureStatus())
     val sendMirrorInput = rememberMirrorInputSender(services, serial)
     fun sendHardware(input: MirrorInput) {
         sendMirrorInput(input)
@@ -2350,12 +2552,14 @@ private fun LiveScreen(
         }
     }
     Row(Modifier.fillMaxSize()) {
-        MirrorFrameContent(services.mirror, serial) { frame ->
+        MirrorFrameContent(services.mirror, serial) { frameFlow, frame ->
             val visibleFrame = frame.takeUnless { bugDialogVisible || clipDialogVisible }
+            val visibleFrameFlow = frameFlow.takeUnless { bugDialogVisible || clipDialogVisible }
             LiveDevicePane(
                 serial = serial,
                 device = device,
                 frame = visibleFrame,
+                frameFlow = visibleFrameFlow,
                 mirrorStatus = mirrorStatus,
                 connectResult = connectResult,
                 modifier = Modifier.width(localDevicePaneWidth.dp).fillMaxHeight().padding(end = 6.dp),
@@ -2424,14 +2628,6 @@ private fun LiveScreen(
                         Text(stopStatus, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
                     }
                 }
-                Text(
-                    "Bug buffer: ${bugCaptureStatus.videoFrameCount} frames · ${bugCaptureStatus.actionCount} actions · ${bugCaptureStatus.logCount} logs",
-                    color = TextSecondary,
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 11.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
                 if (bugSaveStatus.isNotBlank()) {
                     Text(bugSaveStatus, color = Rust, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
@@ -2557,6 +2753,7 @@ private fun LiveDevicePane(
     device: AndroidDevice?,
     displayName: String? = device?.displayName,
     frame: MirrorFrame?,
+    frameFlow: Flow<MirrorFrame>? = null,
     mirrorStatus: String,
     connectResult: String,
     modifier: Modifier = Modifier,
@@ -2573,11 +2770,13 @@ private fun LiveDevicePane(
     zoom: Float = 1f,
     showDeviceHeader: Boolean = true,
     showChromeControls: Boolean = true,
+    showHardwareControls: Boolean = showChromeControls,
     showContainerChrome: Boolean = true,
     deviceBorderWidth: Dp = 5.dp,
     deviceCornerRadius: Dp = 10.dp,
     onHoverColor: (String) -> Unit = {},
     passThroughInput: Boolean = true,
+    onPickerClick: (String) -> Unit = {},
     onDevicePointClick: (Int, Int) -> Unit = { _, _ -> },
     onRulerResize: (Float, Float) -> Unit = { _, _ -> },
     onPower: () -> Unit = {},
@@ -2601,7 +2800,7 @@ private fun LiveDevicePane(
         containerModifier,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        if (showChromeControls) {
+        if (showHardwareControls) {
             LiveHardwareToolbar(
                 enabled = serial != null,
                 onPower = onPower,
@@ -2616,13 +2815,13 @@ private fun LiveDevicePane(
         }
 
         Column(Modifier.weight(1f).fillMaxHeight(), horizontalAlignment = Alignment.CenterHorizontally) {
-            if (showDeviceHeader) {
-                Box(Modifier.fillMaxWidth()) {
+            if (showDeviceHeader && serial != null) {
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        displayName ?: device?.serial ?: serial ?: "No device",
+                        displayName ?: device?.serial ?: serial,
                         color = TextPrimary,
                         fontFamily = FontFamily.Monospace,
-                        modifier = Modifier.align(Alignment.Center),
+                        modifier = Modifier.weight(1f, fill = false),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -2630,7 +2829,7 @@ private fun LiveDevicePane(
                         listOfNotNull(device?.screenSize, frame?.decodedFps?.let { "%.1f fps".format(it) }).joinToString(" · ").ifBlank { "-" },
                         color = TextSecondary,
                         fontFamily = FontFamily.Monospace,
-                        modifier = Modifier.align(Alignment.CenterEnd),
+                        modifier = Modifier.padding(start = 8.dp),
                         maxLines = 1,
                     )
                 }
@@ -2674,47 +2873,47 @@ private fun LiveDevicePane(
                             contentAlignment = Alignment.Center,
                         ) {
                             if (frame != null) {
-                                MirrorVideoSurface(
-                                    frame = frame,
-                                    modifier = Modifier.fillMaxSize(),
-                                    onInput = onInput,
-                                    onHoverColor = onHoverColor,
-                                    passThroughInput = passThroughInput,
-                                    onDevicePointClick = onDevicePointClick,
-                                    onRulerResize = onRulerResize,
-                                    overlay = MirrorOverlay(
-                                        highlightBounds = highlightBounds,
-                                        sourceWidth = sourceWidth,
-                                        sourceHeight = sourceHeight,
-                                        showGrid = gridSize != null,
-                                        gridSize = gridSize ?: 16f,
-                                        gridColor = gridColor,
-                                        showRuler = showRuler,
-                                        rulerColor = Rust,
-                                        rulerWidth = rulerWidth,
-                                        rulerHeight = rulerHeight,
-                                        rulerX = rulerX,
-                                        rulerY = rulerY,
-                                        pickerColor = pickerColor,
-                                        pickerHex = pickerHex,
-                                    ),
+                                val surfaceOverlay = MirrorOverlay(
+                                    highlightBounds = highlightBounds,
+                                    sourceWidth = sourceWidth,
+                                    sourceHeight = sourceHeight,
+                                    showGrid = gridSize != null,
+                                    gridSize = gridSize ?: 16f,
+                                    gridColor = gridColor,
+                                    showRuler = showRuler,
+                                    rulerColor = Rust,
+                                    rulerWidth = rulerWidth,
+                                    rulerHeight = rulerHeight,
+                                    rulerX = rulerX,
+                                    rulerY = rulerY,
+                                    pickerColor = pickerColor,
+                                    pickerHex = pickerHex,
                                 )
-                            } else {
-                                Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(16.dp)) {
-                                    Text("embedded mirror", color = TextPrimary, fontWeight = FontWeight.Bold)
-                                    Text(mirrorStatus, color = TextSecondary, fontSize = 12.sp, maxLines = 3, overflow = TextOverflow.Ellipsis)
-                                    Text(connectResult.ifBlank { if (serial == null) "Select an online device" else "Connect streams H.264 in-app" }, color = TextSecondary, fontSize = 11.sp)
-                                    if (serial != null) {
-                                        Spacer(Modifier.height(12.dp))
-                                        Button(
-                                            onClick = onConnect,
-                                            colors = primaryButtonColors(),
-                                            shape = RoundedCornerShape(10.dp),
-                                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
-                                        ) {
-                                            Text("Connect", color = TextPrimary, fontSize = 12.sp)
-                                        }
-                                    }
+                                if (frameFlow != null) {
+                                    MirrorVideoSurface(
+                                        frames = frameFlow,
+                                        resetKey = serial,
+                                        modifier = Modifier.fillMaxSize(),
+                                        onInput = onInput,
+                                        onHoverColor = onHoverColor,
+                                        passThroughInput = passThroughInput,
+                                        onPickerClick = onPickerClick,
+                                        onDevicePointClick = onDevicePointClick,
+                                        onRulerResize = onRulerResize,
+                                        overlay = surfaceOverlay,
+                                    )
+                                } else {
+                                    MirrorVideoSurface(
+                                        frame = frame,
+                                        modifier = Modifier.fillMaxSize(),
+                                        onInput = onInput,
+                                        onHoverColor = onHoverColor,
+                                        passThroughInput = passThroughInput,
+                                        onPickerClick = onPickerClick,
+                                        onDevicePointClick = onDevicePointClick,
+                                        onRulerResize = onRulerResize,
+                                        overlay = surfaceOverlay,
+                                    )
                                 }
                             }
                         }
@@ -3694,9 +3893,9 @@ private fun AppsScreen(
         }
     }
 
-    fun runAppAction(label: String, packageName: String? = selected?.packageName, block: suspend () -> CommandResult) {
+    fun runAppAction(label: String, packageName: String? = selected?.packageName, appLabel: String? = selected?.label, block: suspend () -> CommandResult) {
         scope.launch {
-            packageName?.let { services.bugs.recordAction("app", label, it) }
+            packageName?.let { services.bugs.recordAction("app", "$label $it", appLabel) }
             val result = block()
             status = "$label: " + if (result.isSuccess) result.stdout.ifBlank { "ok" } else result.stderr.ifBlank { result.stdout }
             if (label == "Uninstall" || label == "Clear data") refresh()
@@ -3742,19 +3941,19 @@ private fun AppsScreen(
                 Text(app?.packageName ?: "No app selected", color = TextPrimary, fontWeight = FontWeight.Bold)
                 if (app != null && serial != null) {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-                        Button(onClick = { runAppAction("Launch", app.packageName) { apps.launch(serial, app.packageName) } }) { Text("Launch") }
-                        OutlinedButton(onClick = { runAppAction("Stop", app.packageName) { apps.stop(serial, app.packageName) } }) { Text("Stop") }
+                        Button(onClick = { runAppAction("Launch", app.packageName, app.label) { apps.launch(serial, app.packageName) } }) { Text("Launch") }
+                        OutlinedButton(onClick = { runAppAction("Stop", app.packageName, app.label) { apps.stop(serial, app.packageName) } }) { Text("Stop") }
                         OutlinedButton(onClick = {
                             pendingConfirmation = PendingConfirmation("Clear app data?", app.packageName) {
-                                runAppAction("Clear data", app.packageName) { apps.clearData(serial, app.packageName) }
+                                runAppAction("Clear data", app.packageName, app.label) { apps.clearData(serial, app.packageName) }
                             }
                         }) { Text("Clear") }
                     }
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-                        OutlinedButton(onClick = { runAppAction("Reset permissions", app.packageName) { apps.resetPermissions(serial, app.packageName) } }) { Text("Reset perms") }
+                        OutlinedButton(onClick = { runAppAction("Reset permissions", app.packageName, app.label) { apps.resetPermissions(serial, app.packageName) } }) { Text("Reset perms") }
                         OutlinedButton(onClick = {
                             pendingConfirmation = PendingConfirmation("Uninstall app?", app.packageName) {
-                                runAppAction("Uninstall", app.packageName) { apps.uninstall(serial, app.packageName) }
+                                runAppAction("Uninstall", app.packageName, app.label) { apps.uninstall(serial, app.packageName) }
                             }
                         }, enabled = !app.system) { Text("Uninstall") }
                     }
@@ -4889,6 +5088,16 @@ private fun NetworkScreen(
         resetRuleForm()
     }
 
+    fun clearCapturedTraffic() {
+        scope.launch {
+            val result = proxy.clearTraffic()
+            selectedFlowId = null
+            seenFlowIds = emptySet()
+            flashingTrafficKeys.clear()
+            status = if (result.isSuccess) result.stdout else result.stderr
+        }
+    }
+
     fun editRule(ruleId: String) {
         val rule = rules.firstOrNull { it.id == ruleId } ?: return
         ruleName = rule.name
@@ -4949,16 +5158,17 @@ private fun NetworkScreen(
                             proxyStatus = result.stdout
                         }
                     }) { Text("Stop") }
-	                    Text(
-	                        if (setupExpanded) "Hide setup" else "Show setup",
-	                        color = Rust,
-	                        fontSize = 12.sp,
-	                        fontWeight = FontWeight.Medium,
-	                        modifier = Modifier.clickable {
-	                            setupManuallyToggled = true
-	                            setupExpanded = !setupExpanded
-	                        },
-	                    )
+                    OutlinedButton(onClick = ::clearCapturedTraffic) { Text("Clear traffic") }
+                    Text(
+                        if (setupExpanded) "Hide setup" else "Show setup",
+                        color = Rust,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                        modifier = Modifier.clickable {
+                            setupManuallyToggled = true
+                            setupExpanded = !setupExpanded
+                        },
+                    )
                 }
                 val proxyStarted = proxyStatus.contains("listening on")
                 val caText = when {
@@ -5064,15 +5274,6 @@ private fun NetworkScreen(
                                     }
                                 },
                             ) { Text("Prepare phone CA") }
-                            OutlinedButton(onClick = {
-                                scope.launch {
-                                    val result = proxy.clearTraffic()
-                                    selectedFlowId = null
-                                    seenFlowIds = emptySet()
-                                    flashingTrafficKeys.clear()
-                                    status = if (result.isSuccess) result.stdout else result.stderr
-                                }
-                            }) { Text("Clear traffic") }
                         }
                         SetupChecklist(setupRequirements)
                         SetupChecklist(networkStatusRequirements)
@@ -5237,7 +5438,7 @@ private fun NetworkScreen(
             Column(Modifier.width(420.dp).fillMaxHeight(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (liveVisible && rulesVisible) {
                     var livePanelHeight by remember { mutableStateOf(300f) }
-                    NetworkLivePanel(
+                    DeviceLivePanel(
                         services = services,
                         serial = serial,
                         device = device,
@@ -5270,7 +5471,7 @@ private fun NetworkScreen(
                         modifier = Modifier.fillMaxWidth().weight(1f)
                     )
                 } else if (liveVisible) {
-                    NetworkLivePanel(
+                    DeviceLivePanel(
                         services = services,
                         serial = serial,
                         device = device,
@@ -6102,7 +6303,7 @@ private fun quoteJsonPreview(value: String): String {
 }
 
 @Composable
-private fun NetworkLivePanel(services: AndyServices, serial: String?, device: AndroidDevice?, modifier: Modifier = Modifier) {
+private fun DeviceLivePanel(services: AndyServices, serial: String?, device: AndroidDevice?, modifier: Modifier = Modifier, showChromeControls: Boolean = true) {
     val scope = rememberCoroutineScope()
     var mirrorStatus by remember { mutableStateOf("Disconnected") }
     var connectResult by remember { mutableStateOf("") }
@@ -6122,14 +6323,16 @@ private fun NetworkLivePanel(services: AndyServices, serial: String?, device: An
         connectResult = ""
         connect()
     }
-    MirrorFrameContent(services.mirror, serial) { frame ->
+    MirrorFrameContent(services.mirror, serial) { frameFlow, frame ->
         LiveDevicePane(
             serial = serial,
             device = device,
             frame = frame,
+            frameFlow = frameFlow,
             mirrorStatus = mirrorStatus,
             connectResult = connectResult,
             modifier = modifier,
+            showChromeControls = showChromeControls,
             onInput = sendMirrorInput,
             onConnect = ::connect,
         )
@@ -6152,61 +6355,134 @@ private fun <T> List<T>.swapItems(first: Int, second: Int): List<T> {
 }
 
 @Composable
-private fun PerformanceScreen(metrics: MetricsService, serial: String?, processesPaneWidth: Float, onProcessesPaneWidthChange: (Float) -> Unit) {
+private fun PerformanceScreen(
+    services: AndyServices,
+    serial: String?,
+    device: AndroidDevice?,
+    processesPaneWidth: Float,
+    onProcessesPaneWidthChange: (Float) -> Unit,
+    liveVisible: Boolean,
+    onLiveVisibleChange: (Boolean) -> Unit,
+    livePaneWidth: Float,
+    onLivePaneWidthChange: (Float) -> Unit,
+) {
     var samples by remember { mutableStateOf<List<PerformanceSample>>(emptyList()) }
     var localProcessesPaneWidth by remember(processesPaneWidth) { mutableStateOf(processesPaneWidth) }
+    var localLivePaneWidth by remember(livePaneWidth) { mutableStateOf(livePaneWidth) }
     LaunchedEffect(serial) {
         samples = emptyList()
-        if (serial != null) metrics.stream(serial, null).collectLatest { samples = (samples + it).takeLast(60) }
+        if (serial != null) services.metrics.stream(serial, null).collectLatest { samples = (samples + it).takeLast(60) }
     }
     val latest = samples.lastOrNull()
     val recentFrames = samples.flatMap { it.frameRenderTimes }.takeLast(60)
-    Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(14.dp)) {
-        Toolbar("Performance", "process CPU/memory · frame render time · battery")
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            MetricCard("CPU", latest?.cpuPercent?.let { "${it.toInt()}%" } ?: "-")
-            MetricCard("Memory", latest?.memoryMb?.let { "${it.toInt()} MB" } ?: "-")
-            MetricCard("Frames green", recentFrames.takeIf { it.isNotEmpty() }?.let { frames -> "${frames.count { it.millis <= 16.6f }}/${frames.size}" } ?: "-")
-            MetricCard("Battery", latest?.batteryPercent?.let { "$it%" } ?: "-")
-        }
-        Row(Modifier.fillMaxSize()) {
-            Column(Modifier.width(localProcessesPaneWidth.dp).fillMaxHeight(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                TableHeader(listOf("PID" to 80.dp, "CPU" to 70.dp, "MEM" to 90.dp, "PROCESS" to 1.dp))
-                LazyColumn {
-                    items(latest?.processes.orEmpty()) { process ->
-                        TableRow {
-                            MonoCell(process.pid, 80.dp, TextSecondary)
-                            MonoCell(process.cpuPercent?.let { "%.1f%%".format(it) } ?: "-", 70.dp, if ((process.cpuPercent ?: 0f) > 10f) Rust else TextPrimary)
-                            MonoCell(process.memoryMb?.let { "%.1f".format(it) } ?: "-", 90.dp, TextSecondary)
-                            MonoCell(process.name, 1.dp, TextPrimary, Modifier.weight(1f))
+    val cpuSeries = samples.map { it.cpuPercent ?: 0f }
+    val memorySeries = samples.map { it.memoryMb ?: 0f }
+    val networkSeries = samples.map { (it.networkRxKbps ?: 0f) + (it.networkTxKbps ?: 0f) }
+    val fpsSeries = samples.map { it.fps ?: 0f }
+    Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(Modifier.weight(1f).fillMaxHeight(), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+            Toolbar("Performance", "process CPU/memory · network · frame render time")
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                PerformanceChartCard(
+                    title = "CPU",
+                    valueText = latest?.cpuPercent?.let { "${it.toInt()}" } ?: "-",
+                    unitText = "%",
+                    caption = "4 cores · avg ${cpuSeries.takeIf { it.isNotEmpty() }?.average()?.toInt() ?: 0}%",
+                    values = cpuSeries,
+                    maxValue = 100f,
+                    lineColor = Rust,
+                    modifier = Modifier.weight(1f),
+                )
+                PerformanceChartCard(
+                    title = "Memory",
+                    valueText = latest?.memoryMb?.let { "${it.toInt()}" } ?: "-",
+                    unitText = "MB",
+                    caption = "peak ${memorySeries.maxOrNull()?.toInt() ?: 0} MB",
+                    values = memorySeries,
+                    maxValue = (memorySeries.maxOrNull() ?: 0f).coerceAtLeast(256f) * 1.15f,
+                    lineColor = Cyan,
+                    modifier = Modifier.weight(1f),
+                )
+                PerformanceChartCard(
+                    title = "Network",
+                    valueText = latest?.let { ((it.networkRxKbps ?: 0f) + (it.networkTxKbps ?: 0f)).toInt().toString() } ?: "-",
+                    unitText = "KB/s",
+                    caption = "down ${latest?.networkRxKbps?.toInt() ?: 0} · up ${latest?.networkTxKbps?.toInt() ?: 0} KB/s",
+                    values = networkSeries,
+                    maxValue = (networkSeries.maxOrNull() ?: 0f).coerceAtLeast(64f) * 1.15f,
+                    lineColor = Green,
+                    modifier = Modifier.weight(1f),
+                )
+                PerformanceChartCard(
+                    title = "FPS",
+                    valueText = latest?.fps?.toInt()?.toString() ?: "Idle",
+                    unitText = if (latest?.fps != null) "fps" else "",
+                    caption = recentFrames.takeIf { it.isNotEmpty() }?.let { frames -> "${frames.size} frames sampled · ${frames.count { it.millis <= 16.6f }} green" } ?: "No active rendering",
+                    values = fpsSeries,
+                    maxValue = (fpsSeries.maxOrNull() ?: 60f).coerceAtLeast(60f) * 1.1f,
+                    lineColor = Yellow,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Row(Modifier.fillMaxWidth().weight(1f)) {
+                Column(Modifier.width(localProcessesPaneWidth.dp).fillMaxHeight(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    TableHeader(listOf("PID" to 80.dp, "CPU" to 70.dp, "MEM" to 90.dp, "PROCESS" to 1.dp))
+                    LazyColumn {
+                        items(latest?.processes.orEmpty()) { process ->
+                            TableRow {
+                                MonoCell(process.pid, 80.dp, TextSecondary)
+                                MonoCell(process.cpuPercent?.let { "%.1f%%".format(it) } ?: "-", 70.dp, if ((process.cpuPercent ?: 0f) > 10f) Rust else TextPrimary)
+                                MonoCell(process.memoryMb?.let { "%.1f".format(it) } ?: "-", 90.dp, TextSecondary)
+                                MonoCell(process.name, 1.dp, TextPrimary, Modifier.weight(1f))
+                            }
+                        }
+                    }
+                }
+                PaneDivider(
+                    onDrag = { dragX -> localProcessesPaneWidth = (localProcessesPaneWidth + dragX).coerceIn(360f, 1300f) },
+                    onDragEnd = { onProcessesPaneWidthChange(localProcessesPaneWidth) },
+                )
+                PanelCard(Modifier.fillMaxSize().padding(start = 6.dp).weight(1f)) {
+                    Text("Frame rendering", color = TextPrimary, fontWeight = FontWeight.Bold)
+                    Text("Green <= 16.6 ms, red is slower than 60 fps.", color = TextSecondary, fontSize = 12.sp)
+                    Canvas(Modifier.fillMaxWidth().height(190.dp)) {
+                        val frames = recentFrames
+                        val barWidth = if (frames.isEmpty()) size.width else size.width / frames.size
+                        frames.forEachIndexed { index, frame ->
+                            val height = (frame.millis.coerceIn(0f, 50f) / 50f) * size.height
+                            drawRect(
+                                color = if (frame.millis <= 16.6f) Green else Red,
+                                topLeft = Offset(index * barWidth, size.height - height),
+                                size = androidx.compose.ui.geometry.Size((barWidth - 1f).coerceAtLeast(1f), height),
+                            )
+                        }
+                    }
+                    LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
+                        items(recentFrames) { frame ->
+                            Text("${frame.label}  ${"%.2f".format(frame.millis)} ms", color = if (frame.millis <= 16.6f) Green else Red, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
                         }
                     }
                 }
             }
-            PaneDivider(
-                onDrag = { dragX -> localProcessesPaneWidth = (localProcessesPaneWidth + dragX).coerceIn(360f, 1300f) },
-                onDragEnd = { onProcessesPaneWidthChange(localProcessesPaneWidth) },
-            )
-            PanelCard(Modifier.fillMaxSize().padding(start = 6.dp)) {
-                Text("Frame rendering", color = TextPrimary, fontWeight = FontWeight.Bold)
-                Text("Green <= 16.6 ms, red is slower than 60 fps.", color = TextSecondary, fontSize = 12.sp)
-                Canvas(Modifier.fillMaxWidth().height(190.dp)) {
-                    val frames = recentFrames
-                    val barWidth = if (frames.isEmpty()) size.width else size.width / frames.size
-                    frames.forEachIndexed { index, frame ->
-                        val height = (frame.millis.coerceIn(0f, 50f) / 50f) * size.height
-                        drawRect(
-                            color = if (frame.millis <= 16.6f) Green else Red,
-                            topLeft = Offset(index * barWidth, size.height - height),
-                            size = androidx.compose.ui.geometry.Size((barWidth - 1f).coerceAtLeast(1f), height),
-                        )
-                    }
-                }
-                LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
-                    items(recentFrames) { frame ->
-                        Text("${frame.label}  ${"%.2f".format(frame.millis)} ms", color = if (frame.millis <= 16.6f) Green else Red, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
-                    }
-                }
+        }
+        AnimatedVisibility(
+            visible = liveVisible,
+            modifier = Modifier.fillMaxHeight(),
+            enter = expandHorizontally(animationSpec = tween(220)) + fadeIn(animationSpec = tween(220)),
+            exit = shrinkHorizontally(animationSpec = tween(220)) + fadeOut(animationSpec = tween(160)),
+        ) {
+            Row(Modifier.fillMaxHeight()) {
+                PaneDivider(
+                    onDrag = { dragX -> localLivePaneWidth = (localLivePaneWidth - dragX).coerceIn(220f, 700f) },
+                    onDragEnd = { onLivePaneWidthChange(localLivePaneWidth) },
+                )
+                DeviceLivePanel(
+                    services = services,
+                    serial = serial,
+                    device = device,
+                    modifier = Modifier.width(localLivePaneWidth.dp).fillMaxHeight(),
+                    showChromeControls = false,
+                )
             }
         }
     }
@@ -6218,17 +6494,25 @@ private fun DesignScreen(services: AndyServices, serial: String?, device: Androi
     var status by remember { mutableStateOf("Design overlays") }
     var mirrorStatus by remember { mutableStateOf("Disconnected") }
     var connectResult by remember { mutableStateOf("") }
-    var grid by remember { mutableStateOf(true) }
-    var ruler by remember { mutableStateOf(true) }
+    var grid by remember { mutableStateOf(false) }
+    var ruler by remember { mutableStateOf(false) }
     var gridSize by remember { mutableStateOf("16") }
     var rulerX by remember { mutableStateOf("540") }
     var rulerY by remember { mutableStateOf("960") }
     var color by remember { mutableStateOf(Cyan) }
-    var pickerEnabled by remember { mutableStateOf(true) }
+    var pickerEnabled by remember { mutableStateOf(false) }
     var pickedColor by remember { mutableStateOf("#------") }
+    var pickerToast by remember { mutableStateOf<String?>(null) }
     var zoom by remember { mutableStateOf("1.0") }
     var localDevicePaneWidth by remember(devicePaneWidth) { mutableStateOf(devicePaneWidth.coerceAtLeast(760f)) }
     val sendMirrorInput = rememberMirrorInputSender(services, serial)
+    val clipboardManager = androidx.compose.ui.platform.LocalClipboardManager.current
+    LaunchedEffect(pickerToast) {
+        if (pickerToast != null) {
+            delay(1800)
+            pickerToast = null
+        }
+    }
     LaunchedEffect(Unit) {
         services.mirror.status.collectLatest { mirrorStatus = it }
     }
@@ -6239,11 +6523,12 @@ private fun DesignScreen(services: AndyServices, serial: String?, device: Androi
         }
     }
     Row(Modifier.fillMaxSize()) {
-        MirrorFrameContent(services.mirror, serial) { frame ->
+        MirrorFrameContent(services.mirror, serial) { frameFlow, frame ->
             LiveDevicePane(
                 serial = serial,
                 device = device,
                 frame = frame,
+                frameFlow = frameFlow,
                 mirrorStatus = mirrorStatus,
                 connectResult = connectResult,
                 modifier = Modifier.width(localDevicePaneWidth.dp).fillMaxHeight(),
@@ -6258,7 +6543,12 @@ private fun DesignScreen(services: AndyServices, serial: String?, device: Androi
                 onHoverColor = { hex ->
                     if (pickerEnabled) pickedColor = hex
                 },
-                passThroughInput = true,
+                passThroughInput = !pickerEnabled,
+                onPickerClick = { hex ->
+                    pickedColor = hex
+                    clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(hex))
+                    pickerToast = "Copied $hex"
+                },
                 onRulerResize = { x, y ->
                     rulerX = x.toInt().toString()
                     rulerY = y.toInt().toString()
@@ -6272,6 +6562,7 @@ private fun DesignScreen(services: AndyServices, serial: String?, device: Androi
                 },
             )
         }
+        Spacer(Modifier.width(6.dp))
         PaneDivider(
             onDrag = { dragX -> localDevicePaneWidth = (localDevicePaneWidth + dragX).coerceIn(640f, 1900f) },
             onDragEnd = { onDevicePaneWidthChange(localDevicePaneWidth) },
@@ -6317,10 +6608,40 @@ private fun DesignScreen(services: AndyServices, serial: String?, device: Androi
                 }
             }
             Text("Color picker", color = TextPrimary, fontWeight = FontWeight.Bold)
-            Text("Under pointer $pickedColor · swatch ${color.toHex()}", color = if (pickerEnabled) TextPrimary else TextSecondary)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier.size(18.dp)
+                        .background(pickedColor.toColorOrNull() ?: Color.Transparent, RoundedCornerShape(4.dp))
+                        .border(1.dp, Border, RoundedCornerShape(4.dp))
+                )
+                Text("Under pointer $pickedColor · swatch ${color.toHex()}", color = if (pickerEnabled) TextPrimary else TextSecondary)
+            }
+            AnimatedVisibility(
+                visible = pickerToast != null,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                Box(
+                    Modifier
+                        .background(Rust.copy(alpha = 0.18f), RoundedCornerShape(AndyRadius.Pill))
+                        .border(1.dp, Rust.copy(alpha = 0.45f), RoundedCornerShape(AndyRadius.Pill))
+                        .padding(horizontal = 10.dp, vertical = 5.dp)
+                ) {
+                    Text(pickerToast.orEmpty(), color = Rust, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                }
+            }
             Text(status, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
         }
     }
+}
+
+private fun String.toColorOrNull(): Color? {
+    if (!matches(Regex("""#[0-9A-Fa-f]{6}"""))) return null
+    return Color(
+        red = substring(1, 3).toInt(16),
+        green = substring(3, 5).toInt(16),
+        blue = substring(5, 7).toInt(16),
+    )
 }
 
 private fun Color.toHex(): String {
@@ -6354,7 +6675,7 @@ private fun AccessibilityScreen(
     state: AccessibilityState = remember { AccessibilityState() }
 ) {
     val scope = rememberCoroutineScope()
-    var localTreePaneWidth by remember(treePaneWidth) { mutableStateOf(treePaneWidth.coerceIn(420f, 760f)) }
+    var localTreePaneWidth by remember(treePaneWidth) { mutableStateOf(treePaneWidth.coerceIn(420f, 1400f)) }
     var mirrorStatus by remember { mutableStateOf("Disconnected") }
     var connectResult by remember { mutableStateOf("") }
     val sendMirrorInput = rememberMirrorInputSender(services, serial, enabled = !state.interactionMode)
@@ -6478,19 +6799,22 @@ private fun AccessibilityScreen(
                     AccessibilityDetails(state.selectedNode)
                 }
             }
+            Spacer(Modifier.width(6.dp))
             PaneDivider(
-                onDrag = { dragX -> localTreePaneWidth = (localTreePaneWidth + dragX).coerceIn(360f, 920f) },
+                onDrag = { dragX -> localTreePaneWidth = (localTreePaneWidth + dragX).coerceIn(360f, 1600f) },
                 onDragEnd = { onTreePaneWidthChange(localTreePaneWidth) },
             )
-            MirrorFrameContent(services.mirror, serial) { frame ->
+            MirrorFrameContent(services.mirror, serial) { frameFlow, frame ->
                 LiveDevicePane(
                     serial = serial,
                     device = device,
                     frame = frame,
+                    frameFlow = frameFlow,
                     mirrorStatus = mirrorStatus,
                     connectResult = connectResult,
                     modifier = Modifier.fillMaxSize().padding(start = 6.dp),
                     highlightBounds = state.hoveredBounds,
+                    showHardwareControls = false,
                     passThroughInput = !state.interactionMode,
                     onDevicePointClick = { x, y ->
                         state.root?.findBestNodeAt(x, y)?.let {
@@ -6683,6 +7007,9 @@ private fun BugsScreen(bugs: BugService) {
     var playbackStartFrameIndex by remember { mutableStateOf(0) }
     var isInspectingPlayback by remember { mutableStateOf(false) }
     var status by remember { mutableStateOf("") }
+    var stepsPaneWidth by remember { mutableStateOf(380f) }
+    var bugDetailsPaneWidth by remember { mutableStateOf(320f) }
+    val expandedStepIds = remember { mutableStateMapOf<String, Boolean>() }
     val stepsListState = rememberLazyListState()
 
     fun refreshReports() {
@@ -6705,6 +7032,7 @@ private fun BugsScreen(bugs: BugService) {
         isInspectingPlayback = false
         playbackFrameCount = id?.let { bugs.bugVideoFrameCount(it) } ?: 0
         isReplaying = false
+        expandedStepIds.clear()
     }
     LaunchedEffect(selectedId, playbackFrameCount, playbackFrameIndex, isReplaying) {
         val id = selectedId ?: return@LaunchedEffect
@@ -6827,7 +7155,7 @@ private fun BugsScreen(bugs: BugService) {
                 }
                 if (status.isNotBlank()) Text(status, color = Rust, fontFamily = FontFamily.Monospace, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 Row(Modifier.weight(1f), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    PanelCard(Modifier.width(380.dp).fillMaxHeight()) {
+                    PanelCard(Modifier.width(stepsPaneWidth.dp).fillMaxHeight()) {
                         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                             Text("STEPS", color = TextSecondary, fontWeight = FontWeight.Bold, fontSize = 11.sp)
                             Text("${report.actions.size} events", color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
@@ -6838,25 +7166,51 @@ private fun BugsScreen(bugs: BugService) {
                             }
                             itemsIndexed(report.actions) { index, action ->
                                 val active = index == activeActionIndex
-                                Row(
+                                val expanded = expandedStepIds[action.id] == true
+                                Column(
                                     Modifier.fillMaxWidth()
+                                        .animateContentSize()
                                         .background(if (active) Rust.copy(alpha = 0.16f) else Color.Transparent, RoundedCornerShape(AndyRadius.R2))
                                         .border(1.dp, if (active) Rust.copy(alpha = 0.55f) else Color.Transparent, RoundedCornerShape(AndyRadius.R2))
+                                        .clickable { expandedStepIds[action.id] = !expanded }
                                         .padding(horizontal = 6.dp, vertical = 4.dp),
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
+                                    verticalArrangement = Arrangement.spacedBy(6.dp),
                                 ) {
-                                    Text("${index + 1}", color = if (active) Rust else TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.width(22.dp))
-                                    Column(Modifier.weight(1f)) {
-                                        Text(action.label, color = if (active) AndyColors.Neutral100 else TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                                        action.detail?.let { Text(it, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis) }
+                                    Row(
+                                        Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(if (expanded) "v" else ">", color = if (active) Rust else TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.width(10.dp))
+                                        Text("${index + 1}", color = if (active) Rust else TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.width(22.dp))
+                                        Column(Modifier.weight(1f)) {
+                                            Text(action.label, color = if (active) AndyColors.Neutral100 else TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                                            action.detail?.let { Text(it, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis) }
+                                        }
+                                        Text(relativeSeconds(action.timestampMillis, report.windowEndedAtMillis), color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
                                     }
-                                    Text(relativeSeconds(action.timestampMillis, report.windowEndedAtMillis), color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                                    AnimatedVisibility(visible = expanded) {
+                                        Column(
+                                            Modifier.fillMaxWidth()
+                                                .background(Color.Black.copy(alpha = 0.28f), RoundedCornerShape(AndyRadius.R2))
+                                                .padding(horizontal = 8.dp, vertical = 7.dp),
+                                            verticalArrangement = Arrangement.spacedBy(5.dp),
+                                        ) {
+                                            BugStepExpandedRow("label", action.label)
+                                            action.detail?.takeIf { it.isNotBlank() }?.let { BugStepExpandedRow("detail", it) }
+                                            BugStepExpandedRow("kind", action.kind)
+                                            BugStepExpandedRow("time", "${formatMillis(action.timestampMillis)}  ${relativeSeconds(action.timestampMillis, report.windowEndedAtMillis)}")
+                                            BugStepExpandedRow("id", action.id)
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
-                    PanelCard(Modifier.weight(1f).fillMaxHeight()) {
+                    PaneDivider(
+                        onDrag = { dragX -> stepsPaneWidth = (stepsPaneWidth + dragX).coerceIn(260f, 1_400f) },
+                    )
+                    PanelCard(Modifier.weight(1f).widthIn(min = 96.dp).fillMaxHeight()) {
                         Text("VIDEO", color = TextSecondary, fontWeight = FontWeight.Bold, fontSize = 11.sp)
                         Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                             Box(
@@ -6912,7 +7266,10 @@ private fun BugsScreen(bugs: BugService) {
                             }
                         }
                     }
-                    PanelCard(Modifier.width(320.dp).fillMaxHeight()) {
+                    PaneDivider(
+                        onDrag = { dragX -> bugDetailsPaneWidth = (bugDetailsPaneWidth - dragX).coerceIn(220f, 900f) },
+                    )
+                    PanelCard(Modifier.width(bugDetailsPaneWidth.dp).fillMaxHeight()) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             FilterPill("Details", selectedTab == "Details", Rust) { selectedTab = "Details" }
                             FilterPill("Logcat", selectedTab == "Logcat", Rust) { selectedTab = "Logcat" }
@@ -6934,20 +7291,38 @@ private fun BugsScreen(bugs: BugService) {
                                 Text(report.notes.ifBlank { "<none>" }, color = TextPrimary, fontSize = 12.sp, modifier = Modifier.fillMaxWidth().background(Color.Black, RoundedCornerShape(AndyRadius.R3)).padding(10.dp))
                             }
                         } else {
-                            SelectionContainer {
-                                Text(
-                                    logcat.ifBlank { "<no logcat captured>" },
-                                    color = TextPrimary,
-                                    fontFamily = FontFamily.Monospace,
-                                    fontSize = 11.sp,
-                                    modifier = Modifier.fillMaxSize().background(Color.Black, RoundedCornerShape(AndyRadius.R3)).padding(10.dp).verticalScroll(rememberScrollState()),
-                                )
-                            }
+                            BugLogcatView(logcat, Modifier.fillMaxSize())
                         }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun BugLogcatView(logcat: String, modifier: Modifier = Modifier) {
+    BugLogcatTextSurface(logcat, modifier.background(Color.Black, RoundedCornerShape(AndyRadius.R3)))
+}
+
+@Composable
+private fun BugStepExpandedRow(label: String, value: String) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            label,
+            color = TextSecondary,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 10.sp,
+            modifier = Modifier.width(46.dp),
+            maxLines = 1,
+        )
+        Text(
+            value,
+            color = TextPrimary,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 
@@ -7212,6 +7587,51 @@ private fun MetricCard(label: String, value: String) {
     PanelCard(Modifier.width(170.dp).height(96.dp)) {
         Text(label.lowercase(), color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold)
         Text(value, color = TextPrimary, fontSize = 26.sp, fontFamily = MonoFont)
+    }
+}
+
+@Composable
+private fun PerformanceChartCard(
+    title: String,
+    valueText: String,
+    unitText: String,
+    caption: String,
+    values: List<Float>,
+    maxValue: Float,
+    lineColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    PanelCard(modifier.height(190.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Text(title.lowercase(), color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 12.sp)
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(valueText, color = TextPrimary, fontSize = 22.sp, fontWeight = FontWeight.Bold, fontFamily = MonoFont)
+                if (unitText.isNotEmpty()) {
+                    Text(" ${unitText.lowercase()}", color = TextSecondary, fontSize = 12.sp, fontFamily = MonoFont, modifier = Modifier.padding(start = 2.dp, bottom = 3.dp))
+                }
+            }
+        }
+        Canvas(Modifier.fillMaxWidth().weight(1f)) {
+            if (values.size < 2) return@Canvas
+            val safeMax = maxValue.takeIf { it > 0f } ?: 1f
+            val stepX = size.width / (values.size - 1)
+            val points = values.mapIndexed { index, value ->
+                Offset(index * stepX, size.height - (value.coerceIn(0f, safeMax) / safeMax) * size.height)
+            }
+            val linePath = androidx.compose.ui.graphics.Path().apply {
+                moveTo(points.first().x, points.first().y)
+                points.drop(1).forEach { lineTo(it.x, it.y) }
+            }
+            val fillPath = androidx.compose.ui.graphics.Path().apply {
+                addPath(linePath)
+                lineTo(points.last().x, size.height)
+                lineTo(points.first().x, size.height)
+                close()
+            }
+            drawPath(fillPath, brush = Brush.verticalGradient(listOf(lineColor.copy(alpha = 0.32f), lineColor.copy(alpha = 0.02f))))
+            drawPath(linePath, color = lineColor, style = Stroke(width = 2f))
+        }
+        Text(caption.lowercase(), color = TextSecondary, fontFamily = MonoFont, fontSize = 11.sp)
     }
 }
 
@@ -7655,6 +8075,7 @@ private fun SettingsScreen(
     val scope = rememberCoroutineScope()
     var portText by remember(workspaceState.mcpServerPort) { mutableStateOf(workspaceState.mcpServerPort.toString()) }
     val clientOptions = remember { services.mcp.getClients() }
+    val toolNames = remember { services.mcp.getToolNames() }
     var selectedClientLabel by remember { mutableStateOf(clientOptions.firstOrNull() ?: "Claude Code") }
     var dropdownExpanded by remember { mutableStateOf(false) }
     var operationStatus by remember { mutableStateOf<String?>(null) }
@@ -7732,6 +8153,28 @@ private fun SettingsScreen(
                 Text("Server Status:", color = TextSecondary, fontSize = 12.sp)
                 GlowingDot(mcpRunning)
                 Text(mcpStatus, color = if (mcpRunning) Green else Rust, fontSize = 12.sp, fontFamily = MonoFont, fontWeight = FontWeight.Bold)
+            }
+        }
+
+        PanelCard {
+            Text("Available Tools", color = TextPrimary, fontWeight = FontWeight.Bold)
+            Text("${toolNames.size} MCP tool calls exposed by Andy", color = TextSecondary, fontSize = 12.sp)
+            @OptIn(androidx.compose.foundation.layout.ExperimentalLayoutApi::class)
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                toolNames.sorted().forEach { tool ->
+                    Box(
+                        Modifier
+                            .background(AndyColors.Neutral850, RoundedCornerShape(AndyRadius.Pill))
+                            .border(1.dp, Border, RoundedCornerShape(AndyRadius.Pill))
+                            .padding(horizontal = 10.dp, vertical = 5.dp)
+                    ) {
+                        Text(tool, color = TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                    }
+                }
             }
         }
 

--- a/src/commonMain/kotlin/app/andy/BugLogcatTextSurface.kt
+++ b/src/commonMain/kotlin/app/andy/BugLogcatTextSurface.kt
@@ -1,0 +1,10 @@
+package app.andy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+expect fun BugLogcatTextSurface(
+    text: String,
+    modifier: Modifier = Modifier,
+)

--- a/src/commonMain/kotlin/app/andy/MirrorVideoSurface.kt
+++ b/src/commonMain/kotlin/app/andy/MirrorVideoSurface.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import app.andy.service.MirrorFrame
 import app.andy.service.MirrorInput
+import kotlinx.coroutines.flow.Flow
 
 @Composable
 expect fun MirrorVideoSurface(
@@ -13,6 +14,21 @@ expect fun MirrorVideoSurface(
     onInput: (MirrorInput) -> Unit = {},
     onHoverColor: (String) -> Unit = {},
     passThroughInput: Boolean = true,
+    onPickerClick: (String) -> Unit = {},
+    onDevicePointClick: (Int, Int) -> Unit = { _, _ -> },
+    onRulerResize: (Float, Float) -> Unit = { _, _ -> },
+    overlay: MirrorOverlay = MirrorOverlay(),
+)
+
+@Composable
+expect fun MirrorVideoSurface(
+    frames: Flow<MirrorFrame>,
+    resetKey: Any? = null,
+    modifier: Modifier = Modifier,
+    onInput: (MirrorInput) -> Unit = {},
+    onHoverColor: (String) -> Unit = {},
+    passThroughInput: Boolean = true,
+    onPickerClick: (String) -> Unit = {},
     onDevicePointClick: (Int, Int) -> Unit = { _, _ -> },
     onRulerResize: (Float, Float) -> Unit = { _, _ -> },
     overlay: MirrorOverlay = MirrorOverlay(),

--- a/src/commonMain/kotlin/app/andy/model/Models.kt
+++ b/src/commonMain/kotlin/app/andy/model/Models.kt
@@ -268,6 +268,8 @@ data class PerformanceSample(
     val fps: Float?,
     val batteryPercent: Int?,
     val thermalStatus: String?,
+    val networkRxKbps: Float? = null,
+    val networkTxKbps: Float? = null,
     val processes: List<ProcessMetric> = emptyList(),
     val frameRenderTimes: List<FrameRenderMetric> = emptyList(),
 )
@@ -282,6 +284,7 @@ data class ProcessMetric(
 data class FrameRenderMetric(
     val label: String,
     val millis: Float,
+    val vsyncGapMillis: Float? = null,
 )
 
 data class AccessibilityNode(
@@ -323,6 +326,7 @@ data class WorkspaceState(
     val appsListPaneWidth: Float = 520f,
     val appsDetailsPaneHeight: Float = 350f,
     val performanceProcessesPaneWidth: Float = 760f,
+    val performanceLivePaneWidth: Float = 320f,
     val designDevicePaneWidth: Float = 820f,
     val accessibilityTreePaneWidth: Float = 560f,
     val hostFileRoots: List<String> = emptyList(),

--- a/src/desktopMain/kotlin/app/andy/BugLogcatTextSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/BugLogcatTextSurface.desktop.kt
@@ -1,0 +1,119 @@
+package app.andy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.SwingPanel
+import androidx.compose.ui.graphics.Color
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants
+import org.fife.ui.rtextarea.RTextScrollPane
+import java.awt.Font
+import java.awt.Rectangle
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.JButton
+import javax.swing.JScrollBar
+import javax.swing.JScrollPane
+import javax.swing.KeyStroke
+import javax.swing.plaf.basic.BasicScrollBarUI
+
+@Composable
+actual fun BugLogcatTextSurface(
+    text: String,
+    modifier: Modifier,
+) {
+    SwingPanel(
+        modifier = modifier,
+        background = Color.Black,
+        factory = { BugLogcatPanel() },
+        update = { panel -> panel.updateText(text.ifBlank { "<no logcat captured>" }) },
+    )
+}
+
+private class BugLogcatPanel : RTextScrollPane() {
+    private val editorBackground = java.awt.Color(0x000000)
+    private val gutterBackground = java.awt.Color(0x0F0D0A)
+    private val primaryText = java.awt.Color(0xE4DED0)
+    private val secondaryText = java.awt.Color(0x8E8779)
+    private val rust = java.awt.Color(0xD18A4B)
+    private val editor = RSyntaxTextArea().apply {
+        syntaxEditingStyle = SyntaxConstants.SYNTAX_STYLE_NONE
+        isEditable = false
+        antiAliasingEnabled = true
+        font = Font(Font.MONOSPACED, Font.PLAIN, 11)
+        background = editorBackground
+        foreground = primaryText
+        caretColor = rust
+        selectionColor = java.awt.Color(0x514D44)
+        selectedTextColor = java.awt.Color(0xF4F1E8)
+        currentLineHighlightColor = java.awt.Color(0x11100D)
+        lineWrap = false
+        wrapStyleWord = false
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.CTRL_DOWN_MASK), "select-all")
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.META_DOWN_MASK), "select-all")
+    }
+
+    init {
+        setViewportView(editor)
+        lineNumbersEnabled = false
+        background = editorBackground
+        viewport.background = editorBackground
+        gutter.background = gutterBackground
+        gutter.lineNumberColor = secondaryText
+        gutter.currentLineNumberColor = rust
+        gutter.borderColor = java.awt.Color(0x302D27)
+        border = null
+        verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
+        horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED
+        verticalScrollBar.applyAndyTheme()
+        horizontalScrollBar.applyAndyTheme()
+    }
+
+    fun updateText(value: String) {
+        if (editor.text == value) return
+        val caret = editor.caretPosition.coerceAtMost(value.length)
+        editor.text = value
+        editor.caretPosition = caret
+    }
+}
+
+private fun JScrollBar.applyAndyTheme() {
+    unitIncrement = 20
+    blockIncrement = 160
+    background = java.awt.Color(0x11100D)
+    ui = object : BasicScrollBarUI() {
+        private val thumb = java.awt.Color(0x514D44)
+        private val thumbHover = java.awt.Color(0xD18A4B)
+        private val track = java.awt.Color(0x11100D)
+
+        override fun configureScrollBarColors() {
+            thumbColor = thumb
+            thumbHighlightColor = thumb
+            thumbDarkShadowColor = thumb
+            thumbLightShadowColor = thumb
+            trackColor = track
+            trackHighlightColor = track
+        }
+
+        override fun paintThumb(g: java.awt.Graphics, c: javax.swing.JComponent, thumbBounds: Rectangle) {
+            if (thumbBounds.isEmpty || !scrollbar.isEnabled) return
+            val g2 = g.create() as java.awt.Graphics2D
+            g2.color = if (isThumbRollover) thumbHover else thumb
+            g2.fillRoundRect(thumbBounds.x + 2, thumbBounds.y + 2, thumbBounds.width - 4, thumbBounds.height - 4, 8, 8)
+            g2.dispose()
+        }
+
+        override fun paintTrack(g: java.awt.Graphics, c: javax.swing.JComponent, trackBounds: Rectangle) {
+            g.color = track
+            g.fillRect(trackBounds.x, trackBounds.y, trackBounds.width, trackBounds.height)
+        }
+
+        override fun createDecreaseButton(orientation: Int): JButton = invisibleButton()
+        override fun createIncreaseButton(orientation: Int): JButton = invisibleButton()
+        private fun invisibleButton() = JButton().apply {
+            preferredSize = java.awt.Dimension(0, 0)
+            minimumSize = java.awt.Dimension(0, 0)
+            maximumSize = java.awt.Dimension(0, 0)
+        }
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
@@ -1,6 +1,8 @@
 package app.andy
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.graphics.Color
@@ -10,6 +12,8 @@ import app.andy.service.MirrorTouchAction
 import java.awt.Point
 import java.awt.BasicStroke
 import java.awt.Cursor
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
@@ -18,8 +22,13 @@ import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
+import java.awt.image.DataBufferInt
+import java.awt.geom.Ellipse2D
 import javax.swing.JPanel
+import javax.swing.SwingUtilities
 import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 actual fun MirrorVideoSurface(
@@ -28,6 +37,7 @@ actual fun MirrorVideoSurface(
     onInput: (MirrorInput) -> Unit,
     onHoverColor: (String) -> Unit,
     passThroughInput: Boolean,
+    onPickerClick: (String) -> Unit,
     onDevicePointClick: (Int, Int) -> Unit,
     onRulerResize: (Float, Float) -> Unit,
     overlay: MirrorOverlay,
@@ -41,11 +51,47 @@ actual fun MirrorVideoSurface(
             panel.onInput = onInput
             panel.onHoverColor = onHoverColor
             panel.passThroughInput = passThroughInput
+            panel.onPickerClick = onPickerClick
             panel.onDevicePointClick = onDevicePointClick
             panel.onRulerResize = onRulerResize
             panel.setOverlay(overlay)
         },
     )
+}
+
+@Composable
+actual fun MirrorVideoSurface(
+    frames: Flow<MirrorFrame>,
+    resetKey: Any?,
+    modifier: Modifier,
+    onInput: (MirrorInput) -> Unit,
+    onHoverColor: (String) -> Unit,
+    passThroughInput: Boolean,
+    onPickerClick: (String) -> Unit,
+    onDevicePointClick: (Int, Int) -> Unit,
+    onRulerResize: (Float, Float) -> Unit,
+    overlay: MirrorOverlay,
+) {
+    val panel = remember { MirrorPanel() }
+    SwingPanel(
+        modifier = modifier,
+        background = Color.Black,
+        factory = { panel },
+        update = {
+            panel.onInput = onInput
+            panel.onHoverColor = onHoverColor
+            panel.passThroughInput = passThroughInput
+            panel.onPickerClick = onPickerClick
+            panel.onDevicePointClick = onDevicePointClick
+            panel.onRulerResize = onRulerResize
+            panel.setOverlay(overlay)
+        },
+    )
+    LaunchedEffect(panel, frames, resetKey) {
+        frames.collectLatest { frame ->
+            panel.enqueueFrame(frame)
+        }
+    }
 }
 
 private class MirrorPanel : JPanel() {
@@ -56,6 +102,7 @@ private class MirrorPanel : JPanel() {
     private var overlay: MirrorOverlay = MirrorOverlay()
     var onInput: (MirrorInput) -> Unit = {}
     var onHoverColor: (String) -> Unit = {}
+    var onPickerClick: (String) -> Unit = {}
     var onDevicePointClick: (Int, Int) -> Unit = { _, _ -> }
     var onRulerResize: (Float, Float) -> Unit = { _, _ -> }
     var passThroughInput: Boolean = true
@@ -63,18 +110,47 @@ private class MirrorPanel : JPanel() {
     private var pickerPoint: Point? = null
     private var dragMode = DragMode.None
     private var lastDeviceMoveSentAtNanos = 0L
+    private val frameLock = Any()
+    private var pendingFrame: MirrorFrame? = null
+    private var frameDispatchPending = false
 
     init {
         background = java.awt.Color.BLACK
         preferredSize = Dimension(240, 520)
         isDoubleBuffered = true
+        // Let the panel own keyboard focus so physical keystrokes reach the device,
+        // and keep Tab/Enter for ourselves instead of moving focus within Swing.
+        isFocusable = true
+        focusTraversalKeysEnabled = false
+        addKeyListener(object : KeyAdapter() {
+            override fun keyTyped(event: KeyEvent) {
+                if (!passThroughInput) return
+                val char = event.keyChar
+                // Printable characters are forwarded as text; control keys (Enter,
+                // Backspace, Tab, Esc, Delete) are handled in keyPressed as key events.
+                if (char == KeyEvent.CHAR_UNDEFINED || char.isISOControl()) return
+                onInput(MirrorInput.Text(char.toString()))
+            }
+
+            override fun keyPressed(event: KeyEvent) {
+                if (!passThroughInput) return
+                val androidKeyCode = androidKeyCodeFor(event.keyCode) ?: return
+                onInput(MirrorInput.Key(androidKeyCode))
+                event.consume()
+            }
+        })
         val listener = object : MouseAdapter() {
             override fun mousePressed(event: MouseEvent) {
+                requestFocusInWindow()
                 pressedPoint = event.point
                 mapPoint(event.point)?.let { point ->
                     dragMode = rulerDragMode(event.point)
                     when {
                         dragMode == DragMode.RulerX || dragMode == DragMode.RulerY -> updateRulerDrag(event.point)
+                        overlay.pickerColor != null -> {
+                            dragMode = DragMode.Inspect
+                            updateHoverColor(event.point)?.let(onPickerClick)
+                        }
                         passThroughInput -> {
                             dragMode = DragMode.Device
                             lastDeviceMoveSentAtNanos = 0L
@@ -91,18 +167,23 @@ private class MirrorPanel : JPanel() {
 
             override fun mouseDragged(event: MouseEvent) {
                 updateHoverColor(event.point)
-                mapPoint(event.point)?.let { point ->
-                    when (dragMode) {
-                        DragMode.RulerX, DragMode.RulerY -> updateRulerDrag(event.point)
-                        DragMode.Device -> sendDeviceMove(point)
-                        else -> Unit
-                    }
+                when (dragMode) {
+                    DragMode.RulerX, DragMode.RulerY -> mapPoint(event.point)?.let { updateRulerDrag(event.point) }
+                    // Clamp so a fling that leaves the image edge still carries its
+                    // final velocity to the device instead of being dropped.
+                    DragMode.Device -> mapPoint(event.point, clamp = true)?.let(::sendDeviceMove)
+                    else -> Unit
                 }
             }
 
             override fun mouseReleased(event: MouseEvent) {
-                mapPoint(event.point)?.let { point ->
-                    if (dragMode == DragMode.Device) onInput(MirrorInput.Touch(MirrorTouchAction.Up, point.x, point.y))
+                // Always release a device touch, even when the mouse is let go outside
+                // the image bounds. Skipping the Up here strands a finger "down" on the
+                // emulator (it uses NEVER_EXPIRE), which wedges every later tap.
+                if (dragMode == DragMode.Device) {
+                    mapPoint(event.point, clamp = true)?.let { point ->
+                        onInput(MirrorInput.Touch(MirrorTouchAction.Up, point.x, point.y))
+                    }
                 }
                 pressedPoint = null
                 lastDeviceMoveSentAtNanos = 0L
@@ -117,9 +198,32 @@ private class MirrorPanel : JPanel() {
                     else -> Cursor.getDefaultCursor()
                 }
             }
+
+            override fun mouseExited(event: MouseEvent) {
+                pickerPoint = null
+                repaint()
+            }
         }
         addMouseListener(listener)
         addMouseMotionListener(listener)
+    }
+
+    // Maps AWT key codes for non-text keys to Android key codes (KeyEvent.KEYCODE_*).
+    private fun androidKeyCodeFor(awtKeyCode: Int): Int? = when (awtKeyCode) {
+        KeyEvent.VK_ENTER -> 66
+        KeyEvent.VK_BACK_SPACE -> 67
+        KeyEvent.VK_DELETE -> 112
+        KeyEvent.VK_TAB -> 61
+        KeyEvent.VK_ESCAPE -> 111
+        KeyEvent.VK_UP -> 19
+        KeyEvent.VK_DOWN -> 20
+        KeyEvent.VK_LEFT -> 21
+        KeyEvent.VK_RIGHT -> 22
+        KeyEvent.VK_HOME -> 122
+        KeyEvent.VK_END -> 123
+        KeyEvent.VK_PAGE_UP -> 92
+        KeyEvent.VK_PAGE_DOWN -> 93
+        else -> null
     }
 
     private fun sendDeviceMove(point: DevicePoint) {
@@ -136,8 +240,24 @@ private class MirrorPanel : JPanel() {
             ?: BufferedImage(frame.width, frame.height, BufferedImage.TYPE_INT_ARGB).also {
                 image = it
             }
-        buffered.setRGB(0, 0, frame.width, frame.height, frame.argb, 0, frame.width)
+        val pixels = (buffered.raster.dataBuffer as DataBufferInt).data
+        frame.argb.copyInto(pixels, endIndex = frame.width * frame.height)
         repaint()
+    }
+
+    fun enqueueFrame(frame: MirrorFrame) {
+        synchronized(frameLock) {
+            pendingFrame = frame
+            if (frameDispatchPending) return
+            frameDispatchPending = true
+        }
+        SwingUtilities.invokeLater {
+            val next = synchronized(frameLock) {
+                frameDispatchPending = false
+                pendingFrame.also { pendingFrame = null }
+            }
+            setFrame(next)
+        }
     }
 
     fun setOverlay(next: MirrorOverlay) {
@@ -156,13 +276,16 @@ private class MirrorPanel : JPanel() {
         paintOverlay(g2, frameImage, rect)
     }
 
-    private fun mapPoint(point: Point): DevicePoint? {
+    // When clamp is false, points outside the fitted image return null (used for
+    // hit-testing hover/press). When clamp is true, off-image points are pinned to the
+    // nearest edge so an in-progress drag/release still produces a valid device point.
+    private fun mapPoint(point: Point, clamp: Boolean = false): DevicePoint? {
         val frameImage = image ?: return null
         if (width <= 0 || height <= 0 || frameImage.width <= 0 || frameImage.height <= 0) return null
         val rect = fittedRect(frameImage)
         val localX = point.x - rect.x
         val localY = point.y - rect.y
-        if (localX < 0.0 || localY < 0.0 || localX > rect.width || localY > rect.height) return null
+        if (!clamp && (localX < 0.0 || localY < 0.0 || localX > rect.width || localY > rect.height)) return null
         return DevicePoint(
             x = (localX / rect.scale).roundToInt().coerceIn(0, frameImage.width - 1),
             y = (localY / rect.scale).roundToInt().coerceIn(0, frameImage.height - 1),
@@ -232,8 +355,13 @@ private class MirrorPanel : JPanel() {
             val point = pickerPoint?.takeIf { it.x in rect.x..(rect.x + rect.width) && it.y in rect.y..(rect.y + rect.height) }
             val cx = point?.x ?: (rect.x + rect.width * 7 / 10)
             val cy = point?.y ?: (rect.y + rect.height / 3)
-            g2.color = color.toAwtColor(alphaOverride = 0.38f)
-            g2.fillOval(cx - radius, cy - radius, radius * 2, radius * 2)
+            val mapped = point?.let { mapPoint(it) }
+            if (mapped != null) {
+                drawMagnifier(g2, frameImage, cx, cy, radius, mapped)
+            } else {
+                g2.color = color.toAwtColor(alphaOverride = 0.38f)
+                g2.fillOval(cx - radius, cy - radius, radius * 2, radius * 2)
+            }
             g2.color = java.awt.Color(216, 111, 74)
             g2.stroke = BasicStroke(2f)
             g2.drawOval(cx - radius, cy - radius, radius * 2, radius * 2)
@@ -243,14 +371,74 @@ private class MirrorPanel : JPanel() {
         }
     }
 
-    private fun updateHoverColor(point: Point) {
-        val frameImage = image ?: return
-        val mapped = mapPoint(point) ?: return
+    private fun drawMagnifier(g2: Graphics2D, frameImage: BufferedImage, cx: Int, cy: Int, radius: Int, point: DevicePoint) {
+        val zoom = 5
+        val sourceRadius = (radius / zoom).coerceAtLeast(1)
+        val sourceLeft = (point.x - sourceRadius).coerceAtLeast(0)
+        val sourceTop = (point.y - sourceRadius).coerceAtLeast(0)
+        val sourceRight = (point.x + sourceRadius + 1).coerceAtMost(frameImage.width)
+        val sourceBottom = (point.y + sourceRadius + 1).coerceAtMost(frameImage.height)
+        val destLeft = cx - (point.x - sourceLeft) * zoom - zoom / 2
+        val destTop = cy - (point.y - sourceTop) * zoom - zoom / 2
+        val destRight = destLeft + (sourceRight - sourceLeft) * zoom
+        val destBottom = destTop + (sourceBottom - sourceTop) * zoom
+        val lens = Ellipse2D.Float(
+            (cx - radius).toFloat(),
+            (cy - radius).toFloat(),
+            (radius * 2).toFloat(),
+            (radius * 2).toFloat(),
+        )
+        val lensGraphics = g2.create() as Graphics2D
+        try {
+            lensGraphics.clip = lens
+            lensGraphics.color = java.awt.Color(8, 8, 8)
+            lensGraphics.fill(lens)
+            lensGraphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR)
+            lensGraphics.drawImage(
+                frameImage,
+                destLeft,
+                destTop,
+                destRight,
+                destBottom,
+                sourceLeft,
+                sourceTop,
+                sourceRight,
+                sourceBottom,
+                null,
+            )
+            lensGraphics.color = java.awt.Color(0, 0, 0, 58)
+            lensGraphics.stroke = BasicStroke(1f)
+            for (x in cx downTo cx - radius step zoom) {
+                lensGraphics.drawLine(x, cy - radius, x, cy + radius)
+            }
+            for (x in cx + zoom..(cx + radius) step zoom) {
+                lensGraphics.drawLine(x, cy - radius, x, cy + radius)
+            }
+            for (y in cy downTo cy - radius step zoom) {
+                lensGraphics.drawLine(cx - radius, y, cx + radius, y)
+            }
+            for (y in cy + zoom..(cy + radius) step zoom) {
+                lensGraphics.drawLine(cx - radius, y, cx + radius, y)
+            }
+        } finally {
+            lensGraphics.dispose()
+        }
+    }
+
+    private fun updateHoverColor(point: Point): String? {
+        val frameImage = image ?: return null
+        val mapped = mapPoint(point) ?: run {
+            pickerPoint = null
+            repaint()
+            return null
+        }
         pickerPoint = point
         val rgb = frameImage.getRGB(mapped.x, mapped.y)
         val color = java.awt.Color(rgb, true)
-        onHoverColor("#%02X%02X%02X".format(color.red, color.green, color.blue))
+        val hex = "#%02X%02X%02X".format(color.red, color.green, color.blue)
+        onHoverColor(hex)
         repaint()
+        return hex
     }
 
     private fun rulerDragMode(point: Point): DragMode {

--- a/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
@@ -40,6 +40,26 @@ object AndroidParsers {
         return Regex("""level:\s*(\d+)""").find(output)?.groupValues?.getOrNull(1)?.toIntOrNull()
     }
 
+    fun parseNetworkTotals(output: String): Pair<Long, Long>? {
+        var rxBytes = 0L
+        var txBytes = 0L
+        var found = false
+        output.lineSequence().forEach { line ->
+            val separatorIndex = line.indexOf(':')
+            if (separatorIndex <= 0) return@forEach
+            val iface = line.substring(0, separatorIndex).trim()
+            if (iface.isBlank() || iface == "lo" || iface.startsWith("face")) return@forEach
+            val values = line.substring(separatorIndex + 1).trim().split(Regex("\\s+"))
+            if (values.size < 9) return@forEach
+            val rx = values[0].toLongOrNull() ?: return@forEach
+            val tx = values[8].toLongOrNull() ?: return@forEach
+            rxBytes += rx
+            txBytes += tx
+            found = true
+        }
+        return if (found) rxBytes to txBytes else null
+    }
+
     fun parseWmSize(output: String): String? {
         return Regex("""Physical size:\s*([0-9]+x[0-9]+)""").find(output)?.groupValues?.getOrNull(1)
     }
@@ -284,11 +304,16 @@ object AndroidParsers {
                 val intended = parts.getOrNull(intendedIndex)?.toLongOrNull() ?: return@mapNotNull null
                 val completed = parts.getOrNull(completedIndex)?.toLongOrNull() ?: return@mapNotNull null
                 val millis = (completed - intended) / 1_000_000f
-                millis.takeIf { it > 0f && it < 10_000f }
+                if (millis > 0f && millis < 10_000f) intended to millis else null
             }
             .toList()
+            .sortedBy { (intended, _) -> intended }
             .takeLast(120)
-        return rows.mapIndexed { index, millis -> FrameRenderMetric("#${index + 1}", millis) }
+        return rows.mapIndexed { index, (intended, millis) ->
+            val previousIntended = rows.getOrNull(index - 1)?.first
+            val vsyncGapMillis = previousIntended?.let { (intended - it) / 1_000_000f }?.takeIf { it > 0f && it < 2_000f }
+            FrameRenderMetric("#${index + 1}", millis, vsyncGapMillis)
+        }
     }
 
     fun parseAccessibilityXml(xml: String): AccessibilityNode? {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopBugService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopBugService.kt
@@ -437,7 +437,7 @@ class DesktopBugService(
     companion object {
         private const val WINDOW_MILLIS = 30_000L
         private const val BUG_VIDEO_FRAME_RATE = 15.0
-        private const val SCREEN_POLL_MILLIS = 1_000L
+        private const val SCREEN_POLL_MILLIS = 3_000L
 
         private fun parseForegroundScreen(activityOutput: String, windowOutput: String, semantic: ScreenSemantics?): ForegroundScreen? {
             val combined = "$activityOutput\n$windowOutput"

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopBugService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopBugService.kt
@@ -2,13 +2,16 @@ package app.andy.desktop.service
 
 import app.andy.desktop.updates.SimpleJsonParser
 import app.andy.model.AndroidDevice
+import app.andy.model.AccessibilityNode
 import app.andy.model.BugAction
 import app.andy.model.BugArtifact
 import app.andy.model.BugCaptureDraft
 import app.andy.model.BugCaptureStatus
 import app.andy.model.BugReport
 import app.andy.model.LogLevel
+import app.andy.service.AccessibilityService
 import app.andy.service.BugService
+import app.andy.service.DeviceService
 import app.andy.service.LogcatFilter
 import app.andy.service.LogcatService
 import app.andy.service.MirrorEngine
@@ -42,6 +45,8 @@ class DesktopBugService(
     private val mirror: MirrorEngine,
     private val logcat: LogcatService,
     private val homeDir: File = File(System.getProperty("user.home")),
+    private val devices: DeviceService? = null,
+    private val accessibility: AccessibilityService? = null,
 ) : BugService {
     override val status = MutableStateFlow(BugCaptureStatus())
 
@@ -55,6 +60,7 @@ class DesktopBugService(
     private var captureStartedAtMillis: Long = 0L
     private var frameJob: Job? = null
     private var logJob: Job? = null
+    private var screenJob: Job? = null
     private var lastFrameSampledAtMillis: Long = 0L
 
     private val bugsDir: File get() = File(homeDir, ".andy/bugs")
@@ -101,6 +107,11 @@ class DesktopBugService(
                 }
             }
             .launchIn(scope)
+        screenJob = devices?.let { deviceService ->
+            scope.launch {
+                pollForegroundScreens(serial, deviceService, accessibility)
+            }
+        }
     }
 
     override suspend fun stopCapture() {
@@ -108,6 +119,8 @@ class DesktopBugService(
         frameJob = null
         logJob?.cancel()
         logJob = null
+        screenJob?.cancel()
+        screenJob = null
         synchronized(lock) {
             captureSerial = null
             captureDevice = null
@@ -117,19 +130,51 @@ class DesktopBugService(
     }
 
     override fun recordAction(kind: String, label: String, detail: String?) {
+        appendAction(kind, label, detail)
+    }
+
+    private fun appendAction(kind: String, label: String, detail: String? = null, timestampMillis: Long = System.currentTimeMillis()) {
         val serial = captureSerial ?: return
-        val now = System.currentTimeMillis()
         synchronized(lock) {
             actions += BugAction(
-                id = "action-$now-${actions.size + 1}",
-                timestampMillis = now,
+                id = "action-$timestampMillis-${actions.size + 1}",
+                timestampMillis = timestampMillis,
                 kind = kind,
                 label = label,
                 detail = detail,
             )
-            trimLocked(now)
+            trimLocked(timestampMillis)
             publishStatusLocked("Recording last 30s for $serial")
         }
+    }
+
+    private suspend fun pollForegroundScreens(serial: String, devices: DeviceService, accessibility: AccessibilityService?) {
+        var previous: ForegroundScreen? = null
+        while (currentCoroutineContext().isActive) {
+            val screen = readForegroundScreen(serial, devices, accessibility)
+            if (screen != null) {
+                val last = previous
+                when {
+                    last == null -> appendAction("screen", "Screen ${screen.shortActivityName}", screen.detail)
+                    last.packageName != screen.packageName -> appendAction("screen", "Launch ${screen.packageName}", screen.detail)
+                    last.activityName != screen.activityName || last.fragments != screen.fragments ->
+                        appendAction("screen", "Screen ${screen.shortActivityName}", screen.detail)
+                    last.semanticSignature != null && last.semanticSignature != screen.semanticSignature ->
+                        appendAction("screen", "Screen ${screen.semanticTitle ?: screen.shortActivityName}", screen.detail)
+                }
+                previous = screen
+            }
+            delay(SCREEN_POLL_MILLIS)
+        }
+    }
+
+    private suspend fun readForegroundScreen(serial: String, devices: DeviceService, accessibility: AccessibilityService?): ForegroundScreen? {
+        val activity = devices.shell(serial, listOf("dumpsys", "activity", "activities"))
+        val window = devices.shell(serial, listOf("dumpsys", "window", "windows"))
+        val activityOutput = activity.stdout.takeIf { activity.isSuccess }.orEmpty()
+        val windowOutput = window.stdout.takeIf { window.isSuccess }.orEmpty()
+        val semantic = accessibility?.dump(serial)?.toScreenSemantics()
+        return parseForegroundScreen(activityOutput, windowOutput, semantic)
     }
 
     override suspend fun saveBug(draft: BugCaptureDraft, device: AndroidDevice?): BugReport = withContext(Dispatchers.IO) {
@@ -365,6 +410,21 @@ class DesktopBugService(
 
     private data class TimestampedFrame(val timestampMillis: Long, val frame: MirrorFrame)
     private data class TimestampedLogLine(val timestampMillis: Long, val line: String)
+    private data class ForegroundScreen(
+        val packageName: String,
+        val activityName: String,
+        val fragments: List<String>,
+        val semanticTitle: String?,
+        val semanticSignature: String?,
+    ) {
+        val shortActivityName: String get() = activityName.substringAfterLast('.')
+        val detail: String get() = buildList {
+            add("$packageName/$activityName")
+            if (fragments.isNotEmpty()) add("fragments: ${fragments.joinToString(", ")}")
+            if (!semanticTitle.isNullOrBlank()) add("content: $semanticTitle")
+        }.joinToString(" · ")
+    }
+
     private data class BugSnapshot(
         val serial: String,
         val device: AndroidDevice?,
@@ -377,7 +437,65 @@ class DesktopBugService(
     companion object {
         private const val WINDOW_MILLIS = 30_000L
         private const val BUG_VIDEO_FRAME_RATE = 15.0
+        private const val SCREEN_POLL_MILLIS = 1_000L
+
+        private fun parseForegroundScreen(activityOutput: String, windowOutput: String, semantic: ScreenSemantics?): ForegroundScreen? {
+            val combined = "$activityOutput\n$windowOutput"
+            val component = listOf(
+                Regex("""topResumedActivity=.*?\s([A-Za-z0-9_.]+)/([A-Za-z0-9_.$]+)"""),
+                Regex("""mResumedActivity=.*?\s([A-Za-z0-9_.]+)/([A-Za-z0-9_.$]+)"""),
+                Regex("""mFocusedApp=.*?\s([A-Za-z0-9_.]+)/([A-Za-z0-9_.$]+)"""),
+                Regex("""mCurrentFocus=.*?\s([A-Za-z0-9_.]+)/([A-Za-z0-9_.$]+)"""),
+            ).firstNotNullOfOrNull { pattern ->
+                pattern.find(combined)?.let { match ->
+                    match.groupValues[1] to match.groupValues[2].trimEnd('}', ')')
+                }
+            } ?: return null
+            val packageName = component.first
+            val rawActivity = component.second
+            val activityName = when {
+                rawActivity.startsWith(".") -> packageName + rawActivity
+                rawActivity.contains(".") -> rawActivity
+                else -> "$packageName.$rawActivity"
+            }
+            val fragments = Regex("""#\d+:\s+([A-Za-z0-9_.$]+)\{""")
+                .findAll(activityOutput)
+                .map { it.groupValues[1].substringAfterLast('.') }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .take(4)
+                .toList()
+            return ForegroundScreen(packageName, activityName, fragments, semantic?.title, semantic?.signature)
+        }
     }
+}
+
+private data class ScreenSemantics(
+    val title: String?,
+    val signature: String?,
+)
+
+private fun AccessibilityNode.toScreenSemantics(): ScreenSemantics {
+    val labels = flattenForScreenSemantics()
+        .filter { node -> node.visible && node.enabled }
+        .mapNotNull { node ->
+            listOf(node.text, node.contentDescription, node.hint, node.resourceId)
+                .firstOrNull { !it.isNullOrBlank() }
+                ?.trim()
+                ?.takeIf { it.length in 2..120 }
+        }
+        .filterNot { it.matches(Regex("""\d{1,2}:\d{2}""")) }
+        .distinct()
+        .take(8)
+        .toList()
+    return ScreenSemantics(
+        title = labels.firstOrNull(),
+        signature = labels.takeIf { it.isNotEmpty() }?.joinToString("|"),
+    )
+}
+
+private fun AccessibilityNode.flattenForScreenSemantics(): List<AccessibilityNode> {
+    return listOf(this) + children.flatMap { it.flattenForScreenSemantics() }
 }
 
 internal object BugJson {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
@@ -1016,6 +1016,7 @@ class DesktopMirrorEngine(
         } catch (cancelled: CancellationException) {
             throw cancelled
         } catch (error: Throwable) {
+            if (!isActive) return@withContext
             val reason = error.message ?: error::class.simpleName.orEmpty()
             status.value = "Emulator gRPC video failed; falling back to scrcpy: $reason"
             if (emulatorGrpcClient === client) emulatorGrpcClient = null
@@ -1528,8 +1529,10 @@ private class EmulatorGrpcClient(
     }
 
     fun close() {
-        managedChannel.shutdownNow()
-        managedChannel.awaitTermination(500, TimeUnit.MILLISECONDS)
+        runCatching {
+            managedChannel.shutdownNow()
+            managedChannel.awaitTermination(500, TimeUnit.MILLISECONDS)
+        }
     }
 
     private fun sendTouch(touch: EmulatorTouch): CommandResult {
@@ -1857,6 +1860,7 @@ private fun emulatorGrpcDiscoveryFiles(): List<File> {
         File(home, "Library/Caches/TemporaryItems/avd/running"),
         tmpDir?.resolve("avd/running"),
         xdgRuntime?.resolve("avd/running"),
+        File(System.getProperty("java.io.tmpdir"), "avd/running"),
         File("/tmp/android-${System.getProperty("user.name")}/avd/running"),
     ).distinctBy { it.absolutePath }
     return roots.flatMap { root ->

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
@@ -3,6 +3,17 @@ package app.andy.desktop.service
 import app.andy.desktop.parser.AndroidParsers
 import app.andy.model.*
 import app.andy.service.*
+import io.grpc.CallOptions
+import io.grpc.Channel
+import io.grpc.ClientCall
+import io.grpc.ClientInterceptor
+import io.grpc.ClientInterceptors
+import io.grpc.ForwardingClientCall
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.Metadata
+import io.grpc.MethodDescriptor
+import io.grpc.stub.ClientCalls
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -28,10 +39,18 @@ import org.bytedeco.javacpp.IntPointer
 import org.bytedeco.javacpp.PointerPointer
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
 import java.net.Socket
 import java.net.ServerSocket
 import java.net.Inet4Address
@@ -41,6 +60,7 @@ import java.util.concurrent.TimeUnit
 import javax.swing.JFileChooser
 import javax.swing.SwingUtilities
 import kotlin.random.Random
+import kotlin.math.abs
 import kotlin.math.roundToInt
 import app.andy.desktop.updates.DesktopAppUpdateService
 import kotlinx.coroutines.CoroutineScope
@@ -91,7 +111,7 @@ fun createDesktopServices(): AndyServices {
         proxy = proxy,
         metrics = DesktopMetricsService(runner, devices),
         accessibility = accessibility,
-        bugs = DesktopBugService(mirror, logcat),
+        bugs = DesktopBugService(mirror, logcat, devices = devices, accessibility = accessibility),
         artifacts = DesktopArtifactService(runner, devices, mirror),
         workspaceStore = store,
         updates = updates,
@@ -157,21 +177,23 @@ class DesktopDeviceService(
         val adb = sdk.adbPath ?: return emptyList()
         val result = runner.run(listOf(adb, "devices", "-l"))
         if (!result.isSuccess) return emptyList()
-        return AndroidParsers.parseAdbDevices(result.stdout).map { base ->
-            if (base.state != DeviceConnectionState.Online) return@map base
-            val props = getProps(adb, base.serial)
-            val avdName = props["ro.boot.qemu.avd_name"] ?: props["ro.kernel.qemu.avd_name"]
-            base.copy(
-                displayName = if (base.kind == DeviceKind.Emulator) avdName ?: props["ro.product.model"] ?: base.displayName else props["ro.product.model"] ?: base.displayName,
-                apiLevel = props["ro.build.version.sdk"],
-                abi = props["ro.product.cpu.abi"],
-                model = props["ro.product.model"] ?: base.model,
-                product = props["ro.product.name"] ?: base.product,
-                batteryPercent = AndroidParsers.parseBatteryPercent(runner.run(listOf(adb, "-s", base.serial, "shell", "dumpsys", "battery"), 6).stdout),
-                screenSize = AndroidParsers.parseWmSize(runner.run(listOf(adb, "-s", base.serial, "shell", "wm", "size"), 6).stdout),
-                storageSummary = AndroidParsers.parseStorage(runner.run(listOf(adb, "-s", base.serial, "shell", "df", "-h", "/data"), 6).stdout),
-            )
-        }
+        return AndroidParsers.parseAdbDevices(result.stdout)
+            .filterNot { it.kind == DeviceKind.Emulator && it.state == DeviceConnectionState.Offline }
+            .map { base ->
+                if (base.state != DeviceConnectionState.Online) return@map base
+                val props = getProps(adb, base.serial)
+                val avdName = props["ro.boot.qemu.avd_name"] ?: props["ro.kernel.qemu.avd_name"]
+                base.copy(
+                    displayName = if (base.kind == DeviceKind.Emulator) avdName ?: props["ro.product.model"] ?: base.displayName else props["ro.product.model"] ?: base.displayName,
+                    apiLevel = props["ro.build.version.sdk"],
+                    abi = props["ro.product.cpu.abi"],
+                    model = props["ro.product.model"] ?: base.model,
+                    product = props["ro.product.name"] ?: base.product,
+                    batteryPercent = AndroidParsers.parseBatteryPercent(runner.run(listOf(adb, "-s", base.serial, "shell", "dumpsys", "battery"), 6).stdout),
+                    screenSize = AndroidParsers.parseWmSize(runner.run(listOf(adb, "-s", base.serial, "shell", "wm", "size"), 6).stdout),
+                    storageSummary = AndroidParsers.parseStorage(runner.run(listOf(adb, "-s", base.serial, "shell", "df", "-h", "/data"), 6).stdout),
+                )
+            }
     }
 
     override suspend fun shell(serial: String, command: List<String>): CommandResult {
@@ -251,13 +273,11 @@ class DesktopAvdService(
     override suspend fun listVirtualDevices(): List<VirtualDevice> {
         val avdManager = locator.discover(preferredSdkPath()).avdManagerPath ?: return emptyList()
         val avds = AndroidParsers.parseAvdList(runner.run(listOf(avdManager, "list", "avd"), 20).stdout)
-        val running = runningEmulatorNames() + avds.filter { avd ->
-            avd.path?.let { File(it, "hardware-qemu.ini.lock").exists() } == true
-        }.map { it.name }
+        val running = runningEmulatorNames()
         return avds.map { avd ->
             val config = loadAvdConfig(avd).orEmpty()
             avd.copy(
-                running = avd.name in running,
+                running = running.any { namesMatch(it, avd.name) },
                 apiLevel = avd.apiLevel ?: Regex("""android-(\d+)""").find(config["image.sysdir.1"].orEmpty())?.groupValues?.getOrNull(1)?.toIntOrNull(),
                 deviceType = AndroidParsers.classifyVirtualDevice(avd.name, avd.target.orEmpty(), config),
                 config = config,
@@ -311,8 +331,14 @@ class DesktopAvdService(
     private suspend fun launchVirtualDevice(name: String, extraArgs: List<String> = emptyList()): CommandResult {
         val emulator = locator.discover(preferredSdkPath()).emulatorPath ?: return CommandResult.failure("emulator not found")
         return withContext(Dispatchers.IO) {
-            ProcessBuilder(listOf(emulator, "-avd", name, "-no-window") + extraArgs + listOf("-no-boot-anim", "-gpu", "swiftshader_indirect", "-writable-system")).start()
-            CommandResult.success("Starting $name headless with writable system")
+            val ports = allocateEmulatorLaunchPorts()
+                ?: return@withContext CommandResult.failure("No free emulator port pair found")
+            val logFile = emulatorLaunchLogFile(name)
+            ProcessBuilder(emulatorStudioStyleLaunchCommand(emulator, name, extraArgs, ports))
+                .redirectErrorStream(true)
+                .redirectOutput(ProcessBuilder.Redirect.appendTo(logFile))
+                .start()
+            CommandResult.success("Starting $name with hidden emulator window and local gRPC control on ${ports.grpc}")
         }
     }
 
@@ -326,11 +352,17 @@ class DesktopAvdService(
                 namesMatch(resolveAvdName(adb, device.serial) ?: device.displayName, name)
         } ?: return CommandResult.failure("No running emulator found for $name")
         val result = runner.run(listOf(adb, "-s", emulator.serial, "emu", "kill"), 8)
-        return if (result.isSuccess) {
-            CommandResult.success("Stopped $name (${emulator.serial})")
-        } else {
-            result
+        if (!result.isSuccess) return result
+        // `emu kill` returns as soon as the console accepts it, but the emulator takes
+        // a moment to actually leave `adb devices`. Wait for it to disappear so a caller
+        // that refreshes right after doesn't still report the device as running.
+        repeat(20) {
+            val stillOnline = AndroidParsers.parseAdbDevices(runner.run(listOf(adb, "devices", "-l"), 8).stdout)
+                .any { it.serial == emulator.serial && it.state == DeviceConnectionState.Online }
+            if (!stillOnline) return CommandResult.success("Stopped $name (${emulator.serial})")
+            delay(300)
         }
+        return CommandResult.success("Stopped $name (${emulator.serial})")
     }
 
     override suspend fun deleteVirtualDevice(name: String): CommandResult {
@@ -548,11 +580,12 @@ class DesktopAvdService(
     }
 
     private suspend fun runningEmulatorNames(): Set<String> = withContext(Dispatchers.IO) {
-        File(System.getProperty("user.home"), ".android/avd").listFiles()
-            ?.filter { it.name.endsWith(".avd") && File(it, "hardware-qemu.ini.lock").exists() }
-            ?.map { it.name.removeSuffix(".avd") }
-            ?.toSet()
-            ?: emptySet()
+        val sdk = locator.discover(preferredSdkPath())
+        val adb = sdk.adbPath ?: return@withContext emptySet()
+        AndroidParsers.parseAdbDevices(runner.run(listOf(adb, "devices", "-l"), 8).stdout)
+            .filter { it.kind == DeviceKind.Emulator && it.state == DeviceConnectionState.Online }
+            .mapNotNull { device -> resolveAvdName(adb, device.serial) ?: device.displayName }
+            .toSet()
     }
 
     private suspend fun findRunningEmulatorSerial(name: String): String? {
@@ -647,6 +680,107 @@ class DesktopAvdService(
     private fun normalizeName(value: String): String {
         return value.replace('_', ' ').trim().lowercase()
     }
+
+    private fun allocateEmulatorLaunchPorts(): EmulatorLaunchPorts? {
+        for (console in 5554..5682 step 2) {
+            val adb = console + 1
+            val grpc = console + 3000
+            if (isLocalTcpPortAvailable(console) && isLocalTcpPortAvailable(adb) && isLocalTcpPortAvailable(grpc)) {
+                return EmulatorLaunchPorts(console = console, adb = adb, grpc = grpc)
+            }
+        }
+        return null
+    }
+
+    private fun isLocalTcpPortAvailable(port: Int): Boolean {
+        return runCatching {
+            ServerSocket().use { socket ->
+                socket.reuseAddress = false
+                socket.bind(InetSocketAddress("127.0.0.1", port))
+            }
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun emulatorLaunchLogFile(name: String): File {
+        val safeName = name.replace(Regex("""[^A-Za-z0-9._-]"""), "_")
+        return File(System.getProperty("user.home"), ".andy/emulator/$safeName.log").also { file ->
+            file.parentFile?.mkdirs()
+        }
+    }
+}
+
+internal data class EmulatorLaunchPorts(
+    val console: Int,
+    val adb: Int,
+    val grpc: Int,
+)
+
+internal fun emulatorStudioStyleLaunchCommand(
+    emulator: String,
+    name: String,
+    extraArgs: List<String> = emptyList(),
+    ports: EmulatorLaunchPorts = EmulatorLaunchPorts(console = 5554, adb = 5555, grpc = 8554),
+): List<String> {
+    return listOf(
+        emulator,
+        "-avd", name,
+        "-qt-hide-window",
+        "-ports", "${ports.console},${ports.adb}",
+        "-grpc", ports.grpc.toString(),
+        "-idle-grpc-timeout", "300",
+    ) + extraArgs + listOf(
+        "-no-boot-anim",
+        "-gpu", "auto",
+        "-writable-system",
+    )
+}
+
+private const val EMULATOR_IMAGE_BYTES_PER_PIXEL = 3
+private const val EMULATOR_DISPLAY_SIZE_SETTLE_NANOS = 60_000_000_000L
+private const val EMULATOR_DISPLAY_SIZE_REFRESH_MIN_NANOS = 1_000_000_000L
+private val EMULATOR_WM_SIZE_REGEX = Regex("""(?:Physical|Override) size:\s*(\d+)x(\d+)""")
+
+internal data class EmulatorDisplaySize(val width: Int, val height: Int)
+internal data class EmulatorTouchPoint(val x: Int, val y: Int)
+
+private fun MirrorInput.usesTouchCoordinates(): Boolean = when (this) {
+    is MirrorInput.Touch,
+    is MirrorInput.Tap,
+    is MirrorInput.Swipe -> true
+    is MirrorInput.Key,
+    is MirrorInput.Text,
+    MirrorInput.Back,
+    MirrorInput.Home,
+    MirrorInput.Recents,
+    MirrorInput.Power -> false
+}
+
+private fun emulatorDisplayAspectDrifted(frame: MirrorFrame, displaySize: EmulatorDisplaySize): Boolean {
+    if (frame.width <= 1 || frame.height <= 1 || displaySize.width <= 0 || displaySize.height <= 0) return false
+    val frameAspect = frame.width.toDouble() / frame.height
+    val displayAspect = displaySize.width.toDouble() / displaySize.height
+    return abs(frameAspect - displayAspect) > 0.03
+}
+
+internal fun scaledEmulatorTouchPoint(
+    x: Int,
+    y: Int,
+    frame: MirrorFrame,
+    displaySize: EmulatorDisplaySize?,
+): EmulatorTouchPoint {
+    val frameWidth = frame.width.coerceAtLeast(1)
+    val frameHeight = frame.height.coerceAtLeast(1)
+    val targetWidth = displaySize?.width ?: frameWidth
+    val targetHeight = displaySize?.height ?: frameHeight
+    return EmulatorTouchPoint(
+        x = (x.coerceIn(0, frameWidth - 1).toLong() * targetWidth / frameWidth)
+            .toInt()
+            .coerceIn(0, targetWidth - 1),
+        y = (y.coerceIn(0, frameHeight - 1).toLong() * targetHeight / frameHeight)
+            .toInt()
+            .coerceIn(0, targetHeight - 1),
+    )
 }
 
 class DesktopMirrorEngine(
@@ -659,9 +793,12 @@ class DesktopMirrorEngine(
     private var videoProcess: Process? = null
     private var controlSocket: Socket? = null
     private var controlOutput: BufferedOutputStream? = null
+    private var emulatorGrpcClient: EmulatorGrpcClient? = null
     private var videoForwardPort: Int? = null
     private var connectedSerial: String? = null
     private var connectedConfig: MirrorVideoConfig? = null
+    private var connectedAtNanos: Long = 0L
+    private var lastEmulatorDisplaySizeRefreshNanos: Long = 0L
     private val controlLock = Any()
 
     override suspend fun connect(serial: String, config: MirrorVideoConfig): CommandResult {
@@ -671,10 +808,24 @@ class DesktopMirrorEngine(
         disconnect()
         connectedSerial = serial
         connectedConfig = config
+        connectedAtNanos = System.nanoTime()
+        lastEmulatorDisplaySizeRefreshNanos = 0L
         val adb = devices.adbPath() ?: return CommandResult.failure("ADB not found")
+        frames.value = MirrorFrame(1, 1, intArrayOf(0xff000000.toInt()))
+        if (serial.isEmulatorSerial()) {
+            val grpcPort = serial.emulatorConsolePort()?.plus(3000)
+                ?: return CommandResult.failure("Unable to resolve emulator gRPC port for $serial")
+            val token = readEmulatorGrpcToken(grpcPort)
+            val client = EmulatorGrpcClient("127.0.0.1", grpcPort, token, readEmulatorDisplaySize(adb, serial))
+            emulatorGrpcClient = client
+            status.value = "Starting emulator gRPC mirror for $serial on port $grpcPort"
+            videoJob = kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
+                runEmulatorGrpcVideoLoop(adb, serial, client, config)
+            }
+            return CommandResult.success("Emulator gRPC mirror starting for $serial")
+        }
         val scrcpyServer = ScrcpyServerLocator.find()
             ?: return CommandResult.failure("scrcpy-server not found. Andy bundles it for packaged builds; for development, install scrcpy with `brew install scrcpy` or set SCRCPY_SERVER_PATH.")
-        frames.value = MirrorFrame(1, 1, intArrayOf(0xff000000.toInt()))
         status.value = "Starting scrcpy-server raw H.264 mirror for $serial (${config.maxSize}px, ${config.bitRate / 1_000_000.0} Mbps)"
         videoJob = kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
             runNativeVideoLoop(adb, serial, scrcpyServer, config)
@@ -683,14 +834,17 @@ class DesktopMirrorEngine(
     }
 
     override suspend fun disconnect() {
-        videoJob?.cancel()
+        val job = videoJob
         videoJob = null
+        job?.cancel()
         synchronized(controlLock) {
             runCatching { controlOutput?.close() }
             controlOutput = null
             runCatching { controlSocket?.close() }
             controlSocket = null
         }
+        emulatorGrpcClient?.close()
+        emulatorGrpcClient = null
         videoProcess?.destroyForcibly()
         videoProcess = null
         videoForwardPort?.let { port ->
@@ -701,10 +855,33 @@ class DesktopMirrorEngine(
         }
         videoForwardPort = null
         connectedConfig = null
+        connectedAtNanos = 0L
+        lastEmulatorDisplaySizeRefreshNanos = 0L
+        // Wait for the video loop to fully stop before clearing the frame so a late
+        // in-flight frame can't win the race and leave a frozen image on screen.
+        job?.let { runCatching { it.join() } }
+        frames.value = MirrorFrame(1, 1, intArrayOf(0xff000000.toInt()))
         status.value = "Disconnected"
     }
 
     override suspend fun sendInput(input: MirrorInput): CommandResult {
+        emulatorGrpcClient?.let { client ->
+            // Run the blocking gRPC touch RPC off the Compose UI dispatcher so dragging
+            // stays as smooth as Android Studio instead of stalling the event thread.
+            withContext(Dispatchers.IO) {
+                val frame = frames.value
+                val serial = connectedSerial
+                val adb = devices.adbPath()
+                val touchInput = input.usesTouchCoordinates()
+                if (serial != null && adb != null && touchInput) {
+                    refreshEmulatorDisplaySizeIfNeeded(client, adb, serial, frame)
+                }
+                if (touchInput && client.displaySize == null) {
+                    return@withContext CommandResult.failure("Waiting for emulator display size before sending touch input")
+                }
+                client.sendInput(input, frame)
+            }?.let { return it }
+        }
         sendScrcpyControl(input)?.let { return it }
         val adb = devices.adbPath() ?: return CommandResult.failure("ADB not found")
         val selectedSerial = connectedSerial ?: devices.listDevices().firstOrNull { it.state == DeviceConnectionState.Online }?.serial
@@ -724,6 +901,25 @@ class DesktopMirrorEngine(
             MirrorInput.Power -> listOf(adb, "-s", selectedSerial, "shell", "input", "keyevent", "26")
         }
         return runner.run(command)
+    }
+
+    private suspend fun refreshEmulatorDisplaySizeIfNeeded(
+        client: EmulatorGrpcClient,
+        adb: String,
+        serial: String,
+        frame: MirrorFrame,
+    ) {
+        val now = System.nanoTime()
+        val withinBootSettleWindow = connectedAtNanos > 0L && now - connectedAtNanos < EMULATOR_DISPLAY_SIZE_SETTLE_NANOS
+        val shouldRefresh = client.displaySize == null ||
+            withinBootSettleWindow ||
+            client.displaySize?.let { displaySize -> emulatorDisplayAspectDrifted(frame, displaySize) } == true
+        if (!shouldRefresh) return
+        if (now - lastEmulatorDisplaySizeRefreshNanos < EMULATOR_DISPLAY_SIZE_REFRESH_MIN_NANOS) return
+        lastEmulatorDisplaySizeRefreshNanos = now
+
+        val next = readEmulatorDisplaySize(adb, serial) ?: return
+        client.updateDisplaySize(next)
     }
 
     private fun sendScrcpyControl(input: MirrorInput): CommandResult? {
@@ -750,6 +946,109 @@ class DesktopMirrorEngine(
         val adb = devices.adbPath() ?: return null
         val result = runner.run(listOf(adb, "-s", serial, "exec-out", "screencap", "-p"), 8)
         return result.stdout.encodeToByteArray().takeIf { result.isSuccess }
+    }
+
+    private suspend fun readEmulatorDisplaySize(adb: String, serial: String): EmulatorDisplaySize? {
+        val result = runner.run(listOf(adb, "-s", serial, "shell", "wm", "size"), 4)
+        if (!result.isSuccess) return null
+        return result.stdout
+            .lineSequence()
+            .mapNotNull { line -> EMULATOR_WM_SIZE_REGEX.find(line)?.destructured }
+            .mapNotNull { (width, height) ->
+                val parsedWidth = width.toIntOrNull()
+                val parsedHeight = height.toIntOrNull()
+                if (parsedWidth != null && parsedHeight != null && parsedWidth > 0 && parsedHeight > 0) {
+                    EmulatorDisplaySize(parsedWidth, parsedHeight)
+                } else {
+                    null
+                }
+            }
+            .firstOrNull()
+    }
+
+    private suspend fun runEmulatorGrpcVideoLoop(adb: String, serial: String, client: EmulatorGrpcClient, config: MirrorVideoConfig) = withContext(Dispatchers.IO) {
+        var frameNumber = 0L
+        var fpsWindowStartedAt = System.nanoTime()
+        var fpsWindowFrame = 0L
+        var decodedFps = 0f
+        var mappedFramebuffer: EmulatorMappedFramebuffer? = null
+        try {
+            mappedFramebuffer = if (System.getenv("ANDY_EMULATOR_GRPC_MMAP") != "0") {
+                runCatching { EmulatorMappedFramebuffer.create(config.maxSize) }.getOrNull()
+            } else {
+                null
+            }
+            val transport = if (mappedFramebuffer != null) "MMAP" else "raw"
+            status.value = "Emulator gRPC video connected (${config.maxSize}px $transport RGB stream)"
+            val screenshots = client.streamScreenshots(config.maxSize, mappedFramebuffer?.handle)
+            while (isActive && screenshots.hasNext()) {
+                val image = screenshots.next()
+                if (image.width <= 0 || image.height <= 0) {
+                    continue
+                }
+                val expectedBytes = image.width * image.height * EMULATOR_IMAGE_BYTES_PER_PIXEL
+                val rgb = if (image.pixels.isNotEmpty()) {
+                    ByteBuffer.wrap(image.pixels)
+                } else {
+                    mappedFramebuffer?.frameBytes(expectedBytes)
+                }
+                if (rgb == null || rgb.remaining() < expectedBytes) {
+                    status.value = "Skipping short emulator frame (${rgb?.remaining() ?: 0}/$expectedBytes bytes)"
+                    continue
+                }
+                fpsWindowFrame++
+                val now = System.nanoTime()
+                val elapsedNanos = now - fpsWindowStartedAt
+                if (elapsedNanos >= 1_000_000_000L) {
+                    decodedFps = fpsWindowFrame * 1_000_000_000f / elapsedNanos
+                    fpsWindowFrame = 0
+                    fpsWindowStartedAt = now
+                }
+                frames.value = MirrorFrame(
+                    width = image.width,
+                    height = image.height,
+                    argb = rgbToArgb(image.width, image.height, rgb),
+                    frameNumber = ++frameNumber,
+                    decodedFps = decodedFps.takeIf { it > 0f },
+                )
+            }
+            status.value = "Emulator gRPC video stream ended"
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Throwable) {
+            val reason = error.message ?: error::class.simpleName.orEmpty()
+            status.value = "Emulator gRPC video failed; falling back to scrcpy: $reason"
+            if (emulatorGrpcClient === client) emulatorGrpcClient = null
+            runCatching { client.close() }
+            val scrcpyServer = ScrcpyServerLocator.find()
+            if (scrcpyServer == null) {
+                status.value = "Emulator gRPC video failed and scrcpy-server was not found: $reason"
+                return@withContext
+            }
+            runNativeVideoLoop(adb, serial, scrcpyServer, config)
+        } finally {
+            mappedFramebuffer?.close()
+        }
+    }
+
+    // The emulator gRPC streamScreenshot RGB888 payload is top-down (top-left origin),
+    // matching how Android Studio renders it, so rows are copied in natural order.
+    private fun rgbToArgb(width: Int, height: Int, rgb: ByteBuffer): IntArray {
+        val pixels = IntArray(width * height)
+        val row = ByteArray(width * EMULATOR_IMAGE_BYTES_PER_PIXEL)
+        for (y in 0 until height) {
+            rgb.position(y * row.size)
+            rgb.get(row, 0, row.size)
+            var source = 0
+            var destination = y * width
+            while (source < row.size) {
+                val red = row[source++].toInt() and 0xff
+                val green = row[source++].toInt() and 0xff
+                val blue = row[source++].toInt() and 0xff
+                pixels[destination++] = 0xff000000.toInt() or (red shl 16) or (green shl 8) or blue
+            }
+        }
+        return pixels
     }
 
     private suspend fun runNativeVideoLoop(adb: String, serial: String, scrcpyServer: File, config: MirrorVideoConfig) = withContext(Dispatchers.IO) {
@@ -913,6 +1212,8 @@ class DesktopMirrorEngine(
             parser?.let { avcodec.av_parser_close(it) }
             // Avoid avcodec_free_context() here for now. JavaCPP/FFmpeg may crash if
             // the parser-owned packet pointers are still referenced during teardown.
+            currentDecodedFrameBuffer?.close()
+            currentDecodedFrameBuffer = null
             process.destroy()
             if (!process.waitFor(500, TimeUnit.MILLISECONDS)) {
                 process.destroyForcibly()
@@ -924,6 +1225,7 @@ class DesktopMirrorEngine(
     }
 
     private var currentSwsContext: SwsContext? = null
+    private var currentDecodedFrameBuffer: DecodedFrameBuffer? = null
 
     private fun receiveDecodedFrames(
         codecContext: AVCodecContext,
@@ -954,39 +1256,54 @@ class DesktopMirrorEngine(
                     null as DoubleArray?,
                 )
             }
-            val bgra = BytePointer(width.toLong() * height * 4)
-            val dstData = PointerPointer<BytePointer>(4)
-            val dstLinesize = IntPointer(4)
-            avutil.av_image_fill_arrays(dstData, dstLinesize, bgra, avutil.AV_PIX_FMT_BGRA, width, height, 1)
-            val scaledRows = swscale.sws_scale(context, frame.data(), frame.linesize(), 0, height, dstData, dstLinesize)
+            val output = decodedFrameBuffer(width, height)
+            val scaledRows = swscale.sws_scale(context, frame.data(), frame.linesize(), 0, height, output.dstData, output.dstLinesize)
             if (scaledRows <= 0) {
-                bgra.close()
-                dstData.close()
-                dstLinesize.close()
                 avutil.av_frame_unref(frame)
                 continue
             }
-            frames.value = MirrorFrame(width, height, bgraToArgb(bgra, width * height), ++nextFrameNumber, decodedFps.takeIf { it > 0f })
-            bgra.close()
-            dstData.close()
-            dstLinesize.close()
+            frames.value = MirrorFrame(width, height, bgraToArgb(output.bgra, width * height), ++nextFrameNumber, decodedFps.takeIf { it > 0f })
             avutil.av_frame_unref(frame)
         }
         currentSwsContext = context
         return nextFrameNumber
     }
 
+    private fun decodedFrameBuffer(width: Int, height: Int): DecodedFrameBuffer {
+        currentDecodedFrameBuffer?.takeIf { it.width == width && it.height == height }?.let { return it }
+        currentDecodedFrameBuffer?.close()
+        val bgra = BytePointer(width.toLong() * height * 4L)
+        val dstData = PointerPointer<BytePointer>(4)
+        val dstLinesize = IntPointer(4)
+        avutil.av_image_fill_arrays(dstData, dstLinesize, bgra, avutil.AV_PIX_FMT_BGRA, width, height, 1)
+        return DecodedFrameBuffer(width, height, bgra, dstData, dstLinesize).also {
+            currentDecodedFrameBuffer = it
+        }
+    }
+
     private fun bgraToArgb(bytes: BytePointer, pixelCount: Int): IntArray {
         val pixels = IntArray(pixelCount)
-        var byteIndex = 0L
-        for (pixelIndex in pixels.indices) {
-            val b = bytes.get(byteIndex++).toInt() and 0xff
-            val g = bytes.get(byteIndex++).toInt() and 0xff
-            val r = bytes.get(byteIndex++).toInt() and 0xff
-            val a = bytes.get(byteIndex++).toInt() and 0xff
-            pixels[pixelIndex] = (a shl 24) or (r shl 16) or (g shl 8) or b
-        }
+        bytes.position(0)
+            .limit(pixelCount.toLong() * 4L)
+            .asByteBuffer()
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asIntBuffer()
+            .get(pixels)
         return pixels
+    }
+
+    private data class DecodedFrameBuffer(
+        val width: Int,
+        val height: Int,
+        val bgra: BytePointer,
+        val dstData: PointerPointer<BytePointer>,
+        val dstLinesize: IntPointer,
+    ) {
+        fun close() {
+            bgra.close()
+            dstData.close()
+            dstLinesize.close()
+        }
     }
 
     private suspend fun captureSize(adb: String, serial: String, maxSize: Int): CaptureSize {
@@ -1058,6 +1375,513 @@ internal object ScrcpyServerLocator {
         }
         return target.takeIf { it.isFile && it.length() > 0 }
     }
+}
+
+private class EmulatorMappedFramebuffer private constructor(
+    private val file: File,
+    private val channel: FileChannel,
+    private val buffer: MappedByteBuffer,
+) : AutoCloseable {
+    val handle: String = file.toPath().toUri().toASCIIString()
+
+    fun frameBytes(byteCount: Int): ByteBuffer? {
+        if (byteCount <= 0 || byteCount > buffer.capacity()) return null
+        val frame = buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN)
+        frame.position(0)
+        frame.limit(byteCount)
+        return frame.slice().order(ByteOrder.LITTLE_ENDIAN)
+    }
+
+    override fun close() {
+        runCatching { channel.close() }
+        runCatching { file.delete() }
+    }
+
+    companion object {
+        fun create(maxSize: Int): EmulatorMappedFramebuffer {
+            val boundedMaxSize = maxSize.coerceIn(1, 4096)
+            val byteCount = boundedMaxSize.toLong() * boundedMaxSize * EMULATOR_IMAGE_BYTES_PER_PIXEL + 4096L
+            val file = File.createTempFile("andy-emulator-framebuffer-", ".rgb")
+            file.deleteOnExit()
+            val channel = FileChannel.open(
+                file.toPath(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+            )
+            try {
+                channel.truncate(byteCount)
+                val buffer = channel.map(FileChannel.MapMode.READ_WRITE, 0, byteCount)
+                return EmulatorMappedFramebuffer(file, channel, buffer)
+            } catch (error: Throwable) {
+                runCatching { channel.close() }
+                runCatching { file.delete() }
+                throw error
+            }
+        }
+    }
+}
+
+private class EmulatorGrpcClient(
+    host: String,
+    port: Int,
+    token: String?,
+    initialDisplaySize: EmulatorDisplaySize?,
+) {
+    var displaySize: EmulatorDisplaySize? = initialDisplaySize
+        private set
+    private val managedChannel: ManagedChannel = ManagedChannelBuilder.forAddress(host, port)
+        .usePlaintext()
+        .build()
+    private val channel: Channel = token
+        ?.let { ClientInterceptors.intercept(managedChannel, EmulatorGrpcAuthInterceptor(it)) }
+        ?: managedChannel
+
+    fun streamScreenshots(maxSize: Int, mmapHandle: String? = null): Iterator<EmulatorImage> {
+        return ClientCalls.blockingServerStreamingCall(
+            channel,
+            STREAM_SCREENSHOT_METHOD,
+            CallOptions.DEFAULT,
+            EmulatorImageFormat(maxSize, mmapHandle),
+        )
+    }
+
+    fun sendInput(input: MirrorInput, frame: MirrorFrame): CommandResult? {
+        return when (input) {
+            is MirrorInput.Touch -> sendTouch(
+                touch = EmulatorTouch(
+                    x = scaleX(input.x, frame),
+                    y = scaleY(input.y, frame),
+                    pressure = if (input.action == MirrorTouchAction.Up) 0 else 1,
+                ),
+            )
+            is MirrorInput.Tap -> {
+                val x = scaleX(input.x, frame)
+                val y = scaleY(input.y, frame)
+                sendTouch(EmulatorTouch(x, y, pressure = 1))
+                sendTouch(EmulatorTouch(x, y, pressure = 0))
+            }
+            is MirrorInput.Swipe -> {
+                val startX = scaleX(input.startX, frame)
+                val startY = scaleY(input.startY, frame)
+                val endX = scaleX(input.endX, frame)
+                val endY = scaleY(input.endY, frame)
+                sendTouch(EmulatorTouch(startX, startY, pressure = 1))
+                sendTouch(EmulatorTouch(endX, endY, pressure = 1))
+                sendTouch(EmulatorTouch(endX, endY, pressure = 0))
+            }
+            is MirrorInput.Text -> sendText(input.value)
+            // Named keys go over gRPC for snappy typing; anything unmapped (volume,
+            // etc.) returns null so the caller falls back to adb keyevent.
+            is MirrorInput.Key -> domKeyName(input.keyCode)?.let { sendNamedKey(it) }
+            MirrorInput.Back,
+            MirrorInput.Home,
+            MirrorInput.Recents,
+            MirrorInput.Power -> null
+        }
+    }
+
+    // Returns null when the gRPC keyboard call cannot be delivered so the caller
+    // falls back to adb `input text`/`keyevent` instead of surfacing an error.
+    private fun sendText(text: String): CommandResult? {
+        if (text.isEmpty()) return null
+        return sendKey(EmulatorKeyEvent(eventType = KEY_EVENT_KEYPRESS, text = text))
+    }
+
+    private fun sendNamedKey(key: String): CommandResult? {
+        val down = sendKey(EmulatorKeyEvent(eventType = KEY_EVENT_KEYDOWN, key = key)) ?: return null
+        return sendKey(EmulatorKeyEvent(eventType = KEY_EVENT_KEYUP, key = key)) ?: down
+    }
+
+    private fun sendKey(event: EmulatorKeyEvent): CommandResult? {
+        return runCatching {
+            ClientCalls.blockingUnaryCall(channel, SEND_KEY_METHOD, CallOptions.DEFAULT, event)
+            CommandResult.success("Input sent")
+        }.getOrNull()
+    }
+
+    // Android key codes (KeyEvent.KEYCODE_*) → DOM-style key names the emulator understands.
+    private fun domKeyName(androidKeyCode: Int): String? = when (androidKeyCode) {
+        66 -> "Enter"
+        67 -> "Backspace"
+        112 -> "Delete"
+        61 -> "Tab"
+        111 -> "Escape"
+        19 -> "ArrowUp"
+        20 -> "ArrowDown"
+        21 -> "ArrowLeft"
+        22 -> "ArrowRight"
+        122 -> "Home"
+        123 -> "End"
+        92 -> "PageUp"
+        93 -> "PageDown"
+        else -> null
+    }
+
+    private fun scaleX(x: Int, frame: MirrorFrame): Int {
+        return scaledEmulatorTouchPoint(x, 0, frame, displaySize).x
+    }
+
+    private fun scaleY(y: Int, frame: MirrorFrame): Int {
+        return scaledEmulatorTouchPoint(0, y, frame, displaySize).y
+    }
+
+    fun close() {
+        managedChannel.shutdownNow()
+        managedChannel.awaitTermination(500, TimeUnit.MILLISECONDS)
+    }
+
+    private fun sendTouch(touch: EmulatorTouch): CommandResult {
+        return runCatching {
+            ClientCalls.blockingUnaryCall(
+                channel,
+                SEND_TOUCH_METHOD,
+                CallOptions.DEFAULT,
+                EmulatorTouchEvent(listOf(touch)),
+            )
+            CommandResult.success("Input sent")
+        }.getOrElse { error ->
+            CommandResult.failure("Emulator gRPC touch failed: ${error.message ?: error::class.simpleName}")
+        }
+    }
+
+    fun updateDisplaySize(next: EmulatorDisplaySize) {
+        displaySize = next
+    }
+
+    private class EmulatorGrpcAuthInterceptor(private val token: String) : ClientInterceptor {
+        override fun <ReqT : Any?, RespT : Any?> interceptCall(
+            method: MethodDescriptor<ReqT, RespT>,
+            callOptions: CallOptions,
+            next: Channel,
+        ): ClientCall<ReqT, RespT> {
+            return object : ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+                override fun start(responseListener: Listener<RespT>, headers: Metadata) {
+                    headers.put(AUTHORIZATION, "Bearer $token")
+                    super.start(responseListener, headers)
+                }
+            }
+        }
+    }
+
+    private companion object {
+        private val AUTHORIZATION: Metadata.Key<String> =
+            Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)
+        private val STREAM_SCREENSHOT_METHOD: MethodDescriptor<EmulatorImageFormat, EmulatorImage> =
+            MethodDescriptor.newBuilder<EmulatorImageFormat, EmulatorImage>()
+                .setType(MethodDescriptor.MethodType.SERVER_STREAMING)
+                .setFullMethodName(
+                    MethodDescriptor.generateFullMethodName(
+                        "android.emulation.control.EmulatorController",
+                        "streamScreenshot",
+                    ),
+                )
+                .setRequestMarshaller(EmulatorImageFormatMarshaller)
+                .setResponseMarshaller(EmulatorImageMarshaller)
+                .build()
+        private val SEND_TOUCH_METHOD: MethodDescriptor<EmulatorTouchEvent, Unit> =
+            MethodDescriptor.newBuilder<EmulatorTouchEvent, Unit>()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName(
+                    MethodDescriptor.generateFullMethodName(
+                        "android.emulation.control.EmulatorController",
+                        "sendTouch",
+                    ),
+                )
+                .setRequestMarshaller(EmulatorTouchEventMarshaller)
+                .setResponseMarshaller(EmulatorEmptyMarshaller)
+                .build()
+        private val SEND_KEY_METHOD: MethodDescriptor<EmulatorKeyEvent, Unit> =
+            MethodDescriptor.newBuilder<EmulatorKeyEvent, Unit>()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName(
+                    MethodDescriptor.generateFullMethodName(
+                        "android.emulation.control.EmulatorController",
+                        "sendKey",
+                    ),
+                )
+                .setRequestMarshaller(EmulatorKeyEventMarshaller)
+                .setResponseMarshaller(EmulatorEmptyMarshaller)
+                .build()
+    }
+}
+
+private const val KEY_EVENT_KEYDOWN = 0
+private const val KEY_EVENT_KEYUP = 1
+private const val KEY_EVENT_KEYPRESS = 2
+
+internal data class EmulatorImageFormat(val maxSize: Int, val mmapHandle: String? = null)
+internal data class EmulatorImage(
+    val width: Int,
+    val height: Int,
+    val pixels: ByteArray,
+    val seq: Long = 0,
+    val timestampUs: Long = 0,
+)
+internal data class EmulatorTouch(val x: Int, val y: Int, val pressure: Int)
+internal data class EmulatorTouchEvent(val touches: List<EmulatorTouch>, val display: Int = 0)
+internal data class EmulatorKeyEvent(val eventType: Int = KEY_EVENT_KEYDOWN, val key: String = "", val text: String = "")
+
+private object EmulatorImageFormatMarshaller : MethodDescriptor.Marshaller<EmulatorImageFormat> {
+    override fun stream(value: EmulatorImageFormat): InputStream {
+        return ByteArrayInputStream(EmulatorGrpcProto.imageFormat(value.maxSize.coerceAtLeast(1), value.mmapHandle))
+    }
+
+    override fun parse(stream: InputStream): EmulatorImageFormat {
+        stream.readAllBytes()
+        return EmulatorImageFormat(0)
+    }
+}
+
+private object EmulatorImageMarshaller : MethodDescriptor.Marshaller<EmulatorImage> {
+    override fun stream(value: EmulatorImage): InputStream {
+        return ByteArrayInputStream(ByteArray(0))
+    }
+
+    override fun parse(stream: InputStream): EmulatorImage {
+        return EmulatorGrpcProto.parseImage(stream.readAllBytes())
+    }
+}
+
+private object EmulatorTouchEventMarshaller : MethodDescriptor.Marshaller<EmulatorTouchEvent> {
+    override fun stream(value: EmulatorTouchEvent): InputStream {
+        return ByteArrayInputStream(EmulatorGrpcProto.touchEvent(value))
+    }
+
+    override fun parse(stream: InputStream): EmulatorTouchEvent {
+        stream.readAllBytes()
+        return EmulatorTouchEvent(emptyList())
+    }
+}
+
+private object EmulatorKeyEventMarshaller : MethodDescriptor.Marshaller<EmulatorKeyEvent> {
+    override fun stream(value: EmulatorKeyEvent): InputStream {
+        return ByteArrayInputStream(EmulatorGrpcProto.keyEvent(value))
+    }
+
+    override fun parse(stream: InputStream): EmulatorKeyEvent {
+        stream.readAllBytes()
+        return EmulatorKeyEvent()
+    }
+}
+
+private object EmulatorEmptyMarshaller : MethodDescriptor.Marshaller<Unit> {
+    override fun stream(value: Unit): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun parse(stream: InputStream) {
+        stream.readAllBytes()
+    }
+}
+
+internal object EmulatorGrpcProto {
+    fun imageFormat(maxSize: Int, mmapHandle: String? = null): ByteArray {
+        val writer = ProtoWriter()
+        writer.varint(1, 2) // ImageFormat.RGB888
+        writer.varint(3, maxSize.toLong())
+        writer.varint(4, maxSize.toLong())
+        if (!mmapHandle.isNullOrBlank()) {
+            val transport = ProtoWriter()
+            transport.varint(1, 1) // ImageTransport.MMAP
+            transport.string(2, mmapHandle)
+            writer.bytes(6, transport.toByteArray())
+        }
+        return writer.toByteArray()
+    }
+
+    fun touchEvent(event: EmulatorTouchEvent): ByteArray {
+        val writer = ProtoWriter()
+        event.touches.forEach { touch ->
+            val touchWriter = ProtoWriter()
+            touchWriter.varint(1, touch.x.coerceAtLeast(0).toLong())
+            touchWriter.varint(2, touch.y.coerceAtLeast(0).toLong())
+            touchWriter.varint(3, 0)
+            touchWriter.varint(4, touch.pressure.coerceAtLeast(0).toLong())
+            touchWriter.varint(7, 1) // NEVER_EXPIRE; Andy sends explicit pressure=0 on release.
+            writer.bytes(1, touchWriter.toByteArray())
+        }
+        if (event.display != 0) writer.varint(2, event.display.toLong())
+        return writer.toByteArray()
+    }
+
+    // KeyboardEvent { codeType=1(Usb, default), eventType=2, keyCode=3, key=4, text=5 }
+    fun keyEvent(event: EmulatorKeyEvent): ByteArray {
+        val writer = ProtoWriter()
+        if (event.eventType != 0) writer.varint(2, event.eventType.toLong())
+        if (event.key.isNotEmpty()) writer.string(4, event.key)
+        if (event.text.isNotEmpty()) writer.string(5, event.text)
+        return writer.toByteArray()
+    }
+
+    fun parseImage(bytes: ByteArray): EmulatorImage {
+        val reader = ProtoReader(bytes)
+        var width = 0
+        var height = 0
+        var deprecatedWidth = 0
+        var deprecatedHeight = 0
+        var image = ByteArray(0)
+        var seq = 0L
+        var timestampUs = 0L
+        while (!reader.isAtEnd()) {
+            when (val tag = reader.readTag()) {
+                10 -> {
+                    val format = parseImageFormat(reader.readBytes())
+                    width = format.first
+                    height = format.second
+                }
+                16 -> deprecatedWidth = reader.readVarint().toInt()
+                24 -> deprecatedHeight = reader.readVarint().toInt()
+                34 -> image = reader.readBytes()
+                40 -> seq = reader.readVarint()
+                48 -> timestampUs = reader.readVarint()
+                else -> reader.skip(tag)
+            }
+        }
+        return EmulatorImage(
+            width = width.takeIf { it > 0 } ?: deprecatedWidth,
+            height = height.takeIf { it > 0 } ?: deprecatedHeight,
+            pixels = image,
+            seq = seq,
+            timestampUs = timestampUs,
+        )
+    }
+
+    private fun parseImageFormat(bytes: ByteArray): Pair<Int, Int> {
+        val reader = ProtoReader(bytes)
+        var width = 0
+        var height = 0
+        while (!reader.isAtEnd()) {
+            when (val tag = reader.readTag()) {
+                8 -> reader.readVarint()
+                24 -> width = reader.readVarint().toInt()
+                32 -> height = reader.readVarint().toInt()
+                else -> reader.skip(tag)
+            }
+        }
+        return width to height
+    }
+
+    class ProtoWriter {
+        private val output = ByteArrayOutputStream()
+
+        fun varint(field: Int, value: Long) {
+            tag(field, 0)
+            writeVarint(value)
+        }
+
+        fun bytes(field: Int, bytes: ByteArray) {
+            tag(field, 2)
+            writeVarint(bytes.size.toLong())
+            output.write(bytes)
+        }
+
+        fun string(field: Int, value: String) {
+            bytes(field, value.encodeToByteArray())
+        }
+
+        fun toByteArray(): ByteArray = output.toByteArray()
+
+        private fun tag(field: Int, wireType: Int) {
+            writeVarint(((field shl 3) or wireType).toLong())
+        }
+
+        private fun writeVarint(value: Long) {
+            var remaining = value
+            while ((remaining and 0x7f.inv().toLong()) != 0L) {
+                output.write(((remaining and 0x7f) or 0x80).toInt())
+                remaining = remaining ushr 7
+            }
+            output.write(remaining.toInt())
+        }
+    }
+
+    private class ProtoReader(private val bytes: ByteArray) {
+        private var offset = 0
+
+        fun isAtEnd(): Boolean = offset >= bytes.size
+
+        fun readTag(): Int = readVarint().toInt()
+
+        fun readVarint(): Long {
+            var shift = 0
+            var result = 0L
+            while (shift < 64 && offset < bytes.size) {
+                val b = bytes[offset++].toInt() and 0xff
+                result = result or ((b and 0x7f).toLong() shl shift)
+                if ((b and 0x80) == 0) return result
+                shift += 7
+            }
+            return result
+        }
+
+        fun readBytes(): ByteArray {
+            val size = readVarint().toInt().coerceAtLeast(0)
+            val end = (offset + size).coerceAtMost(bytes.size)
+            return bytes.copyOfRange(offset, end).also { offset = end }
+        }
+
+        fun skip(tag: Int) {
+            when (tag and 0x7) {
+                0 -> readVarint()
+                1 -> offset = (offset + 8).coerceAtMost(bytes.size)
+                2 -> {
+                    val size = readVarint().toInt().coerceAtLeast(0)
+                    offset = (offset + size).coerceAtMost(bytes.size)
+                }
+                5 -> offset = (offset + 4).coerceAtMost(bytes.size)
+                else -> offset = bytes.size
+            }
+        }
+    }
+}
+
+private fun String.isEmulatorSerial(): Boolean = startsWith("emulator-")
+
+private fun String.emulatorConsolePort(): Int? = removePrefix("emulator-").toIntOrNull()
+
+private fun readEmulatorGrpcToken(grpcPort: Int): String? {
+    return emulatorGrpcDiscoveryFiles()
+        .asSequence()
+        .mapNotNull { file -> loadEmulatorGrpcDiscovery(file) }
+        .firstOrNull { discovery -> discovery.port == grpcPort }
+        ?.token
+}
+
+private data class EmulatorGrpcDiscovery(val port: Int?, val token: String?)
+
+private fun emulatorGrpcDiscoveryFiles(): List<File> {
+    val home = File(System.getProperty("user.home"))
+    val tmpDir = System.getenv("TMPDIR")?.takeIf { it.isNotBlank() }?.let(::File)
+    val xdgRuntime = System.getenv("XDG_RUNTIME_DIR")?.takeIf { it.isNotBlank() }?.let(::File)
+    val roots = listOfNotNull(
+        File(home, "Library/Caches/TemporaryItems/avd/running"),
+        tmpDir?.resolve("avd/running"),
+        xdgRuntime?.resolve("avd/running"),
+        File("/tmp/android-${System.getProperty("user.name")}/avd/running"),
+    ).distinctBy { it.absolutePath }
+    return roots.flatMap { root ->
+        root.listFiles { file -> file.isFile && file.name.startsWith("pid_") && file.name.endsWith(".ini") }
+            ?.toList()
+            .orEmpty()
+    }
+}
+
+private fun loadEmulatorGrpcDiscovery(file: File): EmulatorGrpcDiscovery? {
+    val entries = runCatching {
+        file.readLines()
+            .mapNotNull { line ->
+                val trimmed = line.trim()
+                if (trimmed.isBlank() || trimmed.startsWith("#") || "=" !in trimmed) {
+                    null
+                } else {
+                    trimmed.substringBefore("=").trim() to trimmed.substringAfter("=").trim()
+                }
+            }
+            .toMap()
+    }.getOrNull() ?: return null
+    val port = entries["grpc.port"]?.toIntOrNull()
+    val token = entries["grpc.token"]?.takeIf { it.isNotBlank() }
+    return EmulatorGrpcDiscovery(port = port, token = token)
 }
 
 private object ScrcpyControlMessage {
@@ -2379,6 +3203,8 @@ class DesktopMetricsService(
     private val devices: DesktopDeviceService,
 ) : MetricsService {
     override fun stream(serial: String, packageName: String?): Flow<PerformanceSample> = flow {
+        var lastNetworkTotals: Pair<Long, Long>? = null
+        var lastNetworkAtMillis: Long? = null
         while (true) {
             val cpu = devices.shell(serial, listOf("dumpsys", "cpuinfo")).stdout
             val processRows = devices.shell(serial, listOf("top", "-b", "-n", "1", "-o", "PID,%CPU,RES,ARGS", "-m", "80")).stdout
@@ -2386,21 +3212,42 @@ class DesktopMetricsService(
             val processes = AndroidParsers.parseProcessMetrics(processRows)
             val mem = packageName?.let { devices.shell(serial, listOf("dumpsys", "meminfo", it)).stdout }
             val battery = devices.shell(serial, listOf("dumpsys", "battery")).stdout
+            val netDev = devices.shell(serial, listOf("cat", "/proc/net/dev")).stdout
             val focusedPackage = packageName
                 ?: AndroidParsers.parseFocusedPackage(devices.shell(serial, listOf("dumpsys", "window", "windows")).stdout)
                 ?: AndroidParsers.parseFocusedPackage(devices.shell(serial, listOf("dumpsys", "activity", "activities")).stdout)
             val frameTimes = focusedPackage?.let {
                 AndroidParsers.parseFrameStats(devices.shell(serial, listOf("dumpsys", "gfxinfo", it, "framestats")).stdout)
             }.orEmpty()
+            val now = System.currentTimeMillis()
+            val networkTotals = AndroidParsers.parseNetworkTotals(netDev)
+            var networkRxKbps: Float? = null
+            var networkTxKbps: Float? = null
+            val previousTotals = lastNetworkTotals
+            val previousAtMillis = lastNetworkAtMillis
+            if (networkTotals != null && previousTotals != null && previousAtMillis != null) {
+                val elapsedSeconds = (now - previousAtMillis) / 1000f
+                if (elapsedSeconds > 0f) {
+                    networkRxKbps = ((networkTotals.first - previousTotals.first).coerceAtLeast(0) / 1024f) / elapsedSeconds
+                    networkTxKbps = ((networkTotals.second - previousTotals.second).coerceAtLeast(0) / 1024f) / elapsedSeconds
+                }
+            }
+            if (networkTotals != null) {
+                lastNetworkTotals = networkTotals
+                lastNetworkAtMillis = now
+            }
             emit(
                 PerformanceSample(
-                    timestampMillis = System.currentTimeMillis(),
+                    timestampMillis = now,
                     cpuPercent = Regex("""(\d+(?:\.\d+)?)%""").find(cpu)?.groupValues?.getOrNull(1)?.toFloatOrNull(),
                     memoryMb = (mem?.let { Regex("""TOTAL\s+(\d+)""").find(it)?.groupValues?.getOrNull(1)?.toFloatOrNull()?.div(1024f) }
                         ?: processes.sumOf { it.memoryMb?.toDouble() ?: 0.0 }.toFloat().takeIf { it > 0f }),
-                    fps = frameTimes.takeLast(60).count { it.millis <= 16.6f }.takeIf { frameTimes.isNotEmpty() }?.toFloat(),
+                    fps = frameTimes.takeLast(30).mapNotNull { it.vsyncGapMillis }.takeIf { it.isNotEmpty() }
+                        ?.let { gaps -> 1000f / (gaps.sum() / gaps.size) },
                     batteryPercent = AndroidParsers.parseBatteryPercent(battery),
                     thermalStatus = null,
+                    networkRxKbps = networkRxKbps,
+                    networkTxKbps = networkTxKbps,
                     processes = processes,
                     frameRenderTimes = frameTimes,
                 ),
@@ -2441,6 +3288,7 @@ class DesktopWorkspaceStore : WorkspaceStore {
             appsListPaneWidth = props.getProperty("appsListPaneWidth")?.toFloatOrNull() ?: 520f,
             appsDetailsPaneHeight = props.getProperty("appsDetailsPaneHeight")?.toFloatOrNull() ?: 350f,
             performanceProcessesPaneWidth = props.getProperty("performanceProcessesPaneWidth")?.toFloatOrNull() ?: 760f,
+            performanceLivePaneWidth = props.getProperty("performanceLivePaneWidth")?.toFloatOrNull() ?: 320f,
             designDevicePaneWidth = props.getProperty("designDevicePaneWidth")?.toFloatOrNull() ?: 520f,
             accessibilityTreePaneWidth = props.getProperty("accessibilityTreePaneWidth")?.toFloatOrNull() ?: 760f,
             hostFileRoots = props.getProperty("hostFileRoots").orEmpty().lines().filter { it.isNotBlank() },
@@ -2479,6 +3327,7 @@ class DesktopWorkspaceStore : WorkspaceStore {
             setProperty("appsListPaneWidth", state.appsListPaneWidth.toString())
             setProperty("appsDetailsPaneHeight", state.appsDetailsPaneHeight.toString())
             setProperty("performanceProcessesPaneWidth", state.performanceProcessesPaneWidth.toString())
+            setProperty("performanceLivePaneWidth", state.performanceLivePaneWidth.toString())
             setProperty("designDevicePaneWidth", state.designDevicePaneWidth.toString())
             setProperty("accessibilityTreePaneWidth", state.accessibilityTreePaneWidth.toString())
             setProperty("hostFileRoots", state.hostFileRoots.joinToString("\n"))

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
@@ -1032,13 +1032,14 @@ class DesktopMirrorEngine(
         }
     }
 
-    // The emulator gRPC streamScreenshot RGB888 payload is top-down (top-left origin),
-    // matching how Android Studio renders it, so rows are copied in natural order.
+    // The emulator gRPC streamScreenshot RGB888 payload is bottom-up, so flip rows
+    // while converting to the top-down ARGB layout expected by Swing/Compose.
     private fun rgbToArgb(width: Int, height: Int, rgb: ByteBuffer): IntArray {
         val pixels = IntArray(width * height)
         val row = ByteArray(width * EMULATOR_IMAGE_BYTES_PER_PIXEL)
         for (y in 0 until height) {
-            rgb.position(y * row.size)
+            val sourceY = height - 1 - y
+            rgb.position(sourceY * row.size)
             rgb.get(row, 0, row.size)
             var source = 0
             var destination = y * width

--- a/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
@@ -8,6 +8,7 @@ import app.andy.model.VirtualDeviceType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AndroidParsersTest {
@@ -249,5 +250,48 @@ class AndroidParsersTest {
 
         assertEquals(1, frames.size)
         assertEquals(6.94415f, frames[0].millis)
+    }
+
+    @Test
+    fun parsesFrameStatsVsyncGapForFpsCalculation() {
+        val output = """
+            Flags,IntendedVsync,Vsync,OldestInputEvent,NewestInputEvent,HandleInputStart,AnimationStart,PerformTraversalsStart,DrawStart,SyncQueued,SyncStart,IssueDrawCommandsStart,SwapBuffers,FrameCompleted,DequeueBufferDuration,QueueBufferDuration,GpuCompleted
+            0,1000000000,1000000000,0,0,0,0,0,0,0,0,0,0,1010000000,0,0,0
+            0,1016666666,1016666666,0,0,0,0,0,0,0,0,0,0,1030000000,0,0,0
+            0,1033333333,1033333333,0,0,0,0,0,0,0,0,0,0,1045000000,0,0,0
+        """.trimIndent()
+
+        val frames = AndroidParsers.parseFrameStats(output)
+
+        assertEquals(3, frames.size)
+        assertNull(frames[0].vsyncGapMillis)
+        assertEquals(16.666666f, frames[1].vsyncGapMillis)
+        assertEquals(16.666667f, frames[2].vsyncGapMillis)
+        val fps = frames.mapNotNull { it.vsyncGapMillis }.let { gaps -> 1000f / (gaps.sum() / gaps.size) }
+        assertTrue(fps in 59f..61f)
+    }
+
+    @Test
+    fun parsesNetworkTotalsExcludingLoopback() {
+        val output = """
+            Inter-|   Receive                                                |  Transmit
+             face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+                lo:  140223    2534    0    0    0     0          0         0   140223    2534    0    0    0     0       0          0
+              eth0:   83535     364    0    0    0     0          0         0    43458     362    0    0    0     0       0          0
+             wlan0:  937773    3948    0    0    0     0          0         0   510544    3000    0    0    0     0       0          0
+        """.trimIndent()
+
+        val totals = AndroidParsers.parseNetworkTotals(output)
+
+        assertNotNull(totals)
+        assertEquals(83535L + 937773L, totals!!.first)
+        assertEquals(43458L + 510544L, totals.second)
+    }
+
+    @Test
+    fun parsesNetworkTotalsReturnsNullWhenNoInterfaces() {
+        val totals = AndroidParsers.parseNetworkTotals("cat: /proc/net/dev: Permission denied")
+
+        assertEquals(null, totals)
     }
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopBugServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopBugServiceTest.kt
@@ -9,7 +9,9 @@ import app.andy.model.DeviceConnectionState
 import app.andy.model.DeviceKind
 import app.andy.model.LogcatEntry
 import app.andy.model.LogLevel
+import app.andy.model.SdkDiscovery
 import app.andy.service.CommandResult
+import app.andy.service.DeviceService
 import app.andy.service.LogcatFilter
 import app.andy.service.LogcatService
 import app.andy.service.MirrorEngine
@@ -98,6 +100,22 @@ class DesktopBugServiceTest {
         assertEquals(report.artifacts.single().sizeBytes, decoded.artifacts.single().sizeBytes)
         assertEquals(report.videoFrameTimestampsMillis, decoded.videoFrameTimestampsMillis)
     }
+
+    @Test
+    fun captureRecordsForegroundScreen() = runBlocking {
+        val home = Files.createTempDirectory("andy-bugs-screen-test").toFile()
+        val service = DesktopBugService(FakeMirrorEngine(), FakeLogcatService(), home, FakeForegroundDeviceService())
+
+        service.startCapture("emulator-5554", null)
+        delay(150)
+
+        val report = service.saveBug(BugCaptureDraft("Screen changed"), null)
+
+        val screen = report.actions.firstOrNull { it.kind == "screen" }
+        assertNotNull(screen)
+        assertEquals("Screen MainActivity", screen.label)
+        assertTrue(screen.detail?.contains("com.example.app/com.example.app.MainActivity") == true)
+    }
 }
 
 private class FakeMirrorEngine : MirrorEngine {
@@ -114,4 +132,21 @@ private class FakeLogcatService : LogcatService {
     override fun stream(serial: String, filter: LogcatFilter): Flow<List<LogcatEntry>> = batches
     override suspend fun snapshot(serial: String, filter: LogcatFilter, limit: Int): List<LogcatEntry> = emptyList()
     override suspend fun clear(serial: String) = Unit
+}
+
+private class FakeForegroundDeviceService : DeviceService {
+    override suspend fun discoverSdk(): SdkDiscovery = SdkDiscovery(null, null, null, null, null)
+    override suspend fun listDevices(): List<AndroidDevice> = emptyList()
+    override suspend fun shell(serial: String, command: List<String>): CommandResult {
+        return when (command) {
+            listOf("dumpsys", "activity", "activities") -> CommandResult.success(
+                "topResumedActivity=ActivityRecord{abc u0 com.example.app/.MainActivity t1}\n" +
+                    "    #0: HomeFragment{abc}\n",
+            )
+            listOf("dumpsys", "window", "windows") -> CommandResult.success(
+                "mCurrentFocus=Window{abc u0 com.example.app/.MainActivity}\n",
+            )
+            else -> CommandResult.success()
+        }
+    }
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopMirrorEngineDeviceSmokeTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopMirrorEngineDeviceSmokeTest.kt
@@ -2,6 +2,7 @@ package app.andy.desktop.service
 
 import app.andy.service.MirrorFrame
 import app.andy.service.MirrorInput
+import app.andy.service.MirrorVideoConfig
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -26,7 +27,11 @@ class DesktopMirrorEngineDeviceSmokeTest {
         }
             ?: error("No online Android device connected")
 
-        val result = services.mirror.connect(device.serial)
+        val maxSize = System.getenv("ANDY_DEVICE_SMOKE_MAX_SIZE")?.toIntOrNull()
+        val result = services.mirror.connect(
+            device.serial,
+            maxSize?.let { MirrorVideoConfig(maxSize = it) } ?: MirrorVideoConfig(),
+        )
         assertTrue(result.isSuccess, result.stderr.ifBlank { result.stdout })
 
         val statuses = mutableListOf<String>()

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopMirrorFixVerification.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopMirrorFixVerification.kt
@@ -1,0 +1,88 @@
+package app.andy.desktop.service
+
+import app.andy.service.MirrorInput
+import app.andy.service.MirrorTouchAction
+import app.andy.service.MirrorVideoConfig
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the Stop/tap/fling fixes against a live emulator. Gated behind
+ * ANDY_DEVICE_SMOKE=1 so it never runs in CI.
+ */
+class DesktopMirrorFixVerification {
+    @Test
+    fun disconnectClearsFrameAndCompletedGestureLeavesTapsWorking() = runBlocking {
+        if (System.getenv("ANDY_DEVICE_SMOKE") != "1") return@runBlocking
+        val services = createDesktopServices()
+        val serial = System.getenv("ANDY_DEVICE_SERIAL")?.takeIf { it.isNotBlank() }
+            ?: services.devices.listDevices().first { it.state.name == "Online" }.serial
+        check(services.mirror.connect(serial, MirrorVideoConfig(maxSize = 720)).isSuccess)
+
+        val wm = services.devices.shell(serial, listOf("wm", "size")).stdout
+        val (dispW, dispH) = Regex("""(\d+)x(\d+)""").find(wm)!!.destructured.let { it.component1().toInt() to it.component2().toInt() }
+        val frameW = (720.0 * dispW / dispH).toInt(); val frameH = 720
+        fun fx(x: Int) = x * frameW / dispW
+        fun fy(y: Int) = y * frameH / dispH
+
+        suspend fun down(x: Int, y: Int) = services.mirror.sendInput(MirrorInput.Touch(MirrorTouchAction.Down, x, y))
+        suspend fun move(x: Int, y: Int) = services.mirror.sendInput(MirrorInput.Touch(MirrorTouchAction.Move, x, y))
+        suspend fun up(x: Int, y: Int) = services.mirror.sendInput(MirrorInput.Touch(MirrorTouchAction.Up, x, y))
+        suspend fun screen(): String {
+            val out = services.devices.shell(serial, listOf("dumpsys", "activity", "activities")).stdout
+            val resumed = Regex("""mResumedActivity.*\{[^}]*\s(\S+/\S+)""").find(out)?.groupValues?.getOrNull(1)
+            val top = Regex("""topResumedActivity=\S+\{[^}]*\s(\S+/\S+)""").find(out)?.groupValues?.getOrNull(1)
+            return resumed ?: top ?: "unknown"
+        }
+        suspend fun openSettings() {
+            services.devices.shell(serial, listOf("am", "force-stop", "com.android.settings"))
+            services.devices.shell(serial, listOf("am", "start", "-a", "android.settings.SETTINGS"))
+            delay(2500)
+        }
+        suspend fun rowCenter(): Pair<Int, Int> {
+            services.devices.shell(serial, listOf("uiautomator", "dump"))
+            val xml = services.devices.shell(serial, listOf("cat", "/sdcard/window_dump.xml")).stdout
+            val (l, t, r, b) = Regex("""clickable="true"[^>]*bounds="\[(\d+),(\d+)]\[(\d+),(\d+)]"""").findAll(xml)
+                .map { it.destructured }
+                .first { (l, t, _, b) -> (b.toInt() - t.toInt()) > 60 && (t.toInt() + b.toInt()) / 2 in (dispH / 5)..(dispH * 4 / 5) }
+            return (l.toInt() + r.toInt()) / 2 to (t.toInt() + b.toInt()) / 2
+        }
+        suspend fun tapNavigates(dx: Int, dy: Int): Boolean {
+            openSettings()
+            val home = screen()
+            down(fx(dx), fy(dy)); up(fx(dx), fy(dy))
+            delay(1500)
+            val after = screen()
+            if (after != home) services.devices.shell(serial, listOf("input", "keyevent", "4"))
+            return after != home
+        }
+
+        try {
+            openSettings()
+            val (dx, dy) = rowCenter()
+
+            // A completed drag gesture that ends off the target (like a fling whose Up
+            // now always fires, clamped) must NOT wedge later taps.
+            openSettings()
+            down(fx(dispW / 2), fy((dispH * 0.7f).toInt()))
+            for (i in 1..8) { move(fx(dispW / 2), fy((dispH * (0.7f - i * 0.06f)).toInt())); delay(16) }
+            up(fx(dispW / 2), fy((dispH * 0.2f).toInt()))
+            delay(600)
+            val tapWorksAfterFling = tapNavigates(dx, dy)
+            println("FIXVERIFY tap works after completed fling = $tapWorksAfterFling")
+            assertTrue(tapWorksAfterFling, "tap should work after a fully-released fling")
+
+            // Frozen-frame fix: disconnect resets the stream to the 1x1 sentinel.
+            services.mirror.disconnect()
+            val cleared = withTimeout(3_000) { services.mirror.frames.first { it.width <= 1 && it.height <= 1 } }
+            println("FIXVERIFY frame after disconnect = ${cleared.width}x${cleared.height}")
+            assertTrue(cleared.width <= 1 && cleared.height <= 1, "disconnect should clear the frame")
+        } finally {
+            services.mirror.disconnect()
+        }
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopMirrorThroughputProbe.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopMirrorThroughputProbe.kt
@@ -1,0 +1,169 @@
+package app.andy.desktop.service
+
+import app.andy.service.MirrorFrame
+import app.andy.service.MirrorInput
+import app.andy.service.MirrorVideoConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.test.Test
+
+/**
+ * Measures live-frame throughput while the device screen is continuously animating.
+ * The emulator gRPC streamScreenshot stream is change-driven, so a static screen
+ * legitimately yields near-zero fps; this probe forces sustained motion (fling
+ * scrolling in Settings) and reports the peak rolling fps the pipeline delivers.
+ *
+ * Gated behind ANDY_DEVICE_SMOKE=1 so it never runs in CI.
+ */
+class DesktopMirrorThroughputProbe {
+    @Test
+    fun measuresThroughputUnderMotion() = runBlocking {
+        if (System.getenv("ANDY_DEVICE_SMOKE") != "1") return@runBlocking
+        val services = createDesktopServices()
+        val serial = System.getenv("ANDY_DEVICE_SERIAL")?.takeIf { it.isNotBlank() }
+            ?: services.devices.listDevices().first { it.state.name == "Online" }.serial
+
+        val connect = services.mirror.connect(serial, MirrorVideoConfig(maxSize = 720))
+        check(connect.isSuccess) { connect.stderr.ifBlank { connect.stdout } }
+        try {
+            // Foreground a long, scrollable surface.
+            services.devices.shell(serial, listOf("am", "start", "-a", "android.settings.SETTINGS"))
+            var last: MirrorFrame = withTimeout(12_000) {
+                services.mirror.frames.first { it.width > 1 && it.height > 1 && it.frameNumber > 0 }
+            }
+
+            // Device-side continuous fling scrolling — guaranteed to animate regardless of input path.
+            val motion = launch(Dispatchers.IO) {
+                var down = true
+                while (isActive) {
+                    val (y1, y2) = if (down) 1600 to 400 else 400 to 1600
+                    services.devices.shell(serial, listOf("input", "swipe", "540", y1.toString(), "540", y2.toString(), "120"))
+                    down = !down
+                }
+            }
+
+            var frames = 0L
+            var peakRollingFps = 0f
+            val start = System.nanoTime()
+            val windowStart = longArrayOf(System.nanoTime())
+            var windowFrames = 0L
+            try {
+                val deadline = System.nanoTime() + 6_000_000_000L
+                while (System.nanoTime() < deadline) {
+                    val next = withTimeout(3_000) {
+                        services.mirror.frames.first { it.frameNumber > last.frameNumber }
+                    }
+                    frames += next.frameNumber - last.frameNumber
+                    last = next
+                    next.decodedFps?.let { peakRollingFps = maxOf(peakRollingFps, it) }
+                    windowFrames++
+                    val now = System.nanoTime()
+                    if (now - windowStart[0] >= 1_000_000_000L) {
+                        val fps = windowFrames * 1_000_000_000f / (now - windowStart[0])
+                        peakRollingFps = maxOf(peakRollingFps, fps)
+                        windowStart[0] = now
+                        windowFrames = 0
+                    }
+                }
+            } finally {
+                motion.cancel()
+            }
+            val elapsed = (System.nanoTime() - start) / 1_000_000_000.0
+            val avgFps = frames / elapsed
+            writePng(last, File("build/reports/andy-mirror-smoke/motion-frame.png"))
+            println("THROUGHPUT avgFps=%.1f peakRollingFps=%.1f totalFrames=%d elapsed=%.1fs".format(avgFps, peakRollingFps, frames, elapsed))
+        } finally {
+            services.mirror.disconnect()
+        }
+    }
+
+    @Test
+    fun grpcTouchInputChangesTheScreen() = runBlocking {
+        if (System.getenv("ANDY_DEVICE_SMOKE") != "1") return@runBlocking
+        val services = createDesktopServices()
+        val serial = System.getenv("ANDY_DEVICE_SERIAL")?.takeIf { it.isNotBlank() }
+            ?: services.devices.listDevices().first { it.state.name == "Online" }.serial
+        check(services.mirror.connect(serial, MirrorVideoConfig(maxSize = 720)).isSuccess)
+        try {
+            services.devices.shell(serial, listOf("am", "start", "-a", "android.settings.SETTINGS"))
+            delay(1500)
+            val before = withTimeout(12_000) {
+                services.mirror.frames.first { it.width > 1 && it.height > 1 && it.frameNumber > 0 }
+            }
+            val beforeSig = signature(before)
+            // Inject a scroll purely through the app's gRPC input path.
+            val h = before.height
+            services.mirror.sendInput(MirrorInput.Swipe(360, (h * 0.8f).toInt(), 360, (h * 0.2f).toInt(), 150))
+            val changed = withTimeout(4_000) {
+                services.mirror.frames.first { it.frameNumber > before.frameNumber && signature(it) != beforeSig }
+            }
+            writePng(changed, File("build/reports/andy-mirror-smoke/after-grpc-input.png"))
+            println("GRPC-INPUT screen changed after gRPC swipe: beforeSig=$beforeSig afterSig=${signature(changed)}")
+        } finally {
+            services.mirror.disconnect()
+        }
+    }
+
+    @Test
+    fun keyboardTypesIntoFocusedField() = runBlocking {
+        if (System.getenv("ANDY_DEVICE_SMOKE") != "1") return@runBlocking
+        val services = createDesktopServices()
+        val serial = System.getenv("ANDY_DEVICE_SERIAL")?.takeIf { it.isNotBlank() }
+            ?: services.devices.listDevices().first { it.state.name == "Online" }.serial
+        check(services.mirror.connect(serial, MirrorVideoConfig(maxSize = 720)).isSuccess)
+        try {
+            // This activity opens with its search EditText focused and the soft keyboard up.
+            services.devices.shell(serial, listOf("am", "start", "-a", "android.settings.APP_SEARCH_SETTINGS"))
+            delay(2500)
+            withTimeout(12_000) {
+                services.mirror.frames.first { it.width > 1 && it.height > 1 && it.frameNumber > 0 }
+            }
+            writePng(latest(services), File("build/reports/andy-mirror-smoke/kbd-after-tap.png"))
+
+            val text = "bluetooth"
+            val start = System.nanoTime()
+            for (ch in text) services.mirror.sendInput(MirrorInput.Text(ch.toString()))
+            val typeMs = (System.nanoTime() - start) / 1_000_000
+            delay(1200)
+            writePng(latest(services), File("build/reports/andy-mirror-smoke/kbd-after-type.png"))
+            // Backspace one character via the named-key path.
+            services.mirror.sendInput(MirrorInput.Key(67))
+            delay(800)
+            writePng(latest(services), File("build/reports/andy-mirror-smoke/kbd-after-backspace.png"))
+            println("KEYBOARD typed '${text}' (${text.length} chars) in ${typeMs}ms")
+        } finally {
+            services.mirror.disconnect()
+        }
+    }
+
+    private suspend fun latest(services: app.andy.service.AndyServices): MirrorFrame =
+        withTimeout(4_000) { services.mirror.frames.first { it.width > 1 && it.height > 1 } }
+
+    // Cheap content fingerprint from sampled pixels; enough to detect a scroll.
+    private fun signature(frame: MirrorFrame): Int {
+        var acc = 0
+        val step = (frame.argb.size / 512).coerceAtLeast(1)
+        var i = 0
+        while (i < frame.argb.size) {
+            acc = acc * 31 + frame.argb[i]
+            i += step
+        }
+        return acc
+    }
+
+    private fun writePng(frame: MirrorFrame, output: File) {
+        output.parentFile.mkdirs()
+        val image = BufferedImage(frame.width, frame.height, BufferedImage.TYPE_INT_ARGB)
+        image.setRGB(0, 0, frame.width, frame.height, frame.argb, 0, frame.width)
+        ImageIO.write(image, "png", output)
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
@@ -12,13 +12,16 @@ import app.andy.model.AvdCreationConfig
 import app.andy.model.VirtualDeviceType
 import kotlinx.coroutines.flow.filter
 import app.andy.service.LogcatFilter
+import app.andy.service.MirrorFrame
 import app.andy.service.MirrorInput
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -41,6 +44,91 @@ class DesktopServicesMockDeviceTest {
         assertTrue(serverInfo.second)
         assertTrue(serverInfo.third > 100_000)
         assertEquals(File(testHome, ".andy/scrcpy/scrcpy-server").absolutePath, serverInfo.first)
+    }
+
+    @Test
+    fun emulatorLaunchCommandUsesStudioStyleHiddenWindowAndGrpc() {
+        val command = emulatorStudioStyleLaunchCommand(
+            emulator = "/sdk/emulator/emulator",
+            name = "Pixel_8_API_36",
+            extraArgs = listOf("-no-snapshot-load", "-no-snapshot-save"),
+            ports = EmulatorLaunchPorts(console = 5560, adb = 5561, grpc = 8560),
+        )
+
+        assertEquals("/sdk/emulator/emulator", command.first())
+        assertTrue(command.windowed(2).any { it == listOf("-avd", "Pixel_8_API_36") })
+        assertTrue("-qt-hide-window" in command)
+        assertTrue(command.windowed(2).any { it == listOf("-ports", "5560,5561") })
+        assertTrue(command.windowed(2).any { it == listOf("-grpc", "8560") })
+        assertTrue(command.windowed(2).any { it == listOf("-idle-grpc-timeout", "300") })
+        assertTrue(command.windowed(2).any { it == listOf("-gpu", "auto") })
+        assertTrue("-writable-system" in command)
+        assertTrue("-no-snapshot-load" in command)
+        assertTrue("-no-snapshot-save" in command)
+        assertFalse("-no-window" in command)
+        assertFalse("-grpc-use-token" in command)
+        assertFalse("swiftshader_indirect" in command)
+    }
+
+    @Test
+    fun emulatorGrpcProtoRequestsRgbFramesAndParsesImage() {
+        assertContentEquals(
+            byteArrayOf(8, 2, 24, 0xd0.toByte(), 5, 32, 0xd0.toByte(), 5),
+            EmulatorGrpcProto.imageFormat(720),
+        )
+        val format = EmulatorGrpcProto.ProtoWriter().apply {
+            varint(1, 2)
+            varint(3, 2)
+            varint(4, 2)
+        }
+        val imageBytes = byteArrayOf(
+            0, 0, 255.toByte(),
+            255.toByte(), 255.toByte(), 255.toByte(),
+            255.toByte(), 0, 0,
+            0, 255.toByte(), 0,
+        )
+        val image = EmulatorGrpcProto.ProtoWriter().apply {
+            bytes(1, format.toByteArray())
+            bytes(4, imageBytes)
+            varint(5, 7)
+            varint(6, 123)
+        }
+
+        val parsed = EmulatorGrpcProto.parseImage(image.toByteArray())
+
+        assertEquals(2, parsed.width)
+        assertEquals(2, parsed.height)
+        assertEquals(7, parsed.seq)
+        assertEquals(123, parsed.timestampUs)
+        assertContentEquals(imageBytes, parsed.pixels)
+    }
+
+    @Test
+    fun emulatorGrpcTouchCoordinatesScaleFromMirrorFrameToDisplaySize() {
+        val frame = MirrorFrame(
+            width = 324,
+            height = 720,
+            argb = IntArray(324 * 720),
+            frameNumber = 1,
+        )
+
+        val middle = scaledEmulatorTouchPoint(
+            x = 162,
+            y = 360,
+            frame = frame,
+            displaySize = EmulatorDisplaySize(1080, 2400),
+        )
+        val clamped = scaledEmulatorTouchPoint(
+            x = 999,
+            y = 999,
+            frame = frame,
+            displaySize = EmulatorDisplaySize(1080, 2400),
+        )
+
+        assertEquals(540, middle.x)
+        assertEquals(1200, middle.y)
+        assertEquals(1076, clamped.x)
+        assertEquals(2396, clamped.y)
     }
 
     @Test
@@ -116,6 +204,7 @@ class DesktopServicesMockDeviceTest {
         assertEquals("Pixel_8_API_36", avds.single().name)
         assertEquals(36, avds.single().apiLevel)
         assertEquals(VirtualDeviceType.Phone, avds.single().deviceType)
+        assertTrue(avds.single().running)
         assertTrue(created.isSuccess)
         assertTrue(advancedCreated.isSuccess)
         assertTrue(installedImage.isSuccess)
@@ -137,6 +226,49 @@ class DesktopServicesMockDeviceTest {
         assertTrue(env.ran("avd", "snapshot", "delete", "manual"))
         assertTrue(env.ran("delete", "avd", "-n", "Pixel_8_API_36"))
         assertTrue(env.ran("-s", "emulator-5554", "emu", "kill"))
+    }
+
+    @Test
+    fun stopVirtualDeviceWaitsUntilEmulatorLeavesAdb() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+
+        val stopped = services.avd.stopVirtualDevice("Pixel_8_API_36")
+
+        assertTrue(stopped.isSuccess, stopped.stderr)
+        val killIndex = env.commands.indexOfFirst { it.takeLast(2) == listOf("emu", "kill") }
+        assertTrue(killIndex >= 0, "expected an emu kill to be issued")
+        val polledAfterKill = env.commands.drop(killIndex + 1).any { it.takeLast(2) == listOf("devices", "-l") }
+        assertTrue(polledAfterKill, "expected stop to poll `adb devices` until the emulator was gone")
+        assertTrue(services.devices.listDevices().none { it.serial == "emulator-5554" })
+    }
+
+    @Test
+    fun stoppedEmulatorOfflineAdbEntryIsNotListedAsConnectedDevice() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        env.keepStoppedEmulatorInAdbAsOffline = true
+        val services = env.services()
+
+        val stopped = services.avd.stopVirtualDevice("Pixel_8_API_36")
+        val devices = services.devices.listDevices()
+
+        assertTrue(stopped.isSuccess, stopped.stderr)
+        assertTrue(devices.none { it.serial == "emulator-5554" })
+        assertTrue(devices.any { it.serial == "R3CXB056ZZB" && it.state == DeviceConnectionState.Online })
+        assertTrue(devices.any { it.serial == "OFFLINE" && it.state == DeviceConnectionState.Offline })
+    }
+
+    @Test
+    fun staleAvdLockDoesNotMarkVirtualDeviceRunning() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        env.adbDevicesOutput = "List of devices attached\n"
+        env.hardwareQemuLockPath().mkdirs()
+        val services = env.services()
+
+        val avds = services.avd.listVirtualDevices()
+
+        assertEquals("Pixel_8_API_36", avds.single().name)
+        assertFalse(avds.single().running)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -34,6 +34,7 @@ internal class MockAndroidDeviceEnvironment {
     var chromeFlagsResult: CommandResult = CommandResult.success()
     var remountResult: CommandResult = CommandResult.success("remount succeeded")
     var persistedCaInstalled: Boolean = false
+    var keepStoppedEmulatorInAdbAsOffline: Boolean = false
 
     init {
         File(avdHome, "Pixel_8_API_36.avd").apply {
@@ -91,6 +92,10 @@ internal class MockAndroidDeviceEnvironment {
         return File(avdHome, "Pixel_8_API_36.avd/snapshots/$name")
     }
 
+    fun hardwareQemuLockPath(name: String = "Pixel_8_API_36"): File {
+        return File(avdHome, "$name.avd/hardware-qemu.ini.lock")
+    }
+
     private fun toolName(name: String, windowsExtension: String): String {
         val os = System.getProperty("os.name")
         return if (os.startsWith("Windows", ignoreCase = true)) "$name.$windowsExtension" else name
@@ -143,7 +148,16 @@ internal class MockAndroidDeviceEnvironment {
 
     private fun runEmu(serial: String, args: List<String>): CommandResult {
         return when (args) {
-            listOf("kill") -> CommandResult.success("OK")
+            listOf("kill") -> {
+                // Most kills remove the emulator from adb immediately; some leave a stale offline serial briefly.
+                adbDevicesOutput = adbDevicesOutput.lineSequence()
+                    .mapNotNull { line ->
+                        if (!line.trimStart().startsWith("$serial\t")) return@mapNotNull line
+                        if (keepStoppedEmulatorInAdbAsOffline) "$serial\toffline" else null
+                    }
+                    .joinToString("\n")
+                CommandResult.success("OK")
+            }
             listOf("avd", "snapshot", "list") -> CommandResult.success("default_boot\nmanual\n")
             listOf("avd", "snapshot", "save", "manual") -> CommandResult.success("OK")
             listOf("avd", "snapshot", "load", "manual") -> CommandResult.success("OK")


### PR DESCRIPTION
## Summary
- launch emulators with hidden Studio-style windows, dedicated port pairs, and local gRPC control
- add gRPC screenshot/input handling, keyboard forwarding, frozen-frame clearing, and richer mirror inspection controls
- expand bug reports with foreground screen/action context, searchable logcat text, network/fps metrics, and gated live-device smoke probes

## Tests
- git diff --check
- ./gradlew compileKotlinDesktop
- ./gradlew desktopTest