### PR TITLE
Improve Network proxy diagnostics

### DIFF
--- a/src/commonMain/kotlin/app/andy/App.kt
+++ b/src/commonMain/kotlin/app/andy/App.kt
@@ -692,6 +692,7 @@ private fun AndyShell(
     var sdk by remember { mutableStateOf(SdkDiscovery(null, null, null, null, null, listOf("SDK not scanned yet"))) }
     var selectedSerial by remember { mutableStateOf<String?>(null) }
     var workspaceState by remember { mutableStateOf(WorkspaceState()) }
+    var workspaceLoaded by remember { mutableStateOf(false) }
     var networkRulesVisible by remember { mutableStateOf(false) }
     var networkLiveVisible by remember { mutableStateOf(false) }
     var performanceLiveVisible by remember { mutableStateOf(false) }
@@ -777,6 +778,7 @@ private fun AndyShell(
         workspaceState = saved
         selectedSerial = saved.selectedDeviceSerial
         actionsConfig = services.actionConfig.load()
+        workspaceLoaded = true
         refreshDevices()
     }
 
@@ -802,6 +804,19 @@ private fun AndyShell(
         }
     }
 
+    LaunchedEffect(workspaceLoaded, workspaceState.proxyStartOnLaunch, workspaceState.proxyPort, workspaceState.proxyRules) {
+        if (!workspaceLoaded || !workspaceState.proxyStartOnLaunch) return@LaunchedEffect
+        val currentStatus = try {
+            withTimeout(200) { services.proxy.status.first() }
+        } catch (_: Exception) {
+            "Proxy stopped"
+        }
+        if (shouldAutoStartProxy(currentStatus, workspaceState.proxyPort)) {
+            services.proxy.ensureCertificateAuthority()
+            services.proxy.start(workspaceState.proxyPort, workspaceState.proxyRules)
+        }
+    }
+
     fun updateWorkspace(transform: (WorkspaceState) -> WorkspaceState) {
         val updated = transform(workspaceState).copy(selectedDeviceSerial = selectedSerial)
         workspaceState = updated
@@ -814,6 +829,8 @@ private fun AndyShell(
     }
 
     val mcpRunning by services.mcp.running.collectAsState(false)
+    val proxyStatus by services.proxy.status.collectAsState("Proxy stopped")
+    val proxyRunning = proxyStatus.contains("listening on")
 
     Box(
         Modifier.fillMaxSize()
@@ -848,6 +865,7 @@ private fun AndyShell(
                         services.actionRuns.stop(run.runId)
                         activeRunId = run.runId
                     },
+                    proxyRunning = proxyRunning,
                     actions = {
                         if (destination == AndyDestination.Network) {
                             FilterPill("Rules", networkRulesVisible, Rust) { networkRulesVisible = !networkRulesVisible }
@@ -1202,6 +1220,7 @@ private fun TopChrome(
     runningActions: List<RunningAction>,
     onRunAction: (ActionProject, ProjectAction) -> Unit,
     onStopAction: (RunningAction) -> Unit,
+    proxyRunning: Boolean,
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     val hasActionRunnerControls = actionConfig.projects.any { it.actions.isNotEmpty() }
@@ -1219,6 +1238,10 @@ private fun TopChrome(
         }
         Spacer(Modifier.weight(1f))
         actions()
+        if (destination != AndyDestination.Network && proxyRunning) {
+            ProxyToolbarIndicator()
+            Spacer(Modifier.width(10.dp))
+        }
         if (hasActionRunnerControls) {
             ActionRunnerSelector(
                 config = actionConfig,
@@ -1244,6 +1267,21 @@ private fun TopChrome(
         }
         Spacer(Modifier.width(10.dp))
         DevicePicker(devices, selectedDevice?.serial, onSelectDevice)
+    }
+}
+
+@Composable
+private fun ProxyToolbarIndicator() {
+    Row(
+        Modifier.height(30.dp)
+            .background(Green.copy(alpha = 0.12f), RoundedCornerShape(AndyRadius.Pill))
+            .border(1.dp, Green.copy(alpha = 0.42f), RoundedCornerShape(AndyRadius.Pill))
+            .padding(horizontal = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        GlowingDot(isGreen = true, modifier = Modifier.size(14.dp))
+        Text("proxy", color = AndyColors.GreenSoft, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 11.sp)
     }
 }
 
@@ -4933,6 +4971,7 @@ private fun NetworkScreen(
     }
     var caInstalled by remember { mutableStateOf(false) }
     var proxyConfigured by remember { mutableStateOf(false) }
+    var routeDiagnostics by remember { mutableStateOf<NetworkRouteDiagnostics?>(null) }
     var userCaVerifiedByTrafficForDevice by remember { mutableStateOf(false) }
     var proxyTrafficObservedForDevice by remember { mutableStateOf(false) }
     var trafficEvidenceSerial by remember { mutableStateOf<String?>(null) }
@@ -4992,6 +5031,7 @@ private fun NetworkScreen(
         if (serial == null) {
             caInstalled = false
             proxyConfigured = false
+            routeDiagnostics = null
             deviceReadinessChecked = true
             return@LaunchedEffect
         }
@@ -5000,8 +5040,10 @@ private fun NetworkScreen(
             val isCaOk = proxy.isCertificateInstalled(serial)
             val host = proxy.resolveDeviceProxyHost(serial)
             val isProxyOk = proxy.isDeviceProxyConfigured(serial, host, currentPort)
+            val route = proxy.diagnoseDeviceProxyRoute(serial, host, currentPort)
             caInstalled = isCaOk
             proxyConfigured = isProxyOk
+            routeDiagnostics = route
             deviceReadinessChecked = true
             delay(3000)
         }
@@ -5016,6 +5058,7 @@ private fun NetworkScreen(
         caInstalled,
         proxyTrafficObservedForDevice,
         proxyConfigured,
+        routeDiagnostics,
     ) {
         if (setupDefaultApplied || setupManuallyToggled || !engineChecked || !deviceReadinessChecked) return@LaunchedEffect
         val redCount = listOf(
@@ -5025,6 +5068,7 @@ private fun NetworkScreen(
             proxyStatus.contains("listening on"),
             serial != null && (caInstalled || proxyTrafficObservedForDevice),
             serial != null && proxyConfigured,
+            serial != null && routeDiagnostics?.vpnActive != true && routeDiagnostics?.routeUsesVpn != true,
         ).count { !it }
         setupExpanded = redCount > 2
         setupDefaultApplied = true
@@ -5198,6 +5242,16 @@ private fun NetworkScreen(
                     proxyConfigured -> "Device is routed"
                     else -> "Click 'Configure' to route"
                 }
+                val routeText = when {
+                    serial == null -> "Select a device first"
+                    routeDiagnostics == null -> "Checking route"
+                    routeDiagnostics?.hostProxyActive == true && routeDiagnostics?.hostUpstreamProxy != null -> "Mac proxy chained"
+                    routeDiagnostics?.hostProxyActive == true -> "Mac proxy active"
+                    routeDiagnostics?.vpnActive == true -> "VPN active (may cause issues)"
+                    routeDiagnostics?.routeUsesVpn == true -> "Proxy route uses VPN"
+                    routeDiagnostics?.proxyConfigured == false -> "Proxy route needs repair"
+                    else -> "No VPN route issue detected"
+                }
                 val setupRequirements = listOf(
                     SetupRequirement(
                         label = "Android SDK platform-tools",
@@ -5238,7 +5292,17 @@ private fun NetworkScreen(
                         readyText = configText,
                         missingText = configText,
                     ),
+                    SetupRequirement(
+                        label = "VPN / Route",
+                        ok = serial != null &&
+                            routeDiagnostics?.vpnActive != true &&
+                            routeDiagnostics?.routeUsesVpn != true &&
+                            routeDiagnostics?.hostProxyBypassLooksSafe != false,
+                        readyText = routeText,
+                        missingText = routeText,
+                    ),
                 )
+                val showRouteWarning = routeDiagnostics?.hasBlockingIssue == true && proxyStarted && !proxyTrafficObservedForDevice
                 AnimatedVisibility(setupExpanded) {
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Row(
@@ -5255,9 +5319,42 @@ private fun NetworkScreen(
                                         val result = proxy.configureDeviceProxy(serial, host, currentPort)
                                         status = if (result.isSuccess) "Device proxy set to $host:$currentPort" else result.stderr
                                         proxyConfigured = proxy.isDeviceProxyConfigured(serial, host, currentPort)
+                                        routeDiagnostics = proxy.diagnoseDeviceProxyRoute(serial, host, currentPort)
                                     }
                                 },
                             ) { Text("Configure device proxy") }
+                            OutlinedButton(
+                                enabled = serial != null,
+                                onClick = {
+                                    if (serial != null) scope.launch {
+                                        val host = proxy.resolveDeviceProxyHost(serial)
+                                        proxyHost = host
+                                        val configured = proxy.configureDeviceProxy(serial, host, currentPort)
+                                        val route = proxy.diagnoseDeviceProxyRoute(serial, host, currentPort)
+                                        routeDiagnostics = route
+                                        proxyConfigured = route.proxyConfigured
+                                        val restart = if (route.hostProxyActive) proxy.start(currentPort, rules) else null
+                                        status = if (route.vpnActive) {
+                                            "Proxy route repaired, but VPN is still active. Open VPN settings and disable or split-tunnel the test app."
+                                        } else if (restart?.isSuccess == true) {
+                                            "Proxy route repaired; Andy restarted mitmproxy through the Mac proxy."
+                                        } else if (configured.isSuccess && !route.hasBlockingIssue) {
+                                            "Proxy route repaired"
+                                        } else {
+                                            (route.issues.ifEmpty { listOf(restart?.stderr ?: configured.stderr) }).joinToString(" ")
+                                        }
+                                    }
+                                },
+                            ) { Text("Repair proxy route") }
+                            OutlinedButton(
+                                enabled = serial != null,
+                                onClick = {
+                                    if (serial != null) scope.launch {
+                                        val result = proxy.openVpnSettings(serial)
+                                        status = if (result.isSuccess) "Opened Android VPN settings" else result.stderr
+                                    }
+                                },
+                            ) { Text("Open VPN settings") }
                             OutlinedButton(
                                 enabled = serial != null,
                                 onClick = {
@@ -5292,6 +5389,9 @@ private fun NetworkScreen(
                         }
                         SetupChecklist(setupRequirements)
                         SetupChecklist(networkStatusRequirements)
+                        AnimatedVisibility(showRouteWarning) {
+                            NetworkRouteWarningCard(routeDiagnostics)
+                        }
                         Text(status, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
                         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
                             StatusTag(if (engineReady) "mitmproxy ready" else "mitmproxy missing", if (engineReady) Green else Red)
@@ -5561,6 +5661,30 @@ private fun GlowingDot(isGreen: Boolean, modifier: Modifier = Modifier) {
                 .size(8.dp)
                 .background(color, CircleShape)
                 .border(1.dp, color.copy(alpha = 0.8f), CircleShape)
+        )
+    }
+}
+
+@Composable
+private fun NetworkRouteWarningCard(diagnostics: NetworkRouteDiagnostics?, modifier: Modifier = Modifier) {
+    val issues = diagnostics?.issues.orEmpty()
+    Column(
+        modifier
+            .fillMaxWidth()
+            .background(Yellow.copy(alpha = 0.10f), RoundedCornerShape(AndyRadius.R3))
+            .border(1.dp, Yellow.copy(alpha = 0.55f), RoundedCornerShape(AndyRadius.R3))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("Traffic may be bypassing Andy", color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+        issues.take(3).forEach { issue ->
+            Text(issue, color = TextSecondary, fontSize = 12.sp, lineHeight = 16.sp)
+        }
+        Text(
+            "Repair proxy route reapplies Android's global proxy and restarts mitmproxy through the Mac proxy when one is configured. If traffic still disappears, add localhost, 127.0.0.1, and 10.0.2.2 to the Mac proxy bypass list or disable/split-tunnel the VPN.",
+            color = Yellow,
+            fontSize = 12.sp,
+            lineHeight = 16.sp,
         )
     }
 }
@@ -8099,12 +8223,56 @@ private fun SettingsScreen(
 
     val mcpStatus by services.mcp.status.collectAsState("stopped")
     val mcpRunning by services.mcp.running.collectAsState(false)
+    val proxyStatus by services.proxy.status.collectAsState("Proxy stopped")
+    val proxyRunning = proxyStatus.contains("listening on")
 
     Column(
         Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text("mcp settings", color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 18.sp, fontFamily = MonoFont)
+        Text("settings", color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 18.sp, fontFamily = MonoFont)
+
+        PanelCard {
+            Text("HTTP debug proxy", color = TextPrimary, fontWeight = FontWeight.Bold)
+            Text(
+                "Start Andy's mitmdump capture proxy automatically when the app opens.",
+                color = TextSecondary,
+                fontSize = 12.sp,
+                lineHeight = 16.sp
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Row(
+                Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Checkbox(
+                        checked = workspaceState.proxyStartOnLaunch,
+                        onCheckedChange = { checked ->
+                            onUpdateWorkspace { it.copy(proxyStartOnLaunch = checked) }
+                        }
+                    )
+                    Text("Start proxy on app launch", color = TextPrimary, fontSize = 13.sp)
+                }
+
+                Spacer(Modifier.width(16.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text("Proxy Status:", color = TextSecondary, fontSize = 12.sp)
+                    GlowingDot(proxyRunning)
+                    Text(proxyStatus, color = if (proxyRunning) Green else Rust, fontSize = 12.sp, fontFamily = MonoFont, fontWeight = FontWeight.Bold)
+                }
+            }
+        }
 
         PanelCard {
             Text("Model Context Protocol (MCP) Server", color = TextPrimary, fontWeight = FontWeight.Bold)

--- a/src/commonMain/kotlin/app/andy/App.kt
+++ b/src/commonMain/kotlin/app/andy/App.kt
@@ -5856,7 +5856,7 @@ private fun shouldAutoStartProxy(status: String, port: Int): Boolean {
     if (normalized == "Proxy stopped" || normalized == "mitmdump exited" || normalized.startsWith("Proxy failed")) {
         return true
     }
-    val listeningPort = Regex(""":(\d{1,5})(?:\D*)?$""")
+    val listeningPort = Regex("""listening on \S+:(\d{1,5})""")
         .find(normalized)
         ?.groupValues
         ?.getOrNull(1)

--- a/src/commonMain/kotlin/app/andy/model/Models.kt
+++ b/src/commonMain/kotlin/app/andy/model/Models.kt
@@ -261,6 +261,26 @@ data class NetworkExchange(
     val flowId: String,
 )
 
+data class NetworkRouteDiagnostics(
+    val expectedProxy: String,
+    val configuredProxy: String?,
+    val proxyConfigured: Boolean,
+    val vpnActive: Boolean,
+    val vpnName: String? = null,
+    val routeUsesVpn: Boolean = false,
+    val routeSummary: String? = null,
+    val hostProxyActive: Boolean = false,
+    val hostProxySummary: String? = null,
+    val hostUpstreamProxy: String? = null,
+    val hostProxyBypassLooksSafe: Boolean = true,
+    val hostVpnActive: Boolean = false,
+    val hostVpnSummary: String? = null,
+    val hostRouteSummary: String? = null,
+    val issues: List<String> = emptyList(),
+) {
+    val hasBlockingIssue: Boolean get() = issues.isNotEmpty()
+}
+
 data class PerformanceSample(
     val timestampMillis: Long,
     val cpuPercent: Float?,
@@ -319,6 +339,7 @@ data class WorkspaceState(
     val enabledLogLevels: Set<LogLevel> = setOf(LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal),
     val proxyRules: List<ProxyRule> = emptyList(),
     val proxyPort: Int = 9099,
+    val proxyStartOnLaunch: Boolean = false,
     val mcpServerEnabled: Boolean = false,
     val mcpServerPort: Int = 8565,
     val liveDevicePaneWidth: Float = 720f,

--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -92,6 +92,8 @@ interface ProxyService {
     suspend fun resolveDeviceProxyHost(serial: String): String
     suspend fun configureDeviceProxy(serial: String, host: String, port: Int): CommandResult
     suspend fun clearDeviceProxy(serial: String): CommandResult
+    suspend fun diagnoseDeviceProxyRoute(serial: String, host: String, port: Int): NetworkRouteDiagnostics
+    suspend fun openVpnSettings(serial: String): CommandResult
     suspend fun prepareUserCertificateInstall(serial: String): CommandResult
     suspend fun installSystemCertificateAuthority(serial: String): CommandResult
     suspend fun activatePersistedCertificateAuthority(serial: String): CommandResult

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
@@ -763,6 +763,19 @@ private fun emulatorDisplayAspectDrifted(frame: MirrorFrame, displaySize: Emulat
     return abs(frameAspect - displayAspect) > 0.03
 }
 
+internal fun emulatorRgb888ToArgb(width: Int, height: Int, rgb: ByteBuffer): IntArray {
+    val pixels = IntArray(width * height)
+    val bytes = rgb.duplicate()
+    bytes.position(0)
+    for (index in pixels.indices) {
+        val red = bytes.get().toInt() and 0xff
+        val green = bytes.get().toInt() and 0xff
+        val blue = bytes.get().toInt() and 0xff
+        pixels[index] = 0xff000000.toInt() or (red shl 16) or (green shl 8) or blue
+    }
+    return pixels
+}
+
 internal fun scaledEmulatorTouchPoint(
     x: Int,
     y: Int,
@@ -1007,7 +1020,7 @@ class DesktopMirrorEngine(
                 frames.value = MirrorFrame(
                     width = image.width,
                     height = image.height,
-                    argb = rgbToArgb(image.width, image.height, rgb),
+                    argb = emulatorRgb888ToArgb(image.width, image.height, rgb),
                     frameNumber = ++frameNumber,
                     decodedFps = decodedFps.takeIf { it > 0f },
                 )
@@ -1030,27 +1043,6 @@ class DesktopMirrorEngine(
         } finally {
             mappedFramebuffer?.close()
         }
-    }
-
-    // The emulator gRPC streamScreenshot RGB888 payload is bottom-up, so flip rows
-    // while converting to the top-down ARGB layout expected by Swing/Compose.
-    private fun rgbToArgb(width: Int, height: Int, rgb: ByteBuffer): IntArray {
-        val pixels = IntArray(width * height)
-        val row = ByteArray(width * EMULATOR_IMAGE_BYTES_PER_PIXEL)
-        for (y in 0 until height) {
-            val sourceY = height - 1 - y
-            rgb.position(sourceY * row.size)
-            rgb.get(row, 0, row.size)
-            var source = 0
-            var destination = y * width
-            while (source < row.size) {
-                val red = row[source++].toInt() and 0xff
-                val green = row[source++].toInt() and 0xff
-                val blue = row[source++].toInt() and 0xff
-                pixels[destination++] = 0xff000000.toInt() or (red shl 16) or (green shl 8) or blue
-            }
-        }
-        return pixels
     }
 
     private suspend fun runNativeVideoLoop(adb: String, serial: String, scrcpyServer: File, config: MirrorVideoConfig) = withContext(Dispatchers.IO) {
@@ -2351,19 +2343,28 @@ class DesktopProxyService(
         proxyDir.mkdirs()
         writeAddon()
         writeRules(rules)
-        val command = listOf(
-            executable,
-            "--listen-host", "0.0.0.0",
-            "--listen-port", port.toString(),
-            "--set", "confdir=${proxyDir.absolutePath}",
-            "-s", addonFile.absolutePath,
-            "--set", "termlog_verbosity=warn",
-        )
+        val hostProxy = detectHostProxyState()
+        val command = buildList {
+            add(executable)
+            hostProxy.upstreamProxy?.let { upstream ->
+                add("--mode")
+                add("upstream:$upstream")
+            }
+            addAll(
+                listOf(
+                    "--listen-host", "0.0.0.0",
+                    "--listen-port", port.toString(),
+                    "--set", "confdir=${proxyDir.absolutePath}",
+                    "-s", addonFile.absolutePath,
+                    "--set", "termlog_verbosity=warn",
+                ),
+            )
+        }
         runCatching {
             process = processStarter(command, proxyDir, mapOf("ANDY_RULES_PATH" to rulesFile.absolutePath))
-            status.value = "mitmdump listening on 0.0.0.0:$port"
+            status.value = "mitmdump listening on 0.0.0.0:$port" + hostProxy.upstreamProxy?.let { " via Mac proxy $it" }.orEmpty()
             pumpProcess(process!!)
-            CommandResult.success("mitmdump listening on 0.0.0.0:$port")
+            CommandResult.success(status.value)
         }.getOrElse { error ->
             status.value = "Proxy failed: ${error.message ?: error::class.simpleName}"
             CommandResult.failure(status.value)
@@ -2424,6 +2425,56 @@ class DesktopProxyService(
             listOf("settings", "delete", "global", "global_proxy_pac_url"),
         )
         return runAdbShellSequence(adb, serial, commands, "Device proxy cleared")
+    }
+
+    override suspend fun diagnoseDeviceProxyRoute(serial: String, host: String, port: Int): NetworkRouteDiagnostics = withContext(Dispatchers.IO) {
+        val adb = devices.adbPath()
+            ?: return@withContext NetworkRouteDiagnostics(
+                expectedProxy = "$host:$port",
+                configuredProxy = null,
+                proxyConfigured = false,
+                vpnActive = false,
+                issues = listOf("ADB not found"),
+            )
+        val expectedProxy = "$host:$port"
+        val configuredProxy = readConfiguredProxy(adb, serial)
+        val proxyConfigured = configuredProxy == expectedProxy
+        val connectivity = runner.run(listOf(adb, "-s", serial, "shell", "dumpsys", "connectivity"), 10)
+        val vpn = parseVpnRouteState(connectivity.stdout)
+        val route = runner.run(listOf(adb, "-s", serial, "shell", "ip", "route", "get", host), 10)
+        val routeSummary = route.stdout.lineSequence().firstOrNull { it.isNotBlank() }?.trim()
+        val routeUsesVpn = routeSummary?.contains(Regex("""\b(tun|ppp|wg|vpn)\w*""", RegexOption.IGNORE_CASE)) == true
+        val hostProxy = detectHostProxyState()
+        val hostVpn = detectHostVpnState()
+        val issues = buildList {
+            if (!proxyConfigured) add("Android global proxy is ${configuredProxy ?: "not set"}; expected $expectedProxy.")
+            if (vpn.active) add("A VPN is active${vpn.name?.let { " ($it)" }.orEmpty()}; it can bypass Android's global HTTP proxy or route Andy's proxy endpoint into the tunnel.")
+            if (routeUsesVpn) add("The route to Andy's proxy host appears to use a VPN interface: $routeSummary")
+            if (hostProxy.active && hostProxy.upstreamProxy != null) add("Mac proxy is active; Andy will chain mitmproxy through ${hostProxy.upstreamProxy}.")
+            if (hostProxy.active && !hostProxy.bypassLooksSafe) add("Mac proxy bypass rules do not clearly include localhost/127.0.0.1/10.0.2.2; add them if emulator traffic still disappears.")
+            if (hostVpn.active) add("Mac VPN-like interfaces are active (${hostVpn.summary}); emulator traffic may be routed by the host tunnel.")
+        }
+        NetworkRouteDiagnostics(
+            expectedProxy = expectedProxy,
+            configuredProxy = configuredProxy,
+            proxyConfigured = proxyConfigured,
+            vpnActive = vpn.active,
+            vpnName = vpn.name,
+            routeUsesVpn = routeUsesVpn,
+            routeSummary = routeSummary,
+            hostProxyActive = hostProxy.active,
+            hostProxySummary = hostProxy.summary,
+            hostUpstreamProxy = hostProxy.upstreamProxy,
+            hostProxyBypassLooksSafe = hostProxy.bypassLooksSafe,
+            hostVpnActive = hostVpn.active,
+            hostVpnSummary = hostVpn.summary,
+            issues = issues,
+        )
+    }
+
+    override suspend fun openVpnSettings(serial: String): CommandResult {
+        val adb = devices.adbPath() ?: return CommandResult.failure("ADB not found")
+        return runner.run(listOf(adb, "-s", serial, "shell", "am", "start", "-a", "android.settings.VPN_SETTINGS"), 10)
     }
 
     override suspend fun prepareUserCertificateInstall(serial: String): CommandResult = withContext(Dispatchers.IO) {
@@ -2500,19 +2551,36 @@ class DesktopProxyService(
 
     override suspend fun isDeviceProxyConfigured(serial: String, host: String, port: Int): Boolean = withContext(Dispatchers.IO) {
         val adb = devices.adbPath() ?: return@withContext false
-        val result = runner.run(listOf(adb, "-s", serial, "shell", "settings", "get", "global", "http_proxy"), 10)
-        if (!result.isSuccess) return@withContext false
-        val currentProxy = result.stdout.trim()
-        val parts = currentProxy.split(':')
-        if (parts.size == 2) {
-            val currentHost = parts[0].trim()
-            val currentPort = parts[1].trim().toIntOrNull()
-            currentHost == host && currentPort == port
-        } else {
-            false
-        }
+        readConfiguredProxy(adb, serial) == "$host:$port"
     }
 
+    private suspend fun readConfiguredProxy(adb: String, serial: String): String? {
+        val result = runner.run(listOf(adb, "-s", serial, "shell", "settings", "get", "global", "http_proxy"), 10)
+        if (!result.isSuccess) return null
+        return result.stdout.trim().takeIf { it.isNotBlank() && it != "null" && it != ":0" }
+    }
+
+    private suspend fun detectHostProxyState(): HostProxyState {
+        val result = runner.run(listOf("/usr/sbin/scutil", "--proxy"), 5)
+        if (!result.isSuccess) return HostProxyState(active = false)
+        return parseMacProxyState(result.stdout)
+    }
+
+    private suspend fun detectHostVpnState(): HostVpnState {
+        val result = runner.run(listOf("/sbin/ifconfig"), 5)
+        if (!result.isSuccess) return HostVpnState(active = false)
+        val activeInterfaces = Regex("""^([a-z]+[0-9]+): flags=.*\bUP\b""", setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
+            .findAll(result.stdout)
+            .mapNotNull { match ->
+                val name = match.groupValues.getOrNull(1).orEmpty()
+                name.takeIf { it.startsWith("utun") || it.startsWith("ppp") || it.startsWith("ipsec") || it.startsWith("wg") }
+            }
+            .toList()
+        return HostVpnState(
+            active = activeInterfaces.isNotEmpty(),
+            summary = activeInterfaces.distinct().joinToString(", ").takeIf { it.isNotBlank() },
+        )
+    }
 
     private suspend fun installPersistentCertificateAuthority(adb: String, serial: String, androidCert: File, originalCertificate: File): CommandResult {
         val remount = remountWritableSystem(adb, serial)
@@ -2977,6 +3045,91 @@ internal fun parseMitmproxyFlowLine(line: String): NetworkExchange? {
     )
 }
 
+internal data class VpnRouteState(val active: Boolean, val name: String?)
+
+internal fun parseVpnRouteState(dumpsysConnectivity: String): VpnRouteState {
+    val lines = dumpsysConnectivity.lines()
+    val vpnLine = lines.firstOrNull { line ->
+        line.contains("TRANSPORT_VPN") ||
+            line.contains("type: VPN", ignoreCase = true) ||
+            (line.contains("VPN") && line.contains("CONNECTED", ignoreCase = true))
+    } ?: return VpnRouteState(active = false, name = null)
+    val ownerLine = lines.firstOrNull { line ->
+        line.contains("mOwnerName=", ignoreCase = true) ||
+            line.contains("owner=", ignoreCase = true) ||
+            (line.contains("vpn", ignoreCase = true) && line.contains("package", ignoreCase = true))
+    }
+    val name = ownerLine
+        ?.let { Regex("""(?:mOwnerName|owner|packageName|package)=([A-Za-z0-9_.-]+)""", RegexOption.IGNORE_CASE).find(it)?.groupValues?.getOrNull(1) }
+        ?: Regex("""\b([a-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_-]+){2,})\b""").find(vpnLine)?.groupValues?.getOrNull(1)
+    return VpnRouteState(active = true, name = name)
+}
+
+internal data class HostProxyState(
+    val active: Boolean,
+    val summary: String? = null,
+    val upstreamProxy: String? = null,
+    val bypassLooksSafe: Boolean = true,
+)
+
+private data class HostVpnState(val active: Boolean, val summary: String? = null)
+
+internal fun parseMacProxyState(scutilProxy: String): HostProxyState {
+    val entries = scutilProxy.lineSequence()
+        .mapNotNull { line ->
+            val trimmed = line.trim()
+            if (":" !in trimmed) return@mapNotNull null
+            trimmed.substringBefore(":").trim() to trimmed.substringAfter(":").trim()
+        }
+        .toMap()
+    val http = proxyEndpoint(entries, "HTTP")
+    val https = proxyEndpoint(entries, "HTTPS")
+    val socks = proxyEndpoint(entries, "SOCKS")
+    val upstream = https ?: http ?: socks
+    val activeParts = listOfNotNull(
+        http?.let { "HTTP $it" },
+        https?.let { "HTTPS $it" },
+        socks?.let { "SOCKS $it" },
+        entries["ProxyAutoConfigEnable"]?.takeIf { it == "1" }?.let { entries["ProxyAutoConfigURLString"]?.let { url -> "PAC $url" } ?: "PAC" },
+    )
+    val active = activeParts.isNotEmpty()
+    val exceptions = scutilProxy.lineSequence()
+        .map { it.trim() }
+        .filter { Regex("""^\d+\s*:""").containsMatchIn(it) }
+        .map { it.substringAfter(":").trim() }
+        .toList()
+    val simpleHostsExcluded = entries["ExcludeSimpleHostnames"] == "1"
+    val bypassLooksSafe = !active || simpleHostsExcluded || listOf("localhost", "127.0.0.1", "10.0.2.2").all { expected ->
+        exceptions.any { exception -> proxyExceptionCovers(exception, expected) }
+    }
+    return HostProxyState(
+        active = active,
+        summary = activeParts.joinToString(", ").takeIf { it.isNotBlank() },
+        upstreamProxy = upstream,
+        bypassLooksSafe = bypassLooksSafe,
+    )
+}
+
+private fun proxyEndpoint(entries: Map<String, String>, prefix: String): String? {
+    if (entries["${prefix}Enable"] != "1") return null
+    val host = entries["${prefix}Proxy"]?.takeIf { it.isNotBlank() } ?: return null
+    val port = entries["${prefix}Port"]?.takeIf { it.isNotBlank() } ?: return null
+    val scheme = if (prefix == "SOCKS") "socks5" else "http"
+    return "$scheme://$host:$port"
+}
+
+private fun proxyExceptionCovers(exception: String, expected: String): Boolean {
+    val normalized = exception.trim().lowercase()
+    val target = expected.lowercase()
+    return normalized == target ||
+        normalized == "<local>" && target == "localhost" ||
+        normalized == "*.local" && target.endsWith(".local") ||
+        normalized.endsWith(".*") && target.startsWith(normalized.removeSuffix(".*")) ||
+        normalized.endsWith("/8") && normalized.substringBefore("/") == "10.0.0.0" && target.startsWith("10.") ||
+        normalized.endsWith("/16") && target.startsWith(normalized.substringBeforeLast('.').removeSuffix(".0")) ||
+        normalized.endsWith("/24") && target.startsWith(normalized.substringBeforeLast('.'))
+}
+
 private fun quoteJson(value: String): String {
     return buildString {
         append('"')
@@ -3285,6 +3438,7 @@ class DesktopWorkspaceStore : WorkspaceStore {
             selectedDeviceSerial = props.getProperty("selectedDeviceSerial")?.takeIf { it.isNotBlank() },
             logSearch = props.getProperty("logSearch").orEmpty(),
             proxyPort = props.getProperty("proxyPort")?.toIntOrNull() ?: 9099,
+            proxyStartOnLaunch = props.getProperty("proxyStartOnLaunch")?.toBooleanStrictOrNull() ?: false,
             mcpServerEnabled = props.getProperty("mcpServerEnabled")?.toBooleanStrictOrNull() ?: false,
             mcpServerPort = props.getProperty("mcpServerPort")?.toIntOrNull() ?: 8565,
             proxyRules = loadProxyRules(props),
@@ -3312,6 +3466,7 @@ class DesktopWorkspaceStore : WorkspaceStore {
             setProperty("selectedDeviceSerial", state.selectedDeviceSerial.orEmpty())
             setProperty("logSearch", state.logSearch)
             setProperty("proxyPort", state.proxyPort.toString())
+            setProperty("proxyStartOnLaunch", state.proxyStartOnLaunch.toString())
             setProperty("mcpServerEnabled", state.mcpServerEnabled.toString())
             setProperty("mcpServerPort", state.mcpServerPort.toString())
             setProperty("proxyRuleCount", state.proxyRules.size.toString())

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
@@ -766,12 +766,20 @@ private fun emulatorDisplayAspectDrifted(frame: MirrorFrame, displaySize: Emulat
 internal fun emulatorRgb888ToArgb(width: Int, height: Int, rgb: ByteBuffer): IntArray {
     val pixels = IntArray(width * height)
     val bytes = rgb.duplicate()
-    bytes.position(0)
-    for (index in pixels.indices) {
-        val red = bytes.get().toInt() and 0xff
-        val green = bytes.get().toInt() and 0xff
-        val blue = bytes.get().toInt() and 0xff
-        pixels[index] = 0xff000000.toInt() or (red shl 16) or (green shl 8) or blue
+    val rowSize = width * EMULATOR_IMAGE_BYTES_PER_PIXEL
+    val row = ByteArray(rowSize)
+    for (y in 0 until height) {
+        val sourceY = height - 1 - y
+        bytes.position(sourceY * rowSize)
+        bytes.get(row, 0, rowSize)
+        var source = 0
+        var destination = y * width
+        while (source < rowSize) {
+            val red = row[source++].toInt() and 0xff
+            val green = row[source++].toInt() and 0xff
+            val blue = row[source++].toInt() and 0xff
+            pixels[destination++] = 0xff000000.toInt() or (red shl 16) or (green shl 8) or blue
+        }
     }
     return pixels
 }
@@ -2307,6 +2315,7 @@ class DesktopProxyService(
     },
     private val certificateSubjectHash: suspend (File) -> String? = { certificate -> defaultCertificateSubjectHash(runner, certificate) },
     private val certificateSpkiFingerprint: suspend (File) -> String? = { certificate -> defaultCertificateSpkiFingerprint(runner, certificate) },
+    private val hostOsName: () -> String = { System.getProperty("os.name") },
 ) : ProxyService {
     override val exchanges = MutableStateFlow<List<NetworkExchange>>(emptyList())
     override val status = MutableStateFlow("Proxy stopped")
@@ -2450,7 +2459,6 @@ class DesktopProxyService(
             if (!proxyConfigured) add("Android global proxy is ${configuredProxy ?: "not set"}; expected $expectedProxy.")
             if (vpn.active) add("A VPN is active${vpn.name?.let { " ($it)" }.orEmpty()}; it can bypass Android's global HTTP proxy or route Andy's proxy endpoint into the tunnel.")
             if (routeUsesVpn) add("The route to Andy's proxy host appears to use a VPN interface: $routeSummary")
-            if (hostProxy.active && hostProxy.upstreamProxy != null) add("Mac proxy is active; Andy will chain mitmproxy through ${hostProxy.upstreamProxy}.")
             if (hostProxy.active && !hostProxy.bypassLooksSafe) add("Mac proxy bypass rules do not clearly include localhost/127.0.0.1/10.0.2.2; add them if emulator traffic still disappears.")
             if (hostVpn.active) add("Mac VPN-like interfaces are active (${hostVpn.summary}); emulator traffic may be routed by the host tunnel.")
         }
@@ -2561,12 +2569,14 @@ class DesktopProxyService(
     }
 
     private suspend fun detectHostProxyState(): HostProxyState {
+        if (!isMacHost()) return HostProxyState(active = false)
         val result = runner.run(listOf("/usr/sbin/scutil", "--proxy"), 5)
         if (!result.isSuccess) return HostProxyState(active = false)
         return parseMacProxyState(result.stdout)
     }
 
     private suspend fun detectHostVpnState(): HostVpnState {
+        if (!isMacHost()) return HostVpnState(active = false)
         val result = runner.run(listOf("/sbin/ifconfig"), 5)
         if (!result.isSuccess) return HostVpnState(active = false)
         val activeInterfaces = Regex("""^([a-z]+[0-9]+): flags=.*\bUP\b""", setOf(RegexOption.MULTILINE, RegexOption.IGNORE_CASE))
@@ -2581,6 +2591,8 @@ class DesktopProxyService(
             summary = activeInterfaces.distinct().joinToString(", ").takeIf { it.isNotBlank() },
         )
     }
+
+    private fun isMacHost(): Boolean = hostOsName().contains("Mac", ignoreCase = true)
 
     private suspend fun installPersistentCertificateAuthority(adb: String, serial: String, androidCert: File, originalCertificate: File): CommandResult {
         val remount = remountWritableSystem(adb, serial)

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
@@ -81,6 +81,7 @@ class DesktopProxyServiceTest {
             val store = DesktopWorkspaceStore()
             store.save(
                 WorkspaceState(
+                    proxyStartOnLaunch = true,
                     proxyRules = listOf(
                         ProxyRule(
                             id = "rule-404",
@@ -97,8 +98,10 @@ class DesktopProxyServiceTest {
                 ),
             )
 
-            val loadedRule = store.load().proxyRules.single()
+            val loaded = store.load()
+            val loadedRule = loaded.proxyRules.single()
 
+            assertTrue(loaded.proxyStartOnLaunch)
             assertEquals(404, loadedRule.statusCode)
             assertEquals(mapOf("x-andy" to "missing", "content-type" to "application/json"), loadedRule.setHeaders)
             assertEquals(listOf("Server", "etag"), loadedRule.removeHeaders)
@@ -132,12 +135,108 @@ class DesktopProxyServiceTest {
     }
 
     @Test
+    fun startChainsMitmproxyThroughDetectedMacProxy() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        env.macProxyOutput = """
+            <dictionary> {
+              HTTPEnable : 1
+              HTTPProxy : proxy.example.test
+              HTTPPort : 8080
+              ExceptionsList : <array> {
+                0 : localhost
+                1 : 127.0.0.1
+                2 : 10.0.2.2
+              }
+            }
+        """.trimIndent()
+        val services = env.services()
+
+        val result = services.proxy.start(8888, emptyList())
+
+        assertTrue(result.isSuccess)
+        val command = env.proxyCommands.single()
+        assertTrue(command.windowed(2).any { it == listOf("--mode", "upstream:http://proxy.example.test:8080") })
+        assertTrue(result.stdout.contains("via Mac proxy http://proxy.example.test:8080"))
+    }
+
+    @Test
     fun deviceProxyHostUsesEmulatorLoopbackAliasOnlyForEmulators() = runBlocking {
         val env = MockAndroidDeviceEnvironment()
         val services = env.services()
 
         assertEquals("10.0.2.2", services.proxy.resolveDeviceProxyHost("emulator-5554"))
         assertTrue(services.proxy.resolveDeviceProxyHost("R3CXB056ZZB").isNotBlank())
+    }
+
+    @Test
+    fun routeDiagnosticsDetectsActiveVpnAndProxyMismatch() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+        env.httpProxyValue = ":0"
+        env.connectivityDump = """
+            NetworkAgentInfo{ ni{[type: VPN[], state: CONNECTED/CONNECTED, reason: connected]}
+              mOwnerName=com.example.vpn
+              NetworkCapabilities: TRANSPORT_VPN
+            }
+        """.trimIndent()
+        env.routeToProxyOutput = "10.0.2.2 dev tun0 src 10.8.0.2"
+
+        val diagnostics = services.proxy.diagnoseDeviceProxyRoute("emulator-5554", "10.0.2.2", 8888)
+
+        assertFalse(diagnostics.proxyConfigured)
+        assertTrue(diagnostics.vpnActive)
+        assertEquals("com.example.vpn", diagnostics.vpnName)
+        assertTrue(diagnostics.routeUsesVpn)
+        assertTrue(diagnostics.issues.any { it.contains("VPN is active") })
+        assertTrue(diagnostics.issues.any { it.contains("expected 10.0.2.2:8888") })
+    }
+
+    @Test
+    fun routeDiagnosticsReportsMacProxyBypassRisk() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+        env.macProxyOutput = """
+            <dictionary> {
+              HTTPEnable : 1
+              HTTPProxy : proxy.example.test
+              HTTPPort : 8080
+              ExceptionsList : <array> {
+                0 : localhost
+              }
+            }
+        """.trimIndent()
+
+        val diagnostics = services.proxy.diagnoseDeviceProxyRoute("emulator-5554", "10.0.2.2", 8888)
+
+        assertTrue(diagnostics.hostProxyActive)
+        assertEquals("http://proxy.example.test:8080", diagnostics.hostUpstreamProxy)
+        assertFalse(diagnostics.hostProxyBypassLooksSafe)
+        assertTrue(diagnostics.issues.any { it.contains("Mac proxy is active") })
+        assertTrue(diagnostics.issues.any { it.contains("bypass rules") })
+    }
+
+    @Test
+    fun routeDiagnosticsPassesWhenProxyIsConfiguredAndNoVpnIsActive() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+
+        val diagnostics = services.proxy.diagnoseDeviceProxyRoute("emulator-5554", "10.0.2.2", 8888)
+
+        assertTrue(diagnostics.proxyConfigured)
+        assertFalse(diagnostics.vpnActive)
+        assertFalse(diagnostics.routeUsesVpn)
+        assertTrue(diagnostics.issues.isEmpty())
+    }
+
+    @Test
+    fun openVpnSettingsStartsAndroidVpnSettings() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+
+        val result = services.proxy.openVpnSettings("emulator-5554")
+
+        assertTrue(result.isSuccess)
+        assertTrue(env.ran("shell", "am", "start", "-a", "android.settings.VPN_SETTINGS"))
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
@@ -211,7 +211,6 @@ class DesktopProxyServiceTest {
         assertTrue(diagnostics.hostProxyActive)
         assertEquals("http://proxy.example.test:8080", diagnostics.hostUpstreamProxy)
         assertFalse(diagnostics.hostProxyBypassLooksSafe)
-        assertTrue(diagnostics.issues.any { it.contains("Mac proxy is active") })
         assertTrue(diagnostics.issues.any { it.contains("bypass rules") })
     }
 

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
@@ -108,10 +108,10 @@ class DesktopServicesMockDeviceTest {
     fun emulatorRgbFramesKeepTopDownOrientation() {
         val rgb = ByteBuffer.wrap(
             byteArrayOf(
-                255.toByte(), 0, 0, // top-left red
-                0, 255.toByte(), 0, // top-right green
                 0, 0, 255.toByte(), // bottom-left blue
                 255.toByte(), 255.toByte(), 255.toByte(), // bottom-right white
+                255.toByte(), 0, 0, // top-left red
+                0, 255.toByte(), 0, // top-right green
             ),
         )
 

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import java.nio.ByteBuffer
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -101,6 +102,31 @@ class DesktopServicesMockDeviceTest {
         assertEquals(7, parsed.seq)
         assertEquals(123, parsed.timestampUs)
         assertContentEquals(imageBytes, parsed.pixels)
+    }
+
+    @Test
+    fun emulatorRgbFramesKeepTopDownOrientation() {
+        val rgb = ByteBuffer.wrap(
+            byteArrayOf(
+                255.toByte(), 0, 0, // top-left red
+                0, 255.toByte(), 0, // top-right green
+                0, 0, 255.toByte(), // bottom-left blue
+                255.toByte(), 255.toByte(), 255.toByte(), // bottom-right white
+            ),
+        )
+
+        val argb = emulatorRgb888ToArgb(width = 2, height = 2, rgb = rgb)
+
+        assertContentEquals(
+            intArrayOf(
+                0xffff0000.toInt(),
+                0xff00ff00.toInt(),
+                0xff0000ff.toInt(),
+                0xffffffff.toInt(),
+            ),
+            argb,
+        )
+        assertEquals(0, rgb.position(), "conversion should not mutate caller-owned ByteBuffer position")
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -44,6 +44,7 @@ internal class MockAndroidDeviceEnvironment {
         }
     """.trimIndent()
     var hostIfconfigOutput: String = "lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST>\n"
+    var hostOsName: String = "Mac OS X"
 
     init {
         File(avdHome, "Pixel_8_API_36.avd").apply {
@@ -85,6 +86,7 @@ internal class MockAndroidDeviceEnvironment {
                     proxyCommands += command
                     MockProxyProcess()
                 },
+                hostOsName = { hostOsName },
             ),
             metrics = DesktopMetricsService(runner, devices),
             accessibility = DesktopAccessibilityService(runner, devices),

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -35,6 +35,15 @@ internal class MockAndroidDeviceEnvironment {
     var remountResult: CommandResult = CommandResult.success("remount succeeded")
     var persistedCaInstalled: Boolean = false
     var keepStoppedEmulatorInAdbAsOffline: Boolean = false
+    var httpProxyValue: String = "10.0.2.2:8888"
+    var connectivityDump: String = "NetworkAgentInfo [WIFI () - 100]\n"
+    var routeToProxyOutput: String = "10.0.2.2 dev eth0 src 10.0.2.15\n"
+    var macProxyOutput: String = """
+        <dictionary> {
+          ExcludeSimpleHostnames : 1
+        }
+    """.trimIndent()
+    var hostIfconfigOutput: String = "lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST>\n"
 
     init {
         File(avdHome, "Pixel_8_API_36.avd").apply {
@@ -119,6 +128,8 @@ internal class MockAndroidDeviceEnvironment {
             adb.absolutePath -> runAdb(command)
             sdkManager.absolutePath -> runSdkManager(command)
             avdManager.absolutePath -> runAvdManager(command)
+            "/usr/sbin/scutil" -> if (command == listOf("/usr/sbin/scutil", "--proxy")) CommandResult.success(macProxyOutput) else CommandResult.failure("Unexpected scutil command: ${command.joinToString(" ")}")
+            "/sbin/ifconfig" -> if (command == listOf("/sbin/ifconfig")) CommandResult.success(hostIfconfigOutput) else CommandResult.failure("Unexpected ifconfig command: ${command.joinToString(" ")}")
             else -> CommandResult.failure("Unexpected command: ${command.joinToString(" ")}")
         }
     }
@@ -167,6 +178,28 @@ internal class MockAndroidDeviceEnvironment {
     }
 
     private fun runShell(serial: String, shell: List<String>): CommandResult {
+        if (shell.size == 5 && shell.take(4) == listOf("settings", "put", "global", "http_proxy")) {
+            httpProxyValue = shell[4]
+            return CommandResult.success()
+        }
+        if (shell == listOf("settings", "get", "global", "http_proxy")) {
+            return CommandResult.success(httpProxyValue)
+        }
+        if (shell.size == 5 && shell.take(4) == listOf("settings", "put", "global", "global_http_proxy_host")) {
+            return CommandResult.success()
+        }
+        if (shell.size == 5 && shell.take(4) == listOf("settings", "put", "global", "global_http_proxy_port")) {
+            return CommandResult.success()
+        }
+        if (shell.size == 4 && shell.take(3) == listOf("settings", "delete", "global")) {
+            return CommandResult.success()
+        }
+        if (shell == listOf("dumpsys", "connectivity")) {
+            return CommandResult.success(connectivityDump)
+        }
+        if (shell.size == 4 && shell.take(3) == listOf("ip", "route", "get")) {
+            return CommandResult.success(routeToProxyOutput)
+        }
         return when (shell) {
             listOf("getprop") -> CommandResult.success(getprop(serial))
             listOf("dumpsys", "battery") -> CommandResult.success("level: 87\nstatus: 2\n")
@@ -207,8 +240,6 @@ internal class MockAndroidDeviceEnvironment {
             listOf("chcon", "u:object_r:system_file:s0", "/system/etc/andy/cacerts/abcdef12.0", "/system/etc/security/cacerts/abcdef12.0", "/system/etc/andy/andy-ca-injector.sh", "/system/etc/init/andy-ca.rc") -> CommandResult.success()
             listOf("test", "-f", "/system/etc/andy/andy-ca-injector.sh") -> if (persistedCaInstalled) CommandResult.success() else CommandResult.failure("missing")
             listOf("sh", "/system/etc/andy/andy-ca-injector.sh") -> runtimeCaInjectionResult
-            listOf("settings", "put", "global", "http_proxy", "10.0.2.2:8888") -> CommandResult.success()
-            listOf("settings", "put", "global", "http_proxy", ":0") -> CommandResult.success()
             listOf("settings", "put", "global", "global_http_proxy_host", "10.0.2.2") -> CommandResult.success()
             listOf("settings", "put", "global", "global_http_proxy_port", "8888") -> CommandResult.success()
             listOf("settings", "delete", "global", "global_http_proxy_host") -> CommandResult.success()
@@ -232,6 +263,7 @@ internal class MockAndroidDeviceEnvironment {
             listOf("input", "swipe", "1", "2", "3", "4", "250") -> CommandResult.success()
             listOf("input", "text", "hello%sworld") -> CommandResult.success()
             listOf("input", "keyevent", "4") -> CommandResult.success()
+            listOf("am", "start", "-a", "android.settings.VPN_SETTINGS") -> CommandResult.success("Starting: Intent")
             else -> {
                 if (shell.take(2) == listOf("am", "start")) {
                     CommandResult.success("Starting: Intent")


### PR DESCRIPTION
## Summary
- add Network route diagnostics for Android VPNs, proxy route mismatches, Mac proxy state, and host VPN-like interfaces
- chain mitmproxy through the detected Mac proxy and add repair/setup UI for proxy routes
- preserve proxy start-on-launch state and cover emulator RGB frame orientation

## Tests
- ./gradlew desktopTest
- ./gradlew compileKotlinDesktop