### PR TITLE
Add Wi-Fi QR pairing, action notes, and proxy rewrite diagnostics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
                 implementation("net.peanuuutz.tomlkt:tomlkt:0.4.0")
                 implementation("com.fifesoft:rsyntaxtextarea:3.6.0")
+                implementation("com.google.zxing:core:3.5.3")
 
                 // MCP and Ktor Server Dependencies
                 implementation("io.modelcontextprotocol:kotlin-sdk:0.13.0")

--- a/src/commonMain/kotlin/app/andy/AndyApp.kt
+++ b/src/commonMain/kotlin/app/andy/AndyApp.kt
@@ -34,7 +34,7 @@ enum class AndyDestination(val label: String) {
     Files("Files & data"),
     ComputerFiles("Computer Files"),
     Network("Network"),
-    Actions("Actions"),
+    Actions("Projects"),
     Snapshots("Snapshots"),
     Controls("Controls"),
     Performance("Performance"),

--- a/src/commonMain/kotlin/app/andy/model/ActionModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/ActionModels.kt
@@ -6,6 +6,7 @@ data class ActionProject(
     val contextDir: String,
     val env: Map<String, String> = emptyMap(),
     val actions: List<ProjectAction> = emptyList(),
+    val notes: List<ProjectNote> = emptyList(),
 )
 
 data class ProjectAction(
@@ -15,6 +16,13 @@ data class ProjectAction(
     val command: String,
     val cwd: String? = null,
     val env: Map<String, String> = emptyMap(),
+)
+
+data class ProjectNote(
+    val id: String,
+    val title: String,
+    val body: String = "",
+    val completed: Boolean = false,
 )
 
 data class ActionsConfig(

--- a/src/commonMain/kotlin/app/andy/model/DeviceModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/DeviceModels.kt
@@ -14,6 +14,8 @@ data class AndroidDevice(
     val abi: String? = null,
     val model: String? = null,
     val product: String? = null,
+    /** Stable device identity (ro.serialno / mDNS adb instance body). Not the ADB transport serial. */
+    val hardwareId: String? = null,
     val batteryPercent: Int? = null,
     val screenSize: String? = null,
     val storageSummary: String? = null,
@@ -48,6 +50,23 @@ fun isWifiIpSerial(serial: String): Boolean = WifiSerialPattern.matches(serial)
 fun isMdnsAdbSerial(serial: String): Boolean =
     serial.contains("_adb-tls-connect", ignoreCase = true) || serial.contains("._tcp")
 
+fun isWirelessAdbSerial(serial: String): Boolean = isWifiIpSerial(serial) || isMdnsAdbSerial(serial)
+
+/**
+ * mDNS ADB serials look like `adb-<serial>[-suffix]._adb-tls-connect._tcp`.
+ * Returns the instance body after `adb-` when present.
+ */
+fun extractMdnsHardwareId(serial: String): String? {
+    if (!isMdnsAdbSerial(serial)) return null
+    val instance = serial.substringBefore("._").trim()
+    if (instance.isEmpty()) return null
+    val body = when {
+        instance.startsWith("adb-", ignoreCase = true) -> instance.drop(4)
+        else -> instance
+    }.trim()
+    return body.takeIf { it.isNotEmpty() }
+}
+
 fun classifyDeviceKind(serial: String): DeviceKind =
     if (serial.startsWith("emulator-")) DeviceKind.Emulator else DeviceKind.Physical
 
@@ -61,6 +80,9 @@ fun classifyDeviceTransport(serial: String): DeviceTransport = when {
 /**
  * adb often lists the same wireless device twice: once as `ip:port` (from `adb connect`)
  * and once as `adb-…._adb-tls-connect._tcp` (mDNS). Prefer the IP:port serial.
+ *
+ * Only collapse aliases when a stable hardware id is known on both sides — never by
+ * model/product alone, which would hide a second phone of the same model.
  */
 fun dedupeWifiDeviceAliases(devices: List<AndroidDevice>): List<AndroidDevice> {
     val ipWifi = devices.filter { isWifiIpSerial(it.serial) }
@@ -76,24 +98,12 @@ fun dedupeWifiDeviceAliases(devices: List<AndroidDevice>): List<AndroidDevice> {
 }
 
 private fun sameWifiDeviceIdentity(left: AndroidDevice, right: AndroidDevice): Boolean {
-    val leftModel = left.model?.replace('_', ' ')?.trim()?.lowercase().orEmpty()
-    val rightModel = right.model?.replace('_', ' ')?.trim()?.lowercase().orEmpty()
-    if (leftModel.isNotEmpty() && leftModel == rightModel) return true
-
-    val leftProduct = left.product?.trim()?.lowercase().orEmpty()
-    val rightProduct = right.product?.trim()?.lowercase().orEmpty()
-    if (leftProduct.isNotEmpty() && leftProduct == rightProduct) return true
-
-    val leftName = left.displayName.replace('_', ' ').trim().lowercase()
-    val rightName = right.displayName.replace('_', ' ').trim().lowercase()
-    if (leftName.isNotEmpty() &&
-        leftName == rightName &&
-        !isWifiIpSerial(leftName) &&
-        !isMdnsAdbSerial(leftName)
-    ) {
-        return true
-    }
-    return false
+    val leftId = left.hardwareId?.trim().orEmpty()
+    val rightId = right.hardwareId?.trim().orEmpty()
+    if (leftId.length < 4 || rightId.length < 4) return false
+    if (leftId.equals(rightId, ignoreCase = true)) return true
+    // mDNS instance bodies often append a short random suffix after ro.serialno.
+    return leftId.contains(rightId, ignoreCase = true) || rightId.contains(leftId, ignoreCase = true)
 }
 
 data class SdkDiscovery(

--- a/src/commonMain/kotlin/app/andy/model/DeviceModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/DeviceModels.kt
@@ -2,12 +2,14 @@ package app.andy.model
 
 enum class DeviceKind { Physical, Emulator, Unknown }
 enum class DeviceConnectionState { Online, Offline, Unauthorized, Missing, Unknown }
+enum class DeviceTransport { Usb, Wifi, Unknown }
 
 data class AndroidDevice(
     val serial: String,
     val displayName: String,
     val kind: DeviceKind,
     val state: DeviceConnectionState,
+    val transport: DeviceTransport = DeviceTransport.Unknown,
     val apiLevel: String? = null,
     val abi: String? = null,
     val model: String? = null,
@@ -16,6 +18,83 @@ data class AndroidDevice(
     val screenSize: String? = null,
     val storageSummary: String? = null,
 )
+
+data class MdnsService(
+    val instanceName: String,
+    val serviceType: String,
+    val host: String,
+    val port: Int,
+) {
+    val endpoint: String get() = "$host:$port"
+    val isPairing: Boolean get() = serviceType.contains("pairing", ignoreCase = true)
+    val isConnect: Boolean
+        get() = serviceType.contains("tls-connect", ignoreCase = true) ||
+            serviceType == "_adb._tcp" ||
+            serviceType.startsWith("_adb._tcp")
+}
+
+data class PairedWifiDevice(
+    val id: String,
+    val displayName: String,
+    val mdnsInstanceName: String?,
+    val lastEndpoint: String?,
+    val pairedAtMillis: Long,
+)
+
+private val WifiSerialPattern = Regex("""^\d+\.\d+\.\d+\.\d+:\d+$""")
+
+fun isWifiIpSerial(serial: String): Boolean = WifiSerialPattern.matches(serial)
+
+fun isMdnsAdbSerial(serial: String): Boolean =
+    serial.contains("_adb-tls-connect", ignoreCase = true) || serial.contains("._tcp")
+
+fun classifyDeviceKind(serial: String): DeviceKind =
+    if (serial.startsWith("emulator-")) DeviceKind.Emulator else DeviceKind.Physical
+
+fun classifyDeviceTransport(serial: String): DeviceTransport = when {
+    serial.startsWith("emulator-") -> DeviceTransport.Unknown
+    isWifiIpSerial(serial) -> DeviceTransport.Wifi
+    isMdnsAdbSerial(serial) -> DeviceTransport.Wifi
+    else -> DeviceTransport.Usb
+}
+
+/**
+ * adb often lists the same wireless device twice: once as `ip:port` (from `adb connect`)
+ * and once as `adb-…._adb-tls-connect._tcp` (mDNS). Prefer the IP:port serial.
+ */
+fun dedupeWifiDeviceAliases(devices: List<AndroidDevice>): List<AndroidDevice> {
+    val ipWifi = devices.filter { isWifiIpSerial(it.serial) }
+    if (ipWifi.isEmpty()) return devices
+
+    val drop = devices.asSequence()
+        .filter { isMdnsAdbSerial(it.serial) }
+        .filter { mdns -> ipWifi.any { ip -> sameWifiDeviceIdentity(ip, mdns) } }
+        .map { it.serial }
+        .toSet()
+    if (drop.isEmpty()) return devices
+    return devices.filterNot { it.serial in drop }
+}
+
+private fun sameWifiDeviceIdentity(left: AndroidDevice, right: AndroidDevice): Boolean {
+    val leftModel = left.model?.replace('_', ' ')?.trim()?.lowercase().orEmpty()
+    val rightModel = right.model?.replace('_', ' ')?.trim()?.lowercase().orEmpty()
+    if (leftModel.isNotEmpty() && leftModel == rightModel) return true
+
+    val leftProduct = left.product?.trim()?.lowercase().orEmpty()
+    val rightProduct = right.product?.trim()?.lowercase().orEmpty()
+    if (leftProduct.isNotEmpty() && leftProduct == rightProduct) return true
+
+    val leftName = left.displayName.replace('_', ' ').trim().lowercase()
+    val rightName = right.displayName.replace('_', ' ').trim().lowercase()
+    if (leftName.isNotEmpty() &&
+        leftName == rightName &&
+        !isWifiIpSerial(leftName) &&
+        !isMdnsAdbSerial(leftName)
+    ) {
+        return true
+    }
+    return false
+}
 
 data class SdkDiscovery(
     val sdkPath: String?,

--- a/src/commonMain/kotlin/app/andy/model/NetworkModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/NetworkModels.kt
@@ -26,6 +26,25 @@ fun ProxyRule.matches(method: String, url: String): Boolean {
     return true
 }
 
+data class ProxyStartOptions(
+    val sslInsecure: Boolean = false,
+    val upstreamTrustedCaPath: String? = null,
+)
+
+data class ProxyWarning(
+    val id: String,
+    val atMillis: Long,
+    val kind: ProxyWarningKind,
+    val message: String,
+    val sni: String? = null,
+)
+
+enum class ProxyWarningKind {
+    ClientTlsFailure,
+    UpstreamTlsFailure,
+    Other,
+}
+
 data class NetworkExchange(
     val id: String,
     val startedAtMillis: Long,
@@ -46,6 +65,28 @@ data class NetworkExchange(
     val flowId: String,
 )
 
+enum class NetworkFailureMode {
+    NotRouted,
+    ClientRejectedCa,
+    CorporateTlsInspection,
+    CaNotInstalled,
+    UnsupportedProtocol,
+}
+
+enum class NetworkDiagnosisSeverity {
+    Green,
+    Amber,
+    Red,
+}
+
+data class NetworkDiagnosis(
+    val mode: NetworkFailureMode?,
+    val severity: NetworkDiagnosisSeverity,
+    val title: String,
+    val detail: String,
+    val fix: String,
+)
+
 data class NetworkRouteDiagnostics(
     val expectedProxy: String,
     val configuredProxy: String?,
@@ -64,4 +105,156 @@ data class NetworkRouteDiagnostics(
     val issues: List<String> = emptyList(),
 ) {
     val hasBlockingIssue: Boolean get() = issues.isNotEmpty()
+}
+
+fun isUpstreamTlsVerificationError(message: String?): Boolean {
+    if (message.isNullOrBlank()) return false
+    val lower = message.lowercase()
+    return listOf(
+        "certificate verify failed",
+        "sslcertverificationerror",
+        "unable to get local issuer certificate",
+        "self signed certificate in certificate chain",
+        "upstream server tls",
+        "tls handshake failed with server",
+        "certificate_verify_failed",
+    ).any { it in lower }
+}
+
+fun isClientTlsRejectionError(message: String?): Boolean {
+    if (message.isNullOrBlank()) return false
+    val lower = message.lowercase()
+    return listOf(
+        "client rejected andy's ca",
+        "client tls handshake failed",
+        "does not trust the proxy",
+        "unknown ca",
+        "bad certificate",
+        "certificate unknown",
+        "tlsv1 alert unknown ca",
+        "sslv3 alert bad certificate",
+    ).any { it in lower }
+}
+
+fun diagnoseNetworkTraffic(
+    proxyStarted: Boolean,
+    caInstalled: Boolean,
+    proxyConfigured: Boolean,
+    routeDiagnostics: NetworkRouteDiagnostics?,
+    exchanges: List<NetworkExchange>,
+    warnings: List<ProxyWarning>,
+    clientConnectionsObserved: Int,
+    sslInsecure: Boolean,
+    upstreamTrustedCaPath: String?,
+): List<NetworkDiagnosis> {
+    if (!proxyStarted) {
+        return listOf(
+            NetworkDiagnosis(
+                mode = null,
+                severity = NetworkDiagnosisSeverity.Amber,
+                title = "Proxy is not running",
+                detail = "Andy cannot diagnose missing traffic until mitmdump is listening.",
+                fix = "Click Start to launch the proxy.",
+            ),
+        )
+    }
+
+    val successfulHttps = exchanges.any { it.tlsStatus == "tls" && it.error == null && it.statusCode != null }
+    val successfulAny = exchanges.any { it.error == null && (it.statusCode != null || it.method != "TLS") }
+    if (successfulHttps || (successfulAny && exchanges.none { it.error != null })) {
+        val chaining = routeDiagnostics?.hostUpstreamProxy
+        return listOf(
+            NetworkDiagnosis(
+                mode = null,
+                severity = NetworkDiagnosisSeverity.Green,
+                title = if (chaining != null) "Capturing traffic (chaining through $chaining)" else "Capturing traffic",
+                detail = "HTTPS flows are reaching Andy and completing successfully.",
+                fix = "",
+            ),
+        )
+    }
+
+    val diagnoses = mutableListOf<NetworkDiagnosis>()
+    val tlsFailed = exchanges.filter { it.method == "TLS" || isClientTlsRejectionError(it.error) }
+    val upstreamErrors = exchanges.filter { isUpstreamTlsVerificationError(it.error) } +
+        warnings.filter { it.kind == ProxyWarningKind.UpstreamTlsFailure }
+    val clientWarnings = warnings.filter { it.kind == ProxyWarningKind.ClientTlsFailure }
+
+    if (upstreamErrors.isNotEmpty() || (routeDiagnostics?.hostProxyActive == true && exchanges.any { it.error != null && isUpstreamTlsVerificationError(it.error) })) {
+        val proxyLabel = routeDiagnostics?.hostUpstreamProxy ?: routeDiagnostics?.hostProxySummary ?: "corporate proxy"
+        val hasMitigation = sslInsecure || !upstreamTrustedCaPath.isNullOrBlank()
+        diagnoses += NetworkDiagnosis(
+            mode = NetworkFailureMode.CorporateTlsInspection,
+            severity = NetworkDiagnosisSeverity.Red,
+            title = "Upstream TLS verification failed — corporate TLS inspection",
+            detail = "Andy appears to be behind a corporate TLS-inspection proxy ($proxyLabel). mitmproxy cannot verify the real server certificate because it was re-signed by the corporate root.",
+            fix = if (hasMitigation) {
+                "Corporate CA / insecure-upstream is configured; restart the proxy if traffic still fails."
+            } else {
+                "Add your corporate root CA path or enable insecure-upstream in Network setup / Settings, then restart the proxy."
+            },
+        )
+    }
+
+    if (tlsFailed.isNotEmpty() || clientWarnings.isNotEmpty()) {
+        val host = tlsFailed.firstOrNull()?.url?.removePrefix("https://")?.substringBefore('/')
+            ?: clientWarnings.firstOrNull()?.sni
+            ?: "the app"
+        diagnoses += NetworkDiagnosis(
+            mode = NetworkFailureMode.ClientRejectedCa,
+            severity = NetworkDiagnosisSeverity.Red,
+            title = "$host rejected Andy's CA",
+            detail = "The app connected to Andy but rejected the proxy certificate during the TLS handshake. Likely certificate pinning, a custom TrustManager/SSLSocketFactory, or missing user-CA trust.",
+            fix = "Disable pinning in your debug build, trust user CAs via network_security_config, or install Andy's System CA.",
+        )
+    }
+
+    if (!caInstalled && exchanges.none { it.tlsStatus == "tls" && it.error == null }) {
+        diagnoses += NetworkDiagnosis(
+            mode = NetworkFailureMode.CaNotInstalled,
+            severity = NetworkDiagnosisSeverity.Red,
+            title = "Andy CA is not installed as a system trust",
+            detail = "Without system (or verified user) CA trust, HTTPS clients will reject Andy's MITM certificate and produce no decryptable traffic.",
+            fix = "Use System CA (root) on a writable emulator, or Prepare phone CA and finish the install on-device for debug apps that trust user CAs.",
+        )
+    }
+
+    val routeIssues = routeDiagnostics?.issues.orEmpty()
+    val noHttpTraffic = exchanges.none { it.method != "TLS" }
+    if (noHttpTraffic && (routeIssues.isNotEmpty() || !proxyConfigured || clientConnectionsObserved == 0)) {
+        val detail = when {
+            routeIssues.isNotEmpty() -> routeIssues.joinToString(" ")
+            !proxyConfigured -> "Android's global HTTP proxy is not pointed at Andy."
+            clientConnectionsObserved == 0 -> "No TCP client has connected to mitmdump yet — traffic is not reaching Andy (VPN, proxy override, or QUIC/UDP)."
+            else -> "Clients connected but no HTTP request was captured — the app may bypass the proxy or use QUIC/HTTP3."
+        }
+        diagnoses += NetworkDiagnosis(
+            mode = NetworkFailureMode.NotRouted,
+            severity = NetworkDiagnosisSeverity.Red,
+            title = "No client traffic is reaching Andy",
+            detail = detail,
+            fix = "Repair proxy route, disable/split-tunnel VPN, remove app-level Proxy.NO_PROXY, and force HTTP/1.1 if the app prefers QUIC.",
+        )
+    }
+
+    if (noHttpTraffic && clientConnectionsObserved > 0 && tlsFailed.isEmpty() && upstreamErrors.isEmpty()) {
+        diagnoses += NetworkDiagnosis(
+            mode = NetworkFailureMode.UnsupportedProtocol,
+            severity = NetworkDiagnosisSeverity.Amber,
+            title = "Connected but no HTTP/HTTPS flows",
+            detail = "A client reached Andy without producing decryptable HTTP traffic. QUIC/HTTP3, WebSocket upgrades, or gRPC quirks can look like an empty capture.",
+            fix = "Disable Private DNS / QUIC in the debug app or force HTTP/1.1 for the endpoints you need to inspect.",
+        )
+    }
+
+    if (diagnoses.isEmpty()) {
+        diagnoses += NetworkDiagnosis(
+            mode = null,
+            severity = NetworkDiagnosisSeverity.Amber,
+            title = "Waiting for traffic",
+            detail = "Proxy is running. Make a request from a debug app that trusts Andy's CA.",
+            fix = "Configure the device proxy, install the CA if needed, then exercise the app.",
+        )
+    }
+    return diagnoses.distinctBy { it.mode to it.title }
 }

--- a/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
@@ -7,6 +7,7 @@ data class WorkspaceState(
     val logSearch: String = "",
     val enabledLogLevels: Set<LogLevel> = setOf(LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal),
     val proxyRules: List<ProxyRule> = emptyList(),
+    val pairedWifiDevices: List<PairedWifiDevice> = emptyList(),
     val proxyPort: Int = 9099,
     val proxyStartOnLaunch: Boolean = false,
     val mcpServerEnabled: Boolean = false,

--- a/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
@@ -10,6 +10,8 @@ data class WorkspaceState(
     val pairedWifiDevices: List<PairedWifiDevice> = emptyList(),
     val proxyPort: Int = 9099,
     val proxyStartOnLaunch: Boolean = false,
+    val proxySslInsecure: Boolean = false,
+    val proxyUpstreamTrustedCaPath: String? = null,
     val mcpServerEnabled: Boolean = false,
     val mcpServerPort: Int = 8565,
     val workspaceSidebarExpanded: Boolean = true,

--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -8,6 +8,12 @@ interface DeviceService {
     suspend fun discoverSdk(): SdkDiscovery
     suspend fun listDevices(): List<AndroidDevice>
     suspend fun shell(serial: String, command: List<String>): CommandResult
+    suspend fun pair(host: String, port: Int, code: String): CommandResult
+    suspend fun connect(host: String, port: Int): CommandResult
+    suspend fun disconnect(serial: String): CommandResult
+    suspend fun listMdnsServices(): List<MdnsService>
+    suspend fun mdnsAvailable(): Boolean
+    suspend fun generatePairingQr(content: String): ByteArray?
 }
 
 interface AvdService {

--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -88,10 +88,12 @@ interface HostFileService {
 interface ProxyService {
     val exchanges: Flow<List<NetworkExchange>>
     val status: Flow<String>
+    val warnings: Flow<List<ProxyWarning>>
+    val clientConnectionCount: Flow<Int>
     suspend fun detectMitmproxy(): CommandResult
     suspend fun ensureCertificateAuthority(): CommandResult
     suspend fun certificateAuthorityPath(): String
-    suspend fun start(port: Int, rules: List<ProxyRule>): CommandResult
+    suspend fun start(port: Int, rules: List<ProxyRule>, options: ProxyStartOptions = ProxyStartOptions()): CommandResult
     suspend fun updateRules(rules: List<ProxyRule>): CommandResult
     suspend fun clearTraffic(): CommandResult
     suspend fun stop(): CommandResult

--- a/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -51,6 +51,7 @@ import app.andy.model.ActionProject
 import app.andy.model.ActionRunStatus
 import app.andy.model.ActionsConfig
 import app.andy.model.ProjectAction
+import app.andy.model.ProjectNote
 import app.andy.model.RunningAction
 import app.andy.pickDirectory
 import app.andy.service.AndyServices
@@ -93,6 +94,7 @@ internal fun actionIconMarker(icon: String): String = when (icon.trim().lowercas
 
 private data class EditingProject(val project: ActionProject?)
 private data class EditingAction(val projectId: String, val action: ProjectAction?)
+private data class EditingNote(val projectId: String, val note: ProjectNote?)
 
 @Composable
 internal fun ActionsScreen(
@@ -105,8 +107,10 @@ internal fun ActionsScreen(
 ) {
     var editingProject by remember { mutableStateOf<EditingProject?>(null) }
     var editingAction by remember { mutableStateOf<EditingAction?>(null) }
+    var editingNote by remember { mutableStateOf<EditingNote?>(null) }
     var pendingConfirmation by remember { mutableStateOf<PendingConfirmation?>(null) }
     var catalogPaneWidth by remember { mutableStateOf(560f) }
+    var showCompletedByProject by remember { mutableStateOf(emptyMap<String, Boolean>()) }
 
     val runningIds = remember(running) { running.map { it.runId } }
     LaunchedEffect(runningIds) {
@@ -117,7 +121,17 @@ internal fun ActionsScreen(
 
     fun upsertProject(project: ActionProject) {
         val exists = config.projects.any { it.id == project.id }
-        onConfigChange(config.copy(projects = if (exists) config.projects.map { if (it.id == project.id) project.copy(actions = it.actions) else it } else config.projects + project))
+        onConfigChange(
+            config.copy(
+                projects = if (exists) {
+                    config.projects.map {
+                        if (it.id == project.id) project.copy(actions = it.actions, notes = it.notes) else it
+                    }
+                } else {
+                    config.projects + project
+                },
+            ),
+        )
     }
 
     fun upsertAction(projectId: String, previousProjectId: String?, action: ProjectAction) {
@@ -134,14 +148,53 @@ internal fun ActionsScreen(
         )
     }
 
+    fun upsertNote(projectId: String, note: ProjectNote) {
+        onConfigChange(
+            config.copy(
+                projects = config.projects.map { project ->
+                    if (project.id == projectId) {
+                        project.copy(notes = project.notes.filterNot { it.id == note.id } + note)
+                    } else {
+                        project
+                    }
+                },
+            ),
+        )
+    }
+
+    fun updateNote(projectId: String, note: ProjectNote) {
+        onConfigChange(
+            config.copy(
+                projects = config.projects.map { project ->
+                    if (project.id == projectId) {
+                        project.copy(notes = project.notes.map { if (it.id == note.id) note else it })
+                    } else {
+                        project
+                    }
+                },
+            ),
+        )
+    }
+
+    val actionCount = config.projects.sumOf { it.actions.size }
+    val noteCount = config.projects.sumOf { it.notes.size }
+
     Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         Column(Modifier.width(catalogPaneWidth.dp).fillMaxHeight(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            Toolbar("Actions", "${config.projects.size} projects / ${config.projects.sumOf { it.actions.size }} actions", onPrimary = { editingProject = EditingProject(null) }, primaryLabel = "new project")
+            Toolbar(
+                "Projects",
+                "${config.projects.size} projects / $actionCount actions / $noteCount notes",
+                onPrimary = { editingProject = EditingProject(null) },
+                primaryLabel = "new project",
+            )
             if (config.projects.isEmpty()) {
-                EmptyState("no action projects yet")
+                EmptyState("no projects yet")
             } else {
                 LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxSize()) {
                     items(config.projects, key = { it.id }) { project ->
+                        val showCompleted = showCompletedByProject[project.id] == true
+                        val visibleNotes = if (showCompleted) project.notes else project.notes.filterNot { it.completed }
+                        val completedCount = project.notes.count { it.completed }
                         PanelCard {
                             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                 Column(Modifier.weight(1f)) {
@@ -150,8 +203,12 @@ internal fun ActionsScreen(
                                 }
                                 OutlinedButton(onClick = { editingProject = EditingProject(project) }) { Text("edit") }
                                 OutlinedButton(onClick = { editingAction = EditingAction(project.id, null) }) { Text("+ action") }
+                                OutlinedButton(onClick = { editingNote = EditingNote(project.id, null) }) { Text("+ note") }
                                 OutlinedButton(onClick = {
-                                    pendingConfirmation = PendingConfirmation("Delete project?", "${project.name} and ${project.actions.size} actions") {
+                                    pendingConfirmation = PendingConfirmation(
+                                        "Delete project?",
+                                        "${project.name}, ${project.actions.size} actions, ${project.notes.size} notes",
+                                    ) {
                                         onConfigChange(config.copy(projects = config.projects.filterNot { it.id == project.id }))
                                     }
                                 }) { Text("del") }
@@ -193,6 +250,106 @@ internal fun ActionsScreen(
                                                 modifier = Modifier.height(30.dp),
                                                 contentPadding = PaddingValues(horizontal = 12.dp, vertical = 2.dp),
                                             ) { Text(if (liveRun != null) "stop" else "run", fontSize = 11.sp) }
+                                        }
+                                    }
+                                }
+                            }
+                            Spacer(Modifier.height(8.dp))
+                            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Text("Notes", color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 11.sp)
+                                Spacer(Modifier.weight(1f))
+                                if (completedCount > 0) {
+                                    FilterPill("show completed ($completedCount)", showCompleted, Cyan) {
+                                        showCompletedByProject = showCompletedByProject + (project.id to !showCompleted)
+                                    }
+                                    if (showCompleted) {
+                                        OutlinedButton(
+                                            onClick = {
+                                                pendingConfirmation = PendingConfirmation(
+                                                    "Clear completed notes?",
+                                                    "$completedCount completed note(s) in ${project.name}",
+                                                ) {
+                                                    onConfigChange(
+                                                        config.copy(
+                                                            projects = config.projects.map {
+                                                                if (it.id == project.id) it.copy(notes = it.notes.filterNot { note -> note.completed }) else it
+                                                            },
+                                                        ),
+                                                    )
+                                                }
+                                            },
+                                            modifier = Modifier.height(30.dp),
+                                            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                                        ) { Text("clear completed", fontSize = 11.sp) }
+                                    }
+                                }
+                            }
+                            if (visibleNotes.isEmpty()) {
+                                Text(
+                                    if (project.notes.isEmpty()) "no notes" else "no open notes",
+                                    color = TextSecondary,
+                                    fontFamily = MonoFont,
+                                    fontSize = 12.sp,
+                                )
+                            } else {
+                                visibleNotes.forEach { note ->
+                                    Row(
+                                        Modifier.fillMaxWidth().padding(top = 4.dp),
+                                        verticalAlignment = Alignment.Top,
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    ) {
+                                        Column(
+                                            Modifier.weight(1f)
+                                                .background(AndyColors.Neutral900.copy(alpha = 0.72f))
+                                                .border(1.dp, Color.White.copy(alpha = 0.05f))
+                                                .padding(horizontal = 8.dp, vertical = 6.dp),
+                                        ) {
+                                            Text(
+                                                note.title,
+                                                color = if (note.completed) TextSecondary else TextPrimary,
+                                                fontFamily = MonoFont,
+                                                fontWeight = FontWeight.SemiBold,
+                                                fontSize = 12.sp,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                            if (note.body.isNotBlank()) {
+                                                Text(
+                                                    note.body,
+                                                    color = TextSecondary,
+                                                    fontFamily = MonoFont,
+                                                    fontSize = 11.sp,
+                                                    maxLines = 3,
+                                                    overflow = TextOverflow.Ellipsis,
+                                                )
+                                            }
+                                        }
+                                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            OutlinedButton(
+                                                onClick = { updateNote(project.id, note.copy(completed = !note.completed)) },
+                                                modifier = Modifier.height(30.dp),
+                                                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                                            ) { Text(if (note.completed) "undo" else "done", fontSize = 11.sp) }
+                                            OutlinedButton(
+                                                onClick = { editingNote = EditingNote(project.id, note) },
+                                                modifier = Modifier.height(30.dp),
+                                                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                                            ) { Text("edit", fontSize = 11.sp) }
+                                            OutlinedButton(
+                                                onClick = {
+                                                    pendingConfirmation = PendingConfirmation("Delete note?", note.title) {
+                                                        onConfigChange(
+                                                            config.copy(
+                                                                projects = config.projects.map {
+                                                                    if (it.id == project.id) it.copy(notes = it.notes.filterNot { row -> row.id == note.id }) else it
+                                                                },
+                                                            ),
+                                                        )
+                                                    }
+                                                },
+                                                modifier = Modifier.height(30.dp),
+                                                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                                            ) { Text("del", fontSize = 11.sp) }
                                         }
                                     }
                                 }
@@ -249,6 +406,12 @@ internal fun ActionsScreen(
         ActionDialog(config.projects, editing.projectId, editing.action, onDismiss = { editingAction = null }) { targetProjectId, action ->
             editingAction = null
             upsertAction(targetProjectId, editing.projectId, action)
+        }
+    }
+    editingNote?.let { editing ->
+        NoteDialog(config.projects, editing.projectId, editing.note, onDismiss = { editingNote = null }) { note ->
+            editingNote = null
+            upsertNote(editing.projectId, note)
         }
     }
     pendingConfirmation?.let { confirmation ->
@@ -334,7 +497,18 @@ private fun ProjectDialog(project: ActionProject?, existingProjects: List<Action
         },
         confirmButton = {
             Button(
-                onClick = { onSave(ActionProject(project?.id ?: nextId, name.trim(), contextDir.trim(), parseEnvLines(envText), project?.actions.orEmpty())) },
+                onClick = {
+                    onSave(
+                        ActionProject(
+                            id = project?.id ?: nextId,
+                            name = name.trim(),
+                            contextDir = contextDir.trim(),
+                            env = parseEnvLines(envText),
+                            actions = project?.actions.orEmpty(),
+                            notes = project?.notes.orEmpty(),
+                        ),
+                    )
+                },
                 enabled = name.isNotBlank() && contextDir.isNotBlank(),
                 colors = primaryButtonColors(),
             ) { Text("Save") }
@@ -399,6 +573,48 @@ private fun ActionDialog(projects: List<ActionProject>, initialProjectId: String
             Button(
                 onClick = { onSave(selectedProjectId, ProjectAction(action?.id ?: nextId, name.trim(), icon, command.trim(), cwd.trim().takeIf { it.isNotBlank() }, parseEnvLines(envText))) },
                 enabled = projects.any { it.id == selectedProjectId } && name.isNotBlank() && command.isNotBlank(),
+                colors = primaryButtonColors(),
+            ) { Text("Save") }
+        },
+        dismissButton = { OutlinedButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun NoteDialog(
+    projects: List<ActionProject>,
+    projectId: String,
+    note: ProjectNote?,
+    onDismiss: () -> Unit,
+    onSave: (ProjectNote) -> Unit,
+) {
+    var title by remember(note?.id) { mutableStateOf(note?.title.orEmpty()) }
+    var body by remember(note?.id) { mutableStateOf(note?.body.orEmpty()) }
+    val noteIds = projects.flatMap { it.notes }.map { it.id }.toSet()
+    val nextId = remember(noteIds, title) { nextActionId("note", title, noteIds) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Panel,
+        title = { Text(if (note == null) "New note" else "Edit note", color = TextPrimary, fontWeight = FontWeight.Bold) },
+        text = {
+            Column(Modifier.width(660.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                LabeledField("Title", title, { title = it }, Modifier.fillMaxWidth())
+                LabeledField("Body", body, { body = it }, Modifier.fillMaxWidth(), singleLine = false, minHeight = 160.dp)
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onSave(
+                        ProjectNote(
+                            id = note?.id ?: nextId,
+                            title = title.trim(),
+                            body = body.trim(),
+                            completed = note?.completed == true,
+                        ),
+                    )
+                },
+                enabled = projects.any { it.id == projectId } && title.isNotBlank(),
                 colors = primaryButtonColors(),
             ) { Text("Save") }
         },

--- a/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreen.kt
@@ -309,13 +309,11 @@ internal fun DevicesScreen(
                                 OutlinedButton(onClick = {
                                     state.wifiStatus = "Disconnecting ${live.serial}..."
                                     onDisconnectWifi(live.serial)
-                                    state.wifiStatus = "Disconnected ${live.serial}"
                                 }) { Text("Disconnect") }
                             } else {
                                 OutlinedButton(onClick = {
                                     state.wifiStatus = "Reconnecting ${paired.displayName}..."
                                     onReconnectPairedWifi(paired)
-                                    state.wifiStatus = "Reconnect requested for ${paired.displayName}"
                                 }) { Text("Reconnect") }
                             }
                             OutlinedButton(onClick = {

--- a/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreen.kt
@@ -51,6 +51,8 @@ import app.andy.model.AvdCreationConfig
 import app.andy.model.AvdProfile
 import app.andy.model.DeviceConnectionState
 import app.andy.model.DeviceKind
+import app.andy.model.DeviceTransport
+import app.andy.model.PairedWifiDevice
 import app.andy.model.SdkDiscovery
 import app.andy.model.SystemImage
 import app.andy.model.VirtualDevice
@@ -89,6 +91,7 @@ internal fun DevicesScreen(
     services: AndyServices,
     devices: List<AndroidDevice>,
     sdk: SdkDiscovery,
+    pairedWifiDevices: List<PairedWifiDevice>,
     onRefresh: () -> Unit,
     onLive: (String) -> Unit,
     onEmulatorStarted: (Set<String>, String) -> Unit,
@@ -97,6 +100,10 @@ internal fun DevicesScreen(
     stopStatus: String,
     startingEmulatorName: String?,
     startStatus: String,
+    onSavePairedWifi: (PairedWifiDevice) -> Unit,
+    onForgetPairedWifi: (String) -> Unit,
+    onReconnectPairedWifi: (PairedWifiDevice) -> Unit,
+    onDisconnectWifi: (String) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val state = remember(services.avd) { DevicesScreenState(services.avd) }
@@ -144,6 +151,7 @@ internal fun DevicesScreen(
                 FilterPill(filter.label, state.deviceFilter == filter, if (state.deviceFilter == filter) Rust else Cyan) { state.deviceFilter = filter }
             }
             Spacer(Modifier.weight(1f))
+            OutlinedButton(onClick = { state.showPairDialog = true }) { Text("Pair over Wi‑Fi") }
             Button(onClick = { state.showCreateWizard = true }, colors = primaryButtonColors()) { Text("Create virtual device") }
         }
         if (sdk.issues.isNotEmpty()) {
@@ -261,6 +269,69 @@ internal fun DevicesScreen(
                 }
             }
         }
+        PanelCard {
+            Text("Wireless devices", color = TextPrimary, fontWeight = FontWeight.Bold)
+            if (state.wifiStatus.isNotBlank()) {
+                Text(state.wifiStatus, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+            }
+            if (pairedWifiDevices.isEmpty()) {
+                Text("No remembered Wi‑Fi devices. Use Pair over Wi‑Fi to add one.", color = TextSecondary, fontSize = 12.sp)
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    pairedWifiDevices.forEach { paired ->
+                        val live = findLiveWifiDevice(devices, paired)
+                        val online = live?.state == DeviceConnectionState.Online
+                        Row(
+                            Modifier.fillMaxWidth()
+                                .heightIn(min = 48.dp)
+                                .background(PanelSoft, RoundedCornerShape(AndyRadius.R4))
+                                .border(1.dp, Border, RoundedCornerShape(AndyRadius.R4))
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            Column(Modifier.weight(1f)) {
+                                Text(paired.displayName, color = TextPrimary, fontWeight = FontWeight.Bold)
+                                Text(
+                                    listOfNotNull(paired.mdnsInstanceName, paired.lastEndpoint, live?.serial)
+                                        .distinct()
+                                        .joinToString(" · "),
+                                    color = TextSecondary,
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 11.sp,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            StatusTag(if (online) "connected" else "disconnected", if (online) Green else TextSecondary)
+                            if (live != null && online) {
+                                OutlinedButton(onClick = { onLive(live.serial) }) { Text("Live") }
+                                OutlinedButton(onClick = {
+                                    state.wifiStatus = "Disconnecting ${live.serial}..."
+                                    onDisconnectWifi(live.serial)
+                                    state.wifiStatus = "Disconnected ${live.serial}"
+                                }) { Text("Disconnect") }
+                            } else {
+                                OutlinedButton(onClick = {
+                                    state.wifiStatus = "Reconnecting ${paired.displayName}..."
+                                    onReconnectPairedWifi(paired)
+                                    state.wifiStatus = "Reconnect requested for ${paired.displayName}"
+                                }) { Text("Reconnect") }
+                            }
+                            OutlinedButton(onClick = {
+                                state.pendingConfirmation = PendingConfirmation(
+                                    "Forget ${paired.displayName}?",
+                                    "Removes this device from Andy's remembered Wi‑Fi list. It does not unpair on the phone.",
+                                ) {
+                                    onForgetPairedWifi(paired.id)
+                                    state.wifiStatus = "Forgot ${paired.displayName}"
+                                }
+                            }) { Text("Forget") }
+                        }
+                    }
+                }
+            }
+        }
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             items(filteredDevices) { device ->
                 val online = device.state == DeviceConnectionState.Online
@@ -281,7 +352,12 @@ internal fun DevicesScreen(
                     }
                     Text("API ${device.apiLevel ?: "-"}\n${device.abi ?: "-"}", color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.width(170.dp))
                     Text(device.storageSummary ?: "-", color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.width(150.dp))
-                    StatusTag(device.state.name, if (online) Green else TextSecondary, Modifier.weight(1f))
+                    Row(Modifier.weight(1f), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                        StatusTag(device.state.name, if (online) Green else TextSecondary)
+                        if (device.transport == DeviceTransport.Wifi) {
+                            StatusTag("Wi‑Fi", Cyan)
+                        }
+                    }
                     OutlinedButton(onClick = { onLive(device.serial) }) { Text("Live") }
                     if (device.kind == DeviceKind.Emulator && online) {
                         Spacer(Modifier.width(8.dp))
@@ -295,7 +371,7 @@ internal fun DevicesScreen(
                 }
             }
         }
-        if (devices.isEmpty()) EmptyState("No connected Android devices. Connect USB debugging or start an emulator.")
+        if (devices.isEmpty()) EmptyState("No connected Android devices. Connect USB debugging, pair over Wi‑Fi, or start an emulator.")
         if (state.showCreateWizard) {
             CreateVirtualDeviceDialog(
                 avd = state.avd,
@@ -304,6 +380,18 @@ internal fun DevicesScreen(
                     state.avdStatus = it
                     state.showCreateWizard = false
                     refreshAvds()
+                    onRefresh()
+                },
+            )
+        }
+        if (state.showPairDialog) {
+            PairOverWifiDialog(
+                devices = services.devices,
+                onDismiss = { state.showPairDialog = false },
+                onPaired = { paired, message ->
+                    onSavePairedWifi(paired)
+                    state.wifiStatus = message
+                    state.showPairDialog = false
                     onRefresh()
                 },
             )

--- a/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreenState.kt
+++ b/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreenState.kt
@@ -16,6 +16,8 @@ internal class DevicesScreenState(
     var deviceQuery by mutableStateOf("")
     var deviceFilter by mutableStateOf(DeviceListFilter.All)
     var showCreateWizard by mutableStateOf(false)
+    var showPairDialog by mutableStateOf(false)
+    var wifiStatus by mutableStateOf("")
     var pendingConfirmation by mutableStateOf<PendingConfirmation?>(null)
     var cloneSource by mutableStateOf<VirtualDevice?>(null)
 }

--- a/src/commonMain/kotlin/app/andy/ui/devices/PairOverWifiDialog.kt
+++ b/src/commonMain/kotlin/app/andy/ui/devices/PairOverWifiDialog.kt
@@ -1,0 +1,321 @@
+package app.andy.ui.devices
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.andy.loadImageBitmap
+import app.andy.model.MdnsService
+import app.andy.model.PairedWifiDevice
+import app.andy.service.DeviceService
+import app.andy.ui.components.Button
+import app.andy.ui.components.FilterPill
+import app.andy.ui.components.LabeledField
+import app.andy.ui.components.OutlinedButton
+import app.andy.ui.components.primaryButtonColors
+import app.andy.ui.theme.AndyRadius
+import app.andy.ui.theme.Border
+import app.andy.ui.theme.Panel
+import app.andy.ui.theme.PanelSoft
+import app.andy.ui.theme.Rust
+import app.andy.ui.theme.TextPrimary
+import app.andy.ui.theme.TextSecondary
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private enum class WifiPairTab { Discover, PairingCode, Qr }
+
+@Composable
+internal fun PairOverWifiDialog(
+    devices: DeviceService,
+    onDismiss: () -> Unit,
+    onPaired: (PairedWifiDevice, String) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    var tab by remember { mutableStateOf(WifiPairTab.Discover) }
+    var status by remember { mutableStateOf("Ready") }
+    var busy by remember { mutableStateOf(false) }
+    var mdnsReady by remember { mutableStateOf<Boolean?>(null) }
+    var mdnsServices by remember { mutableStateOf<List<MdnsService>>(emptyList()) }
+    var pairingEndpoint by remember { mutableStateOf("") }
+    var pairingCode by remember { mutableStateOf("") }
+    var connectEndpoint by remember { mutableStateOf("") }
+    var discoverCode by remember { mutableStateOf("") }
+    var selectedPairing by remember { mutableStateOf<MdnsService?>(null) }
+    val qrName = remember { "Andy${(100000..999999).random()}" }
+    val qrPassword = remember { (100000..999999).random().toString() }
+    var qrBytes by remember { mutableStateOf<ByteArray?>(null) }
+    val qrBitmap = remember(qrBytes) { qrBytes?.let { loadImageBitmap(it) } }
+
+    LaunchedEffect(Unit) {
+        mdnsReady = runCatching { devices.mdnsAvailable() }.getOrDefault(false)
+        qrBytes = devices.generatePairingQr("WIFI:T:ADB;S:$qrName;P:$qrPassword;;")
+    }
+
+    LaunchedEffect(tab, mdnsReady) {
+        if (mdnsReady != true) return@LaunchedEffect
+        if (tab != WifiPairTab.Discover && tab != WifiPairTab.Qr) return@LaunchedEffect
+        while (true) {
+            mdnsServices = runCatching { devices.listMdnsServices() }.getOrDefault(emptyList())
+            if (tab == WifiPairTab.Qr) {
+                val pairing = mdnsServices.firstOrNull { it.isPairing && it.instanceName.equals(qrName, ignoreCase = true) }
+                if (pairing != null && !busy) {
+                    busy = true
+                    status = "QR service found — pairing..."
+                    val (result, paired) = pairThenConnect(
+                        devices = devices,
+                        pairHost = pairing.host,
+                        pairPort = pairing.port,
+                        code = qrPassword,
+                        preferredInstanceName = qrName,
+                    )
+                    if (paired != null && result.isSuccess) {
+                        onPaired(paired, result.stdout.ifBlank { "Paired via QR" })
+                        return@LaunchedEffect
+                    }
+                    status = result.stderr.ifBlank { result.stdout }.ifBlank { "QR pairing failed" }
+                    busy = false
+                }
+            }
+            delay(2_000)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Panel,
+        title = { Text("Pair over Wi‑Fi", color = TextPrimary, fontWeight = FontWeight.Bold) },
+        text = {
+            Column(Modifier.width(720.dp).heightIn(max = 560.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterPill("Discover", tab == WifiPairTab.Discover, Rust) { tab = WifiPairTab.Discover }
+                    FilterPill("Pairing code", tab == WifiPairTab.PairingCode, Rust) { tab = WifiPairTab.PairingCode }
+                    FilterPill("QR code", tab == WifiPairTab.Qr, Rust) { tab = WifiPairTab.Qr }
+                }
+                Text(status, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                if (mdnsReady == false) {
+                    Text(
+                        "adb mdns is unavailable on this SDK. Use the Pairing code tab with IP:port from Wireless debugging.",
+                        color = Rust,
+                        fontSize = 12.sp,
+                    )
+                }
+                when (tab) {
+                    WifiPairTab.Discover -> {
+                        val pairing = mdnsServices.filter { it.isPairing }
+                        val connectable = mdnsServices.filter { it.isConnect }
+                        if (pairing.isEmpty() && connectable.isEmpty()) {
+                            Text(
+                                "No mDNS services yet. On the phone open Developer options → Wireless debugging, then Pair device with pairing code.",
+                                color = TextSecondary,
+                                fontSize = 12.sp,
+                            )
+                        }
+                        if (pairing.isNotEmpty()) {
+                            Text("Pairable", color = TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 12.sp)
+                            pairing.forEach { service ->
+                                Row(
+                                    Modifier.fillMaxWidth()
+                                        .background(PanelSoft, RoundedCornerShape(AndyRadius.R4))
+                                        .border(1.dp, Border, RoundedCornerShape(AndyRadius.R4))
+                                        .padding(10.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    Column(Modifier.weight(1f)) {
+                                        Text(service.instanceName, color = TextPrimary, fontWeight = FontWeight.Bold)
+                                        Text("${service.endpoint} · ${service.serviceType}", color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                                    }
+                                    OutlinedButton(
+                                        onClick = { selectedPairing = service },
+                                        enabled = !busy,
+                                    ) { Text(if (selectedPairing == service) "Selected" else "Select") }
+                                }
+                            }
+                            if (selectedPairing != null) {
+                                LabeledField("6-digit pairing code", discoverCode, {
+                                    discoverCode = it.filter { ch -> ch.isDigit() }.take(6)
+                                }, Modifier.fillMaxWidth(), placeholder = "123456")
+                                Button(
+                                    onClick = {
+                                        val service = selectedPairing ?: return@Button
+                                        scope.launch {
+                                            busy = true
+                                            status = "Pairing ${service.instanceName}..."
+                                            val (result, paired) = pairThenConnect(
+                                                devices = devices,
+                                                pairHost = service.host,
+                                                pairPort = service.port,
+                                                code = discoverCode,
+                                                preferredInstanceName = service.instanceName,
+                                            )
+                                            if (paired != null && result.isSuccess) {
+                                                onPaired(paired, result.stdout.ifBlank { "Paired ${service.instanceName}" })
+                                            } else {
+                                                status = result.stderr.ifBlank { result.stdout }.ifBlank { "Pairing failed" }
+                                                busy = false
+                                            }
+                                        }
+                                    },
+                                    enabled = !busy && discoverCode.length == 6,
+                                    colors = primaryButtonColors(),
+                                ) { Text("Pair & connect") }
+                            }
+                        }
+                        if (connectable.isNotEmpty()) {
+                            Text("Already connectable", color = TextPrimary, fontWeight = FontWeight.SemiBold, fontSize = 12.sp)
+                            connectable.forEach { service ->
+                                Row(
+                                    Modifier.fillMaxWidth()
+                                        .background(PanelSoft, RoundedCornerShape(AndyRadius.R4))
+                                        .border(1.dp, Border, RoundedCornerShape(AndyRadius.R4))
+                                        .padding(10.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    Column(Modifier.weight(1f)) {
+                                        Text(service.instanceName, color = TextPrimary, fontWeight = FontWeight.Bold)
+                                        Text(service.endpoint, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp)
+                                    }
+                                    OutlinedButton(
+                                        onClick = {
+                                            scope.launch {
+                                                busy = true
+                                                status = "Connecting ${service.endpoint}..."
+                                                val result = devices.connect(service.host, service.port)
+                                                if (result.isSuccess) {
+                                                    val paired = PairedWifiDevice(
+                                                        id = "wifi-${System.currentTimeMillis()}-${service.endpoint.hashCode().toUInt()}",
+                                                        displayName = service.instanceName,
+                                                        mdnsInstanceName = service.instanceName,
+                                                        lastEndpoint = service.endpoint,
+                                                        pairedAtMillis = System.currentTimeMillis(),
+                                                    )
+                                                    onPaired(paired, result.stdout.ifBlank { "Connected to ${service.endpoint}" })
+                                                } else {
+                                                    status = result.stderr.ifBlank { result.stdout }.ifBlank { "Connect failed" }
+                                                    busy = false
+                                                }
+                                            }
+                                        },
+                                        enabled = !busy,
+                                    ) { Text("Connect") }
+                                }
+                            }
+                        }
+                    }
+                    WifiPairTab.PairingCode -> {
+                        Text(
+                            "On the phone: Developer options → Wireless debugging → Pair device with pairing code.",
+                            color = TextSecondary,
+                            fontSize = 12.sp,
+                        )
+                        LabeledField("Pairing IP:port", pairingEndpoint, { pairingEndpoint = it }, Modifier.fillMaxWidth(), placeholder = "192.168.1.20:37199")
+                        LabeledField("6-digit code", pairingCode, {
+                            pairingCode = it.filter { ch -> ch.isDigit() }.take(6)
+                        }, Modifier.fillMaxWidth(), placeholder = "123456")
+                        LabeledField(
+                            "Connect IP:port (optional)",
+                            connectEndpoint,
+                            { connectEndpoint = it },
+                            Modifier.fillMaxWidth(),
+                            placeholder = "192.168.1.20:5555",
+                        )
+                        Button(
+                            onClick = {
+                                val pairTarget = parseHostPort(pairingEndpoint)
+                                if (pairTarget == null) {
+                                    status = "Enter a valid pairing IP:port"
+                                    return@Button
+                                }
+                                val connectTarget = connectEndpoint.trim().takeIf { it.isNotBlank() }?.let(::parseHostPort)
+                                if (connectEndpoint.isNotBlank() && connectTarget == null) {
+                                    status = "Enter a valid connect IP:port"
+                                    return@Button
+                                }
+                                scope.launch {
+                                    busy = true
+                                    status = "Pairing ${pairTarget.first}:${pairTarget.second}..."
+                                    val (result, paired) = pairThenConnect(
+                                        devices = devices,
+                                        pairHost = pairTarget.first,
+                                        pairPort = pairTarget.second,
+                                        code = pairingCode,
+                                        preferredConnect = connectTarget,
+                                    )
+                                    if (paired != null && result.isSuccess) {
+                                        onPaired(paired, result.stdout.ifBlank { "Paired and connected" })
+                                    } else {
+                                        status = result.stderr.ifBlank { result.stdout }.ifBlank { "Pairing failed" }
+                                        busy = false
+                                    }
+                                }
+                            },
+                            enabled = !busy && pairingCode.length == 6 && pairingEndpoint.isNotBlank(),
+                            colors = primaryButtonColors(),
+                        ) { Text("Pair & connect") }
+                    }
+                    WifiPairTab.Qr -> {
+                        Text(
+                            "On the phone: Developer options → Wireless debugging → Pair device with QR code, then scan this code.",
+                            color = TextSecondary,
+                            fontSize = 12.sp,
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(16.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Box(
+                                Modifier.size(220.dp)
+                                    .background(Color.White, RoundedCornerShape(AndyRadius.R4))
+                                    .padding(12.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                if (qrBitmap != null) {
+                                    Image(bitmap = qrBitmap, contentDescription = "ADB pairing QR", modifier = Modifier.fillMaxSize())
+                                } else {
+                                    CircularProgressIndicator(color = Rust, strokeWidth = 2.dp)
+                                }
+                            }
+                            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Text("Name: $qrName", color = TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                                Text("Password: $qrPassword", color = TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                                Text(
+                                    if (busy) "Pairing..." else "Waiting for phone to advertise pairing service…",
+                                    color = TextSecondary,
+                                    fontSize = 12.sp,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = { OutlinedButton(onClick = onDismiss, enabled = !busy) { Text("Close") } },
+    )
+}

--- a/src/commonMain/kotlin/app/andy/ui/devices/WifiPairing.kt
+++ b/src/commonMain/kotlin/app/andy/ui/devices/WifiPairing.kt
@@ -1,0 +1,90 @@
+package app.andy.ui.devices
+
+import app.andy.model.AndroidDevice
+import app.andy.model.DeviceTransport
+import app.andy.model.MdnsService
+import app.andy.model.PairedWifiDevice
+import app.andy.service.CommandResult
+import app.andy.service.DeviceService
+import kotlinx.coroutines.delay
+
+internal fun parseHostPort(value: String): Pair<String, Int>? {
+    val trimmed = value.trim()
+    val host = trimmed.substringBeforeLast(':').trim()
+    val port = trimmed.substringAfterLast(':').trim().toIntOrNull()
+    if (host.isBlank() || port == null || port !in 1..65535) return null
+    return host to port
+}
+
+internal fun findLiveWifiDevice(devices: List<AndroidDevice>, paired: PairedWifiDevice): AndroidDevice? {
+    return devices.firstOrNull { device ->
+        device.transport == DeviceTransport.Wifi && (
+            device.serial == paired.lastEndpoint ||
+                (paired.mdnsInstanceName != null && device.serial.contains(paired.mdnsInstanceName, ignoreCase = true)) ||
+                device.displayName.equals(paired.displayName, ignoreCase = true)
+            )
+    } ?: paired.lastEndpoint?.let { endpoint -> devices.firstOrNull { it.serial == endpoint } }
+}
+
+internal fun findConnectService(services: List<MdnsService>, instanceName: String?): MdnsService? {
+    if (instanceName.isNullOrBlank()) return null
+    return services.firstOrNull { it.isConnect && it.instanceName.equals(instanceName, ignoreCase = true) }
+        ?: services.firstOrNull { it.isConnect && it.instanceName.contains(instanceName, ignoreCase = true) }
+}
+
+internal suspend fun reconnectPairedWifiDevice(
+    devices: DeviceService,
+    paired: PairedWifiDevice,
+    knownServices: List<MdnsService>? = null,
+): Pair<CommandResult, String?> {
+    val services = knownServices ?: runCatching { devices.listMdnsServices() }.getOrDefault(emptyList())
+    val mdnsMatch = findConnectService(services, paired.mdnsInstanceName)
+    if (mdnsMatch != null) {
+        val result = devices.connect(mdnsMatch.host, mdnsMatch.port)
+        if (result.isSuccess) return result to mdnsMatch.endpoint
+    }
+    val endpoint = paired.lastEndpoint?.let(::parseHostPort)
+    if (endpoint != null) {
+        val result = devices.connect(endpoint.first, endpoint.second)
+        return result to if (result.isSuccess) paired.lastEndpoint else null
+    }
+    return CommandResult.failure("No mDNS service or saved endpoint for ${paired.displayName}") to null
+}
+
+internal suspend fun pairThenConnect(
+    devices: DeviceService,
+    pairHost: String,
+    pairPort: Int,
+    code: String,
+    preferredConnect: Pair<String, Int>? = null,
+    preferredInstanceName: String? = null,
+): Pair<CommandResult, PairedWifiDevice?> {
+    val pairResult = devices.pair(pairHost, pairPort, code)
+    if (!pairResult.isSuccess) return pairResult to null
+
+    delay(800)
+    val mdns = runCatching { devices.listMdnsServices() }.getOrDefault(emptyList())
+    val connectService = preferredInstanceName?.let { findConnectService(mdns, it) }
+        ?: mdns.firstOrNull { it.isConnect && it.host == pairHost }
+        ?: mdns.firstOrNull { it.isConnect }
+    val connectTarget = preferredConnect
+        ?: connectService?.let { it.host to it.port }
+    if (connectTarget == null) {
+        return CommandResult.failure("Paired, but no connect endpoint was found. Enter IP:port manually.") to null
+    }
+    val connectResult = devices.connect(connectTarget.first, connectTarget.second)
+    if (!connectResult.isSuccess) return connectResult to null
+
+    val endpoint = "${connectTarget.first}:${connectTarget.second}"
+    val instanceName = preferredInstanceName
+        ?: connectService?.instanceName
+        ?: mdns.firstOrNull { it.host == pairHost }?.instanceName
+    val paired = PairedWifiDevice(
+        id = "wifi-${System.currentTimeMillis()}-${endpoint.hashCode().toUInt()}",
+        displayName = instanceName ?: endpoint,
+        mdnsInstanceName = instanceName,
+        lastEndpoint = endpoint,
+        pairedAtMillis = System.currentTimeMillis(),
+    )
+    return CommandResult.success("Paired and connected to $endpoint") to paired
+}

--- a/src/commonMain/kotlin/app/andy/ui/network/NetworkScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/network/NetworkScreen.kt
@@ -53,10 +53,14 @@ import androidx.compose.ui.unit.sp
 import app.andy.ui.components.HeaderCell
 import app.andy.domain.*
 import app.andy.model.AndroidDevice
+import app.andy.model.NetworkDiagnosis
+import app.andy.model.NetworkDiagnosisSeverity
 import app.andy.model.NetworkExchange
 import app.andy.model.NetworkRouteDiagnostics
 import app.andy.model.ProxyRule
+import app.andy.model.ProxyStartOptions
 import app.andy.model.SdkDiscovery
+import app.andy.model.diagnoseNetworkTraffic
 import app.andy.service.AndyServices
 import app.andy.ui.components.Button
 import app.andy.ui.components.EmptyState
@@ -142,9 +146,13 @@ internal fun NetworkScreen(
     rules: List<ProxyRule>,
     rulesVisible: Boolean,
     liveVisible: Boolean,
+    sslInsecure: Boolean = false,
+    upstreamTrustedCaPath: String = "",
     onPortChange: (Int) -> Unit,
     onRulesChange: (List<ProxyRule>) -> Unit,
     onRulesVisibleChange: (Boolean) -> Unit,
+    onSslInsecureChange: (Boolean) -> Unit = {},
+    onUpstreamTrustedCaPathChange: (String) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
     val state = remember(services.proxy) { NetworkScreenState(services.proxy) }
@@ -167,6 +175,15 @@ internal fun NetworkScreen(
         flattenNetworkTrafficTree(trafficTree, state.expandedTrafficKeys)
     }
     val latestRules by rememberUpdatedState(rules)
+    fun currentStartOptions() = ProxyStartOptions(
+        sslInsecure = sslInsecure,
+        upstreamTrustedCaPath = upstreamTrustedCaPath.trim().takeIf { it.isNotBlank() },
+    )
+
+    LaunchedEffect(sslInsecure, upstreamTrustedCaPath) {
+        state.sslInsecure = sslInsecure
+        state.upstreamTrustedCaPath = upstreamTrustedCaPath
+    }
 
     LaunchedEffect(Unit) {
         state.caPath = proxy.certificateAuthorityPath()
@@ -179,7 +196,7 @@ internal fun NetworkScreen(
         }
         state.engineChecked = true
     }
-    LaunchedEffect(state.engineReady, currentPort) {
+    LaunchedEffect(state.engineReady, currentPort, sslInsecure, upstreamTrustedCaPath) {
         if (!state.engineReady) return@LaunchedEffect
         val currentStatus = try {
             withTimeout(200) { proxy.status.first() }
@@ -188,7 +205,7 @@ internal fun NetworkScreen(
         }
         if (shouldAutoStartProxy(currentStatus, currentPort)) {
             proxy.ensureCertificateAuthority()
-            val result = proxy.start(currentPort, latestRules)
+            val result = proxy.start(currentPort, latestRules, currentStartOptions())
             val message = if (result.isSuccess) result.stdout else result.stderr
             state.status = message
             if (result.isSuccess) state.proxyStatus = message
@@ -196,6 +213,12 @@ internal fun NetworkScreen(
     }
     LaunchedEffect(Unit) {
         proxy.exchanges.collectLatest { state.exchanges = it }
+    }
+    LaunchedEffect(Unit) {
+        proxy.warnings.collectLatest { state.warnings = it }
+    }
+    LaunchedEffect(Unit) {
+        proxy.clientConnectionCount.collectLatest { state.clientConnectionCount = it }
     }
     LaunchedEffect(Unit) {
         proxy.status.collectLatest {
@@ -211,11 +234,35 @@ internal fun NetworkScreen(
             state.proxyTrafficObservedForDevice = false
         } else {
             val newExchanges = state.exchanges.filter { it.flowId !in state.flowIdsAtSerialChange }
-            if (newExchanges.isNotEmpty()) state.proxyTrafficObservedForDevice = true
+            if (newExchanges.any { it.method != "TLS" }) state.proxyTrafficObservedForDevice = true
             if (newExchanges.any { it.tlsStatus == "tls" && it.error == null }) {
                 state.userCaVerifiedByTrafficForDevice = true
             }
         }
+    }
+    LaunchedEffect(
+        state.proxyStatus,
+        state.caInstalled,
+        state.proxyConfigured,
+        state.routeDiagnostics,
+        state.exchanges,
+        state.warnings,
+        state.clientConnectionCount,
+        state.sslInsecure,
+        state.upstreamTrustedCaPath,
+    ) {
+        val proxyStarted = state.proxyStatus.contains("listening on")
+        state.diagnoses = diagnoseNetworkTraffic(
+            proxyStarted = proxyStarted,
+            caInstalled = state.caInstalled || state.userCaVerifiedByTrafficForDevice,
+            proxyConfigured = state.proxyConfigured,
+            routeDiagnostics = state.routeDiagnostics,
+            exchanges = state.exchanges,
+            warnings = state.warnings,
+            clientConnectionsObserved = state.clientConnectionCount,
+            sslInsecure = state.sslInsecure,
+            upstreamTrustedCaPath = state.upstreamTrustedCaPath.trim().takeIf { it.isNotBlank() },
+        )
     }
     LaunchedEffect(serial, currentPort) {
         if (serial == null) {
@@ -355,8 +402,6 @@ internal fun NetworkScreen(
         onRulesVisibleChange(true)
     }
 
-    val networkPageScrollState = rememberScrollState()
-
     Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         Column(
             Modifier
@@ -364,14 +409,7 @@ internal fun NetworkScreen(
                 .fillMaxHeight(),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Column(
-                Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .verticalScroll(networkPageScrollState),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                PanelCard(Modifier.animateContentSize()) {
+            PanelCard(Modifier.animateContentSize()) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
                     Text("Debug-app HTTPS proxy", color = TextPrimary, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
                     TextField(
@@ -389,7 +427,7 @@ internal fun NetworkScreen(
                         persistPort()
                         scope.launch {
                             proxy.ensureCertificateAuthority()
-                            val result = proxy.start(currentPort, rules)
+                            val result = proxy.start(currentPort, rules, currentStartOptions())
                             val message = if (result.isSuccess) result.stdout else result.stderr
                             state.status = message
                             if (result.isSuccess) state.proxyStatus = message
@@ -430,7 +468,14 @@ internal fun NetworkScreen(
                 val routeText = when {
                     serial == null -> "Select a device first"
                     state.routeDiagnostics == null -> "Checking route"
-                    state.routeDiagnostics?.hostProxyActive == true && state.routeDiagnostics?.hostUpstreamProxy != null -> "Mac proxy chained"
+                    state.routeDiagnostics?.hostProxyActive == true && state.routeDiagnostics?.hostUpstreamProxy != null -> {
+                        val upstream = state.routeDiagnostics?.hostUpstreamProxy
+                        if (upstream != null && (upstream.contains("127.0.0.1") || upstream.contains("localhost"))) {
+                            "Chaining through local Mac proxy $upstream"
+                        } else {
+                            "Chaining through Mac proxy $upstream"
+                        }
+                    }
                     state.routeDiagnostics?.hostProxyActive == true -> "Mac proxy active"
                     state.routeDiagnostics?.vpnActive == true -> "VPN active (may cause issues)"
                     state.routeDiagnostics?.routeUsesVpn == true -> "Proxy route uses VPN"
@@ -482,14 +527,25 @@ internal fun NetworkScreen(
                         ok = serial != null &&
                             state.routeDiagnostics?.vpnActive != true &&
                             state.routeDiagnostics?.routeUsesVpn != true &&
-                            state.routeDiagnostics?.hostProxyBypassLooksSafe != false,
+                            (
+                                state.routeDiagnostics?.hostProxyBypassLooksSafe != false ||
+                                    state.routeDiagnostics?.hostUpstreamProxy.orEmpty().let { upstream ->
+                                        upstream.contains("127.0.0.1") || upstream.contains("localhost")
+                                    }
+                            ),
                         readyText = routeText,
                         missingText = routeText,
                     ),
                 )
                 val showRouteWarning = state.routeDiagnostics?.hasBlockingIssue == true && proxyStarted && !state.proxyTrafficObservedForDevice
                 AnimatedVisibility(state.setupExpanded) {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Column(
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 360.dp)
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -518,7 +574,11 @@ internal fun NetworkScreen(
                                         val route = proxy.diagnoseDeviceProxyRoute(serial, host, currentPort)
                                         state.routeDiagnostics = route
                                         state.proxyConfigured = route.proxyConfigured
-                                        val restart = if (route.hostProxyActive) proxy.start(currentPort, rules) else null
+                                        val restart = if (route.hostProxyActive) {
+                                            proxy.start(currentPort, rules, currentStartOptions())
+                                        } else {
+                                            null
+                                        }
                                         state.status = if (route.vpnActive) {
                                             "Proxy route repaired, but VPN is still active. Open VPN settings and disable or split-tunnel the test app."
                                         } else if (restart?.isSuccess == true) {
@@ -574,6 +634,19 @@ internal fun NetworkScreen(
                         }
                         SetupChecklist(setupRequirements)
                         SetupChecklist(networkStatusRequirements)
+                        CorporateUpstreamSettings(
+                            sslInsecure = state.sslInsecure,
+                            upstreamTrustedCaPath = state.upstreamTrustedCaPath,
+                            hostUpstreamProxy = state.routeDiagnostics?.hostUpstreamProxy,
+                            onSslInsecureChange = {
+                                onSslInsecureChange(it)
+                                state.sslInsecure = it
+                            },
+                            onUpstreamTrustedCaPathChange = {
+                                onUpstreamTrustedCaPathChange(it)
+                                state.upstreamTrustedCaPath = it
+                            },
+                        )
                         AnimatedVisibility(showRouteWarning) {
                             NetworkRouteWarningCard(state.routeDiagnostics)
                         }
@@ -626,6 +699,13 @@ internal fun NetworkScreen(
                     }
                 }
             }
+            NetworkDiagnosisStrip(state.diagnoses)
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(0.dp),
+            ) {
             if (state.focusedPath != null) {
                 Row(
                     modifier = Modifier
@@ -663,14 +743,14 @@ internal fun NetworkScreen(
                 }
             }
             Row(Modifier.fillMaxWidth().height(28.dp).padding(horizontal = 4.dp), verticalAlignment = Alignment.CenterVertically) {
-                HeaderCell("TRAFFIC", state.trafficWidth.dp) { state.trafficWidth = it.coerceIn(120f, 600f) }
+                HeaderCell("TRAFFIC", state.trafficWidth.dp) { state.trafficWidth = it.coerceIn(160f, 2400f) }
                 HeaderCell("STATUS", state.statusWidth.dp) { state.statusWidth = it.coerceIn(50f, 150f) }
                 HeaderCell("TYPE", state.typeWidth.dp) { state.typeWidth = it.coerceIn(80f, 250f) }
                 HeaderCell("SIZE", state.sizeWidth.dp) { state.sizeWidth = it.coerceIn(50f, 150f) }
                 HeaderCell("MS", state.msWidth.dp) { state.msWidth = it.coerceIn(50f, 150f) }
                 Text("RULE", color = TextSecondary, fontWeight = FontWeight.Bold, fontSize = 11.sp, modifier = Modifier.weight(1f).padding(horizontal = 4.dp))
             }
-            LazyColumn(Modifier.fillMaxWidth().heightIn(min = 220.dp, max = 520.dp)) {
+            LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
                 items(visibleTrafficRows, key = { row -> row.key }) { row ->
                     NetworkTrafficRowItem(
                         row = row,
@@ -722,7 +802,10 @@ internal fun NetworkScreen(
                 }
                 if (visibleTrafficRows.isEmpty()) {
                     item {
-                        EmptyState("No traffic yet. Start the proxy, configure a device, then make a request.")
+                        val emptyMessage = state.diagnoses.firstOrNull { it.severity == NetworkDiagnosisSeverity.Red }?.let {
+                            "${it.title}. ${it.fix}"
+                        } ?: "No traffic yet. Start the proxy, configure a device, then make a request."
+                        EmptyState(emptyMessage)
                     }
                 }
             }
@@ -847,6 +930,85 @@ internal fun GlowingDot(isGreen: Boolean, modifier: Modifier = Modifier) {
                 .background(color, CircleShape)
                 .border(1.dp, color.copy(alpha = 0.8f), CircleShape)
         )
+    }
+}
+
+@Composable
+private fun NetworkDiagnosisStrip(diagnoses: List<NetworkDiagnosis>, modifier: Modifier = Modifier) {
+    if (diagnoses.isEmpty()) return
+    Column(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        diagnoses.forEach { diagnosis ->
+            val (bg, border, accent) = when (diagnosis.severity) {
+                NetworkDiagnosisSeverity.Red -> Triple(Red.copy(alpha = 0.12f), Red.copy(alpha = 0.55f), Red)
+                NetworkDiagnosisSeverity.Amber -> Triple(Yellow.copy(alpha = 0.10f), Yellow.copy(alpha = 0.55f), Yellow)
+                NetworkDiagnosisSeverity.Green -> Triple(Green.copy(alpha = 0.10f), Green.copy(alpha = 0.45f), Green)
+            }
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .background(bg, RoundedCornerShape(AndyRadius.R3))
+                    .border(1.dp, border, RoundedCornerShape(AndyRadius.R3))
+                    .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Box(Modifier.size(8.dp).background(accent, CircleShape))
+                    Text(diagnosis.title, color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+                }
+                Text(diagnosis.detail, color = TextSecondary, fontSize = 12.sp, lineHeight = 16.sp)
+                if (diagnosis.fix.isNotBlank()) {
+                    Text(diagnosis.fix, color = accent, fontSize = 12.sp, lineHeight = 16.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CorporateUpstreamSettings(
+    sslInsecure: Boolean,
+    upstreamTrustedCaPath: String,
+    hostUpstreamProxy: String?,
+    onSslInsecureChange: (Boolean) -> Unit,
+    onUpstreamTrustedCaPathChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier
+            .fillMaxWidth()
+            .background(AndyColors.Neutral850, RoundedCornerShape(AndyRadius.R3))
+            .border(1.dp, Border, RoundedCornerShape(AndyRadius.R3))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("Corporate TLS / upstream trust", color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+        Text(
+            if (hostUpstreamProxy != null) {
+                val local = hostUpstreamProxy.contains("127.0.0.1") || hostUpstreamProxy.contains("localhost")
+                if (local) {
+                    "Mac system proxy is a local debug tool ($hostUpstreamProxy). Andy chains through it. Quit Proxyman/Charles or fix its bypass list if traffic looks wrong."
+                } else {
+                    "Chaining through Mac proxy $hostUpstreamProxy. If upstream verify fails (corporate TLS inspection), trust the corporate root or enable insecure-upstream."
+                }
+            } else {
+                "When a Mac proxy re-signs TLS (common with corporate security tools), mitmproxy needs the corporate root CA or insecure-upstream to reach the real server."
+            },
+            color = TextSecondary,
+            fontSize = 12.sp,
+            lineHeight = 16.sp,
+        )
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Checkbox(checked = sslInsecure, onCheckedChange = onSslInsecureChange)
+            Text("Insecure upstream (--ssl-insecure)", color = TextPrimary, fontSize = 12.sp)
+        }
+        LabeledField(
+            label = "Corporate root CA path",
+            value = upstreamTrustedCaPath,
+            onValueChange = onUpstreamTrustedCaPathChange,
+            placeholder = "/path/to/corp-root.pem",
+            singleLine = true,
+        )
+        Text("Restart the proxy after changing these options.", color = TextSecondary, fontSize = 11.sp)
     }
 }
 

--- a/src/commonMain/kotlin/app/andy/ui/network/NetworkScreenState.kt
+++ b/src/commonMain/kotlin/app/andy/ui/network/NetworkScreenState.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import app.andy.model.NetworkDiagnosis
 import app.andy.model.NetworkExchange
 import app.andy.model.NetworkRouteDiagnostics
+import app.andy.model.ProxyWarning
 import app.andy.service.ProxyService
 
 internal class NetworkScreenState(
@@ -18,6 +20,9 @@ internal class NetworkScreenState(
     var caPath by mutableStateOf("")
     var proxyHost by mutableStateOf("")
     var exchanges by mutableStateOf<List<NetworkExchange>>(emptyList())
+    var warnings by mutableStateOf<List<ProxyWarning>>(emptyList())
+    var clientConnectionCount by mutableStateOf(0)
+    var diagnoses by mutableStateOf<List<NetworkDiagnosis>>(emptyList())
     var selectedFlowId by mutableStateOf<String?>(null)
     var setupExpanded by mutableStateOf(false)
     var setupManuallyToggled by mutableStateOf(false)
@@ -34,7 +39,7 @@ internal class NetworkScreenState(
     var ruleRemoveHeaders by mutableStateOf("")
     var ruleBody by mutableStateOf("")
     var editingRuleId by mutableStateOf<String?>(null)
-    var trafficWidth by mutableStateOf(260f)
+    var trafficWidth by mutableStateOf(480f)
     var statusWidth by mutableStateOf(72f)
     var typeWidth by mutableStateOf(150f)
     var sizeWidth by mutableStateOf(80f)
@@ -49,6 +54,8 @@ internal class NetworkScreenState(
     var proxyTrafficObservedForDevice by mutableStateOf(false)
     var trafficEvidenceSerial by mutableStateOf<String?>(null)
     var flowIdsAtSerialChange by mutableStateOf(emptySet<String>())
+    var sslInsecure by mutableStateOf(false)
+    var upstreamTrustedCaPath by mutableStateOf("")
 
     fun clearRuleEditor() {
         ruleName = ""

--- a/src/commonMain/kotlin/app/andy/ui/settings/SettingsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/settings/SettingsScreen.kt
@@ -176,6 +176,42 @@ internal fun SettingsScreen(
                     Text(proxyStatus, color = if (proxyRunning) Green else Rust, fontSize = 12.sp, fontFamily = MonoFont, fontWeight = FontWeight.Bold)
                 }
             }
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                "Corporate TLS inspection: if your Mac routes through a security proxy that re-signs HTTPS, point Andy at the corporate root CA or enable insecure upstream.",
+                color = TextSecondary,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Checkbox(
+                    checked = workspaceState.proxySslInsecure,
+                    onCheckedChange = { checked ->
+                        onUpdateWorkspace { it.copy(proxySslInsecure = checked) }
+                    },
+                )
+                Text("Insecure upstream (--ssl-insecure)", color = TextPrimary, fontSize = 13.sp)
+            }
+            TextField(
+                value = workspaceState.proxyUpstreamTrustedCaPath.orEmpty(),
+                onValueChange = { value ->
+                    onUpdateWorkspace {
+                        it.copy(proxyUpstreamTrustedCaPath = value.trim().takeIf { path -> path.isNotBlank() })
+                    }
+                },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().height(48.dp),
+                textStyle = LocalTextStyle.current.copy(color = TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 13.sp),
+                colors = fieldColors(),
+                placeholder = {
+                    Text("Corporate root CA path (optional)", color = TextSecondary, fontSize = 13.sp)
+                },
+            )
         }
 
         PanelCard {

--- a/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -159,6 +159,7 @@ internal fun AndyShell(
                             services,
                             state.devices,
                             state.sdk,
+                            pairedWifiDevices = state.workspaceState.pairedWifiDevices,
                             onRefresh = { state.refreshDevices() },
                             onLive = { state.openLive(it) },
                             onEmulatorStarted = { previousSerials, avdName ->
@@ -169,6 +170,10 @@ internal fun AndyShell(
                             stopStatus = state.emulatorStopStatus,
                             startingEmulatorName = state.startingEmulatorName,
                             startStatus = state.emulatorStartStatus,
+                            onSavePairedWifi = state::savePairedWifi,
+                            onForgetPairedWifi = state::forgetPairedWifi,
+                            onReconnectPairedWifi = state::reconnectPairedWifi,
+                            onDisconnectWifi = state::disconnectWifi,
                         )
                         AndyDestination.Catalog -> CatalogScreen(services.avd)
                         AndyDestination.Live -> LiveScreen(

--- a/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -38,6 +38,7 @@ import app.andy.ui.intents.IntentsScreen
 import app.andy.ui.live.LiveScreen
 import app.andy.ui.logcat.LogcatScreen
 import app.andy.ui.network.NetworkScreen
+import app.andy.model.ProxyStartOptions
 import app.andy.ui.network.shouldAutoStartProxy
 import app.andy.ui.performance.PerformanceScreen
 import app.andy.ui.settings.SettingsScreen
@@ -88,7 +89,7 @@ internal fun AndyShell(
         }
     }
 
-    LaunchedEffect(state.workspaceLoaded, state.workspaceState.proxyStartOnLaunch, state.workspaceState.proxyPort, state.workspaceState.proxyRules) {
+    LaunchedEffect(state.workspaceLoaded, state.workspaceState.proxyStartOnLaunch, state.workspaceState.proxyPort, state.workspaceState.proxyRules, state.workspaceState.proxySslInsecure, state.workspaceState.proxyUpstreamTrustedCaPath) {
         if (!state.workspaceLoaded || !state.workspaceState.proxyStartOnLaunch) return@LaunchedEffect
         val currentStatus = try {
             withTimeout(200) { services.proxy.status.first() }
@@ -97,7 +98,14 @@ internal fun AndyShell(
         }
         if (shouldAutoStartProxy(currentStatus, state.workspaceState.proxyPort)) {
             services.proxy.ensureCertificateAuthority()
-            services.proxy.start(state.workspaceState.proxyPort, state.workspaceState.proxyRules)
+            services.proxy.start(
+                state.workspaceState.proxyPort,
+                state.workspaceState.proxyRules,
+                ProxyStartOptions(
+                    sslInsecure = state.workspaceState.proxySslInsecure,
+                    upstreamTrustedCaPath = state.workspaceState.proxyUpstreamTrustedCaPath,
+                ),
+            )
         }
     }
 
@@ -227,9 +235,15 @@ internal fun AndyShell(
                             rules = state.workspaceState.proxyRules,
                             rulesVisible = state.networkRulesVisible,
                             liveVisible = state.networkLiveVisible,
+                            sslInsecure = state.workspaceState.proxySslInsecure,
+                            upstreamTrustedCaPath = state.workspaceState.proxyUpstreamTrustedCaPath.orEmpty(),
                             onPortChange = { value -> state.updateWorkspace { it.copy(proxyPort = value) } },
                             onRulesChange = { value -> state.updateWorkspace { it.copy(proxyRules = value) } },
                             onRulesVisibleChange = { state.setNetworkRulesVisible(it) },
+                            onSslInsecureChange = { value -> state.updateWorkspace { it.copy(proxySslInsecure = value) } },
+                            onUpstreamTrustedCaPathChange = { value ->
+                                state.updateWorkspace { it.copy(proxyUpstreamTrustedCaPath = value.trim().takeIf { path -> path.isNotBlank() }) }
+                            },
                         )
                         AndyDestination.Actions -> ActionsScreen(
                             services = services,

--- a/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
@@ -12,16 +12,19 @@ import app.andy.model.ActionsConfig
 import app.andy.model.AndroidDevice
 import app.andy.model.DeviceConnectionState
 import app.andy.model.DeviceKind
+import app.andy.model.PairedWifiDevice
 import app.andy.model.ProjectAction
 import app.andy.model.RunningAction
 import app.andy.model.SdkDiscovery
 import app.andy.model.WorkspaceState
 import app.andy.service.AndyServices
 import app.andy.ui.accessibility.AccessibilityState
+import app.andy.ui.devices.reconnectPairedWifiDevice
 import app.andy.ui.logcat.LogcatState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 
 internal class ShellState(
     private val services: AndyServices,
@@ -164,7 +167,75 @@ internal class ShellState(
         selectedSerial = saved.selectedDeviceSerial
         actionsConfig = services.actionConfig.load()
         workspaceLoaded = true
+        if (saved.pairedWifiDevices.isNotEmpty()) {
+            val discovery = services.devices.discoverSdk()
+            if (discovery.hasAdb) {
+                val mdnsReady = runCatching { services.devices.mdnsAvailable() }.getOrDefault(false)
+                val mdnsServices = if (mdnsReady) {
+                    runCatching { services.devices.listMdnsServices() }.getOrDefault(emptyList())
+                } else {
+                    emptyList()
+                }
+                saved.pairedWifiDevices.forEach { paired ->
+                    runCatching {
+                        withTimeout(8_000) {
+                            val (result, endpoint) = reconnectPairedWifiDevice(services.devices, paired, mdnsServices)
+                            if (result.isSuccess && endpoint != null && endpoint != paired.lastEndpoint) {
+                                workspaceState = workspaceState.copy(
+                                    pairedWifiDevices = workspaceState.pairedWifiDevices.map {
+                                        if (it.id == paired.id) it.copy(lastEndpoint = endpoint) else it
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+                if (workspaceState.pairedWifiDevices != saved.pairedWifiDevices) {
+                    services.workspaceStore.save(workspaceState)
+                }
+            }
+        }
         refreshDevices()
+    }
+
+    fun savePairedWifi(device: PairedWifiDevice) {
+        updateWorkspace { state ->
+            val without = state.pairedWifiDevices.filterNot {
+                it.id == device.id ||
+                    (device.mdnsInstanceName != null && it.mdnsInstanceName == device.mdnsInstanceName) ||
+                    (device.lastEndpoint != null && it.lastEndpoint == device.lastEndpoint)
+            }
+            state.copy(pairedWifiDevices = without + device)
+        }
+    }
+
+    fun forgetPairedWifi(id: String) {
+        updateWorkspace { state ->
+            state.copy(pairedWifiDevices = state.pairedWifiDevices.filterNot { it.id == id })
+        }
+    }
+
+    fun reconnectPairedWifi(paired: PairedWifiDevice) {
+        scope.launch {
+            val (result, endpoint) = reconnectPairedWifiDevice(services.devices, paired)
+            if (result.isSuccess && endpoint != null && endpoint != paired.lastEndpoint) {
+                updateWorkspace { state ->
+                    state.copy(
+                        pairedWifiDevices = state.pairedWifiDevices.map {
+                            if (it.id == paired.id) it.copy(lastEndpoint = endpoint) else it
+                        },
+                    )
+                }
+            }
+            refreshDevicesNow()
+        }
+    }
+
+    fun disconnectWifi(serial: String) {
+        scope.launch {
+            services.devices.disconnect(serial)
+            refreshDevicesNow()
+        }
     }
 
     fun syncActiveRun(runningActions: List<RunningAction>) {

--- a/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
@@ -168,8 +168,10 @@ internal class ShellState(
         actionsConfig = services.actionConfig.load()
         workspaceLoaded = true
         if (saved.pairedWifiDevices.isNotEmpty()) {
-            val discovery = services.devices.discoverSdk()
-            if (discovery.hasAdb) {
+            // Reconnect in the background so workspace load / first device refresh are not blocked.
+            scope.launch {
+                val discovery = services.devices.discoverSdk()
+                if (!discovery.hasAdb) return@launch
                 val mdnsReady = runCatching { services.devices.mdnsAvailable() }.getOrDefault(false)
                 val mdnsServices = if (mdnsReady) {
                     runCatching { services.devices.listMdnsServices() }.getOrDefault(emptyList())
@@ -177,21 +179,23 @@ internal class ShellState(
                     emptyList()
                 }
                 saved.pairedWifiDevices.forEach { paired ->
-                    runCatching {
-                        withTimeout(8_000) {
-                            val (result, endpoint) = reconnectPairedWifiDevice(services.devices, paired, mdnsServices)
-                            if (result.isSuccess && endpoint != null && endpoint != paired.lastEndpoint) {
-                                workspaceState = workspaceState.copy(
-                                    pairedWifiDevices = workspaceState.pairedWifiDevices.map {
-                                        if (it.id == paired.id) it.copy(lastEndpoint = endpoint) else it
-                                    },
-                                )
+                    launch {
+                        runCatching {
+                            withTimeout(8_000) {
+                                val (result, endpoint) = reconnectPairedWifiDevice(services.devices, paired, mdnsServices)
+                                if (result.isSuccess && endpoint != null && endpoint != paired.lastEndpoint) {
+                                    updateWorkspace { state ->
+                                        state.copy(
+                                            pairedWifiDevices = state.pairedWifiDevices.map {
+                                                if (it.id == paired.id) it.copy(lastEndpoint = endpoint) else it
+                                            },
+                                        )
+                                    }
+                                }
                             }
                         }
+                        refreshDevicesNow()
                     }
-                }
-                if (workspaceState.pairedWifiDevices != saved.pairedWifiDevices) {
-                    services.workspaceStore.save(workspaceState)
                 }
             }
         }

--- a/src/commonTest/kotlin/app/andy/model/DeviceModelsTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/DeviceModelsTest.kt
@@ -1,0 +1,94 @@
+package app.andy.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DeviceModelsTest {
+    @Test
+    fun extractMdnsHardwareIdParsesInstanceBody() {
+        assertEquals(
+            "5A080DLCH000UR-oVigq2",
+            extractMdnsHardwareId("adb-5A080DLCH000UR-oVigq2._adb-tls-connect._tcp"),
+        )
+        assertEquals(
+            "VAN10A203710441",
+            extractMdnsHardwareId("adb-VAN10A203710441._adb-tls-connect._tcp"),
+        )
+        assertNull(extractMdnsHardwareId("192.168.86.150:35923"))
+        assertNull(extractMdnsHardwareId("R3CXB056ZZB"))
+    }
+
+    @Test
+    fun dedupeWifiAliasesRequiresStableHardwareId() {
+        val ip = AndroidDevice(
+            serial = "192.168.86.150:35923",
+            displayName = "Pixel 10 Pro",
+            kind = DeviceKind.Physical,
+            state = DeviceConnectionState.Online,
+            transport = DeviceTransport.Wifi,
+            model = "Pixel_10_Pro",
+            product = "blazer",
+            hardwareId = "5A080DLCH000UR",
+        )
+        val matchingMdns = AndroidDevice(
+            serial = "adb-5A080DLCH000UR-oVigq2._adb-tls-connect._tcp",
+            displayName = "Pixel 10 Pro",
+            kind = DeviceKind.Physical,
+            state = DeviceConnectionState.Online,
+            transport = DeviceTransport.Wifi,
+            model = "Pixel_10_Pro",
+            product = "blazer",
+            hardwareId = "5A080DLCH000UR-oVigq2",
+        )
+        val sameModelDifferentPhone = AndroidDevice(
+            serial = "adb-OTHERSERIAL._adb-tls-connect._tcp",
+            displayName = "Pixel 10 Pro",
+            kind = DeviceKind.Physical,
+            state = DeviceConnectionState.Online,
+            transport = DeviceTransport.Wifi,
+            model = "Pixel_10_Pro",
+            product = "blazer",
+            hardwareId = "OTHERSERIAL",
+        )
+
+        val deduped = dedupeWifiDeviceAliases(listOf(ip, matchingMdns, sameModelDifferentPhone))
+        assertEquals(listOf(ip.serial, sameModelDifferentPhone.serial), deduped.map { it.serial })
+    }
+
+    @Test
+    fun dedupeDoesNotCollapseSameModelWithoutHardwareIds() {
+        val ip = AndroidDevice(
+            serial = "192.168.86.200:5555",
+            displayName = "SM S921U",
+            kind = DeviceKind.Physical,
+            state = DeviceConnectionState.Online,
+            transport = DeviceTransport.Wifi,
+            model = "SM_S921U",
+            product = "e3q",
+        )
+        val mdns = AndroidDevice(
+            serial = "adb-OTHER._adb-tls-connect._tcp",
+            displayName = "SM S921U",
+            kind = DeviceKind.Physical,
+            state = DeviceConnectionState.Online,
+            transport = DeviceTransport.Wifi,
+            model = "SM_S921U",
+            product = "e3q",
+            hardwareId = "OTHER",
+        )
+
+        val deduped = dedupeWifiDeviceAliases(listOf(ip, mdns))
+        assertEquals(2, deduped.size)
+    }
+
+    @Test
+    fun wirelessAdbSerialDetection() {
+        assertTrue(isWirelessAdbSerial("192.168.1.20:5555"))
+        assertTrue(isWirelessAdbSerial("adb-ABC._adb-tls-connect._tcp"))
+        assertFalse(isWirelessAdbSerial("R3CXB056ZZB"))
+        assertFalse(isWirelessAdbSerial("emulator-5554"))
+    }
+}

--- a/src/commonTest/kotlin/app/andy/model/NetworkDiagnosisTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/NetworkDiagnosisTest.kt
@@ -1,0 +1,115 @@
+package app.andy.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NetworkDiagnosisTest {
+    @Test
+    fun clientCaRejectionProducesRedTlsFailedDiagnosis() {
+        val diagnoses = diagnoseNetworkTraffic(
+            proxyStarted = true,
+            caInstalled = true,
+            proxyConfigured = true,
+            routeDiagnostics = null,
+            exchanges = listOf(
+                NetworkExchange(
+                    id = "tls-1",
+                    flowId = "tls-1",
+                    startedAtMillis = 1,
+                    completedAtMillis = 1,
+                    method = "TLS",
+                    url = "https://api.example.com/",
+                    statusCode = null,
+                    contentType = null,
+                    sizeBytes = null,
+                    durationMillis = 0,
+                    requestHeaders = emptyMap(),
+                    responseHeaders = emptyMap(),
+                    requestBodyPreview = null,
+                    responseBodyPreview = null,
+                    error = "Client rejected Andy's CA for api.example.com: unknown ca",
+                    tlsStatus = "tls",
+                    matchedRuleId = null,
+                ),
+            ),
+            warnings = emptyList(),
+            clientConnectionsObserved = 1,
+            sslInsecure = false,
+            upstreamTrustedCaPath = null,
+        )
+
+        assertTrue(diagnoses.any { it.mode == NetworkFailureMode.ClientRejectedCa && it.severity == NetworkDiagnosisSeverity.Red })
+        assertTrue(diagnoses.any { it.title.contains("api.example.com") })
+    }
+
+    @Test
+    fun corporateUpstreamFailureProducesRedInspectionDiagnosis() {
+        val diagnoses = diagnoseNetworkTraffic(
+            proxyStarted = true,
+            caInstalled = true,
+            proxyConfigured = true,
+            routeDiagnostics = NetworkRouteDiagnostics(
+                expectedProxy = "10.0.2.2:8888",
+                configuredProxy = "10.0.2.2:8888",
+                proxyConfigured = true,
+                vpnActive = false,
+                hostProxyActive = true,
+                hostUpstreamProxy = "http://proxy.corp:8080",
+            ),
+            exchanges = listOf(
+                NetworkExchange(
+                    id = "flow-1",
+                    flowId = "flow-1",
+                    startedAtMillis = 1,
+                    completedAtMillis = 2,
+                    method = "GET",
+                    url = "https://api.example.com/",
+                    statusCode = null,
+                    contentType = null,
+                    sizeBytes = null,
+                    durationMillis = 1,
+                    requestHeaders = emptyMap(),
+                    responseHeaders = emptyMap(),
+                    requestBodyPreview = null,
+                    responseBodyPreview = null,
+                    error = "Certificate verify failed",
+                    tlsStatus = "tls",
+                    matchedRuleId = null,
+                ),
+            ),
+            warnings = emptyList(),
+            clientConnectionsObserved = 1,
+            sslInsecure = false,
+            upstreamTrustedCaPath = null,
+        )
+
+        val corporate = diagnoses.first { it.mode == NetworkFailureMode.CorporateTlsInspection }
+        assertEquals(NetworkDiagnosisSeverity.Red, corporate.severity)
+        assertTrue(corporate.detail.contains("http://proxy.corp:8080"))
+        assertTrue(corporate.fix.contains("corporate root CA") || corporate.fix.contains("insecure-upstream"))
+    }
+
+    @Test
+    fun notRoutedWhenNoClientConnected() {
+        val diagnoses = diagnoseNetworkTraffic(
+            proxyStarted = true,
+            caInstalled = true,
+            proxyConfigured = false,
+            routeDiagnostics = NetworkRouteDiagnostics(
+                expectedProxy = "10.0.2.2:8888",
+                configuredProxy = null,
+                proxyConfigured = false,
+                vpnActive = false,
+                issues = listOf("Android global proxy is not set; expected 10.0.2.2:8888."),
+            ),
+            exchanges = emptyList(),
+            warnings = emptyList(),
+            clientConnectionsObserved = 0,
+            sslInsecure = false,
+            upstreamTrustedCaPath = null,
+        )
+
+        assertTrue(diagnoses.any { it.mode == NetworkFailureMode.NotRouted && it.severity == NetworkDiagnosisSeverity.Red })
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
@@ -22,16 +22,37 @@ object AndroidParsers {
                 AndroidDevice(
                     serial = serial,
                     displayName = fields["model"]?.replace("_", " ") ?: serial,
-                    kind = if (serial.startsWith("emulator-")) DeviceKind.Emulator else DeviceKind.Physical,
+                    kind = classifyDeviceKind(serial),
                     state = when (stateRaw) {
                         "device" -> DeviceConnectionState.Online
                         "offline" -> DeviceConnectionState.Offline
                         "unauthorized" -> DeviceConnectionState.Unauthorized
                         else -> DeviceConnectionState.Unknown
                     },
+                    transport = classifyDeviceTransport(serial),
                     model = fields["model"],
                     product = fields["product"],
                 )
+            }
+            .toList()
+            .let(::dedupeWifiDeviceAliases)
+    }
+
+    fun parseMdnsServices(output: String): List<MdnsService> {
+        return output.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .filterNot { it.startsWith("List of discovered", ignoreCase = true) }
+            .mapNotNull { line ->
+                val parts = line.split(Regex("\\s+"))
+                if (parts.size < 3) return@mapNotNull null
+                val instanceName = parts[0]
+                val serviceType = parts[1]
+                val endpoint = parts[2]
+                val host = endpoint.substringBeforeLast(':')
+                val port = endpoint.substringAfterLast(':').toIntOrNull() ?: return@mapNotNull null
+                if (host.isBlank()) return@mapNotNull null
+                MdnsService(instanceName = instanceName, serviceType = serviceType, host = host, port = port)
             }
             .toList()
     }

--- a/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
@@ -32,6 +32,7 @@ object AndroidParsers {
                     transport = classifyDeviceTransport(serial),
                     model = fields["model"],
                     product = fields["product"],
+                    hardwareId = extractMdnsHardwareId(serial),
                 )
             }
             .toList()

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
@@ -3,6 +3,7 @@ package app.andy.desktop.service
 import app.andy.model.ActionProject
 import app.andy.model.ActionsConfig
 import app.andy.model.ProjectAction
+import app.andy.model.ProjectNote
 import app.andy.service.ActionConfigStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -39,6 +40,7 @@ private data class ActionsFileDto(
     val version: Int = 1,
     val projects: List<ProjectDto> = emptyList(),
     val actions: List<ActionDto> = emptyList(),
+    val notes: List<NoteDto> = emptyList(),
 )
 
 @Serializable
@@ -60,8 +62,18 @@ private data class ActionDto(
     @TomlInline val env: Map<String, String> = emptyMap(),
 )
 
+@Serializable
+private data class NoteDto(
+    val id: String,
+    val projectId: String,
+    val title: String,
+    val body: String = "",
+    val completed: Boolean = false,
+)
+
 private fun ActionsFileDto.toModel(): ActionsConfig {
     val actionsByProject = actions.groupBy { it.projectId }
+    val notesByProject = notes.groupBy { it.projectId }
     return ActionsConfig(
         projects = projects.map { project ->
             ActionProject(
@@ -77,6 +89,14 @@ private fun ActionsFileDto.toModel(): ActionsConfig {
                         command = action.command,
                         cwd = action.cwd.takeIf { it.isNotBlank() },
                         env = action.env,
+                    )
+                },
+                notes = notesByProject[project.id].orEmpty().map { note ->
+                    ProjectNote(
+                        id = note.id,
+                        title = note.title,
+                        body = note.body,
+                        completed = note.completed,
                     )
                 },
             )
@@ -103,6 +123,17 @@ private fun ActionsConfig.toFileDto(): ActionsFileDto = ActionsFileDto(
                 command = action.command,
                 cwd = action.cwd.orEmpty(),
                 env = action.env,
+            )
+        }
+    },
+    notes = projects.flatMap { project ->
+        project.notes.map { note ->
+            NoteDto(
+                id = note.id,
+                projectId = project.id,
+                title = note.title,
+                body = note.body,
+                completed = note.completed,
             )
         }
     },

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopDeviceService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopDeviceService.kt
@@ -4,10 +4,17 @@ import app.andy.desktop.parser.AndroidParsers
 import app.andy.model.AndroidDevice
 import app.andy.model.DeviceConnectionState
 import app.andy.model.DeviceKind
+import app.andy.model.MdnsService
 import app.andy.model.SdkDiscovery
+import app.andy.model.dedupeWifiDeviceAliases
 import app.andy.service.CommandResult
 import app.andy.service.DeviceService
 import app.andy.service.WorkspaceStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
 
 class DesktopDeviceService(
     private val runner: CommandRunner,
@@ -40,11 +47,81 @@ class DesktopDeviceService(
                     storageSummary = AndroidParsers.parseStorage(runner.run(listOf(adb, "-s", base.serial, "shell", "df", "-h", "/data"), 6).stdout),
                 )
             }
+            .let(::dedupeWifiDeviceAliases)
     }
 
     override suspend fun shell(serial: String, command: List<String>): CommandResult {
         val adb = discoverSdk().adbPath ?: return CommandResult.failure("ADB not found")
         return runner.run(listOf(adb, "-s", serial, "shell") + command)
+    }
+
+    override suspend fun pair(host: String, port: Int, code: String): CommandResult {
+        val adb = discoverSdk().adbPath ?: return CommandResult.failure("ADB not found")
+        val result = runner.run(listOf(adb, "pair", "$host:$port", code), 30)
+        val combined = "${result.stdout}\n${result.stderr}"
+        return if (combined.contains("Successfully paired", ignoreCase = true)) {
+            CommandResult.success(result.stdout.ifBlank { "Successfully paired to $host:$port" })
+        } else {
+            CommandResult.failure(
+                message = result.stderr.ifBlank { result.stdout }.ifBlank { "Pairing failed for $host:$port" },
+                exitCode = if (result.exitCode == 0) 1 else result.exitCode,
+            )
+        }
+    }
+
+    override suspend fun connect(host: String, port: Int): CommandResult {
+        val adb = discoverSdk().adbPath ?: return CommandResult.failure("ADB not found")
+        val result = runner.run(listOf(adb, "connect", "$host:$port"), 15)
+        val combined = "${result.stdout}\n${result.stderr}".lowercase()
+        val connected = combined.contains("connected to") &&
+            !combined.contains("failed") &&
+            !combined.contains("cannot")
+        return if (connected) {
+            CommandResult.success(result.stdout.ifBlank { "connected to $host:$port" })
+        } else {
+            CommandResult.failure(
+                message = result.stderr.ifBlank { result.stdout }.ifBlank { "Failed to connect to $host:$port" },
+                exitCode = if (result.exitCode == 0) 1 else result.exitCode,
+            )
+        }
+    }
+
+    override suspend fun disconnect(serial: String): CommandResult {
+        val adb = discoverSdk().adbPath ?: return CommandResult.failure("ADB not found")
+        return runner.run(listOf(adb, "disconnect", serial), 10)
+    }
+
+    override suspend fun listMdnsServices(): List<MdnsService> {
+        val adb = discoverSdk().adbPath ?: return emptyList()
+        val result = runner.run(listOf(adb, "mdns", "services"), 8)
+        if (!result.isSuccess && result.stdout.isBlank()) return emptyList()
+        return AndroidParsers.parseMdnsServices(result.stdout.ifBlank { result.stderr })
+    }
+
+    override suspend fun mdnsAvailable(): Boolean {
+        val adb = discoverSdk().adbPath ?: return false
+        val result = runner.run(listOf(adb, "mdns", "check"), 8)
+        return result.isSuccess
+    }
+
+    override suspend fun generatePairingQr(content: String): ByteArray? = withContext(Dispatchers.IO) {
+        runCatching {
+            val matrix = com.google.zxing.qrcode.QRCodeWriter().encode(
+                content,
+                com.google.zxing.BarcodeFormat.QR_CODE,
+                512,
+                512,
+            )
+            val image = BufferedImage(matrix.width, matrix.height, BufferedImage.TYPE_INT_RGB)
+            for (x in 0 until matrix.width) {
+                for (y in 0 until matrix.height) {
+                    image.setRGB(x, y, if (matrix[x, y]) 0xFF000000.toInt() else 0xFFFFFFFF.toInt())
+                }
+            }
+            val out = ByteArrayOutputStream()
+            ImageIO.write(image, "PNG", out)
+            out.toByteArray()
+        }.getOrNull()
     }
 
     suspend fun adbPath(): String? = discoverSdk().adbPath

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopDeviceService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopDeviceService.kt
@@ -42,6 +42,9 @@ class DesktopDeviceService(
                     abi = props["ro.product.cpu.abi"],
                     model = props["ro.product.model"] ?: base.model,
                     product = props["ro.product.name"] ?: base.product,
+                    hardwareId = props["ro.serialno"]
+                        ?: props["ro.boot.serialno"]
+                        ?: base.hardwareId,
                     batteryPercent = AndroidParsers.parseBatteryPercent(runner.run(listOf(adb, "-s", base.serial, "shell", "dumpsys", "battery"), 6).stdout),
                     screenSize = AndroidParsers.parseWmSize(runner.run(listOf(adb, "-s", base.serial, "shell", "wm", "size"), 6).stdout),
                     storageSummary = AndroidParsers.parseStorage(runner.run(listOf(adb, "-s", base.serial, "shell", "df", "-h", "/data"), 6).stdout),

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
@@ -21,6 +21,8 @@ class DesktopWorkspaceStore : WorkspaceStore {
             logSearch = props.getProperty("logSearch").orEmpty(),
             proxyPort = props.getProperty("proxyPort")?.toIntOrNull() ?: 9099,
             proxyStartOnLaunch = props.getProperty("proxyStartOnLaunch")?.toBooleanStrictOrNull() ?: false,
+            proxySslInsecure = props.getProperty("proxySslInsecure")?.toBooleanStrictOrNull() ?: false,
+            proxyUpstreamTrustedCaPath = props.getProperty("proxyUpstreamTrustedCaPath")?.takeIf { it.isNotBlank() },
             mcpServerEnabled = props.getProperty("mcpServerEnabled")?.toBooleanStrictOrNull() ?: false,
             mcpServerPort = props.getProperty("mcpServerPort")?.toIntOrNull() ?: 8565,
             workspaceSidebarExpanded = props.getProperty("workspaceSidebarExpanded")?.toBooleanStrictOrNull() ?: true,
@@ -51,6 +53,8 @@ class DesktopWorkspaceStore : WorkspaceStore {
             setProperty("logSearch", state.logSearch)
             setProperty("proxyPort", state.proxyPort.toString())
             setProperty("proxyStartOnLaunch", state.proxyStartOnLaunch.toString())
+            setProperty("proxySslInsecure", state.proxySslInsecure.toString())
+            setProperty("proxyUpstreamTrustedCaPath", state.proxyUpstreamTrustedCaPath.orEmpty())
             setProperty("mcpServerEnabled", state.mcpServerEnabled.toString())
             setProperty("mcpServerPort", state.mcpServerPort.toString())
             setProperty("workspaceSidebarExpanded", state.workspaceSidebarExpanded.toString())

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
@@ -1,5 +1,6 @@
 package app.andy.desktop.service
 
+import app.andy.model.PairedWifiDevice
 import app.andy.model.ProxyRule
 import app.andy.model.WorkspaceState
 import app.andy.service.WorkspaceStore
@@ -24,6 +25,7 @@ class DesktopWorkspaceStore : WorkspaceStore {
             mcpServerPort = props.getProperty("mcpServerPort")?.toIntOrNull() ?: 8565,
             workspaceSidebarExpanded = props.getProperty("workspaceSidebarExpanded")?.toBooleanStrictOrNull() ?: true,
             proxyRules = loadProxyRules(props),
+            pairedWifiDevices = loadPairedWifi(props),
             liveDevicePaneWidth = props.getProperty("liveDevicePaneWidth")?.toFloatOrNull() ?: 390f,
             liveControlsPaneHeight = props.getProperty("liveControlsPaneHeight")?.toFloatOrNull() ?: 230f,
             appsListPaneWidth = props.getProperty("appsListPaneWidth")?.toFloatOrNull() ?: 520f,
@@ -65,6 +67,15 @@ class DesktopWorkspaceStore : WorkspaceStore {
                 setProperty(prefix + "removeHeaders", rule.removeHeaders.joinToString("\n"))
                 setProperty(prefix + "responseBody", rule.responseBody.orEmpty())
             }
+            setProperty("pairedWifiCount", state.pairedWifiDevices.size.toString())
+            state.pairedWifiDevices.forEachIndexed { index, device ->
+                val prefix = "pairedWifi.$index."
+                setProperty(prefix + "id", device.id)
+                setProperty(prefix + "displayName", device.displayName)
+                setProperty(prefix + "mdnsInstanceName", device.mdnsInstanceName.orEmpty())
+                setProperty(prefix + "lastEndpoint", device.lastEndpoint.orEmpty())
+                setProperty(prefix + "pairedAtMillis", device.pairedAtMillis.toString())
+            }
             setProperty("liveDevicePaneWidth", state.liveDevicePaneWidth.toString())
             setProperty("liveControlsPaneHeight", state.liveControlsPaneHeight.toString())
             setProperty("appsListPaneWidth", state.appsListPaneWidth.toString())
@@ -98,6 +109,21 @@ class DesktopWorkspaceStore : WorkspaceStore {
                 setHeaders = decodeHeaderMap(props.getProperty(prefix + "setHeaders").orEmpty()),
                 removeHeaders = props.getProperty(prefix + "removeHeaders").orEmpty().lineSequence().map { it.trim() }.filter { it.isNotBlank() }.toList(),
                 responseBody = props.getProperty(prefix + "responseBody")?.takeIf { it.isNotBlank() },
+            )
+        }
+    }
+
+    private fun loadPairedWifi(props: Properties): List<PairedWifiDevice> {
+        val count = props.getProperty("pairedWifiCount")?.toIntOrNull() ?: return emptyList()
+        return (0 until count).mapNotNull { index ->
+            val prefix = "pairedWifi.$index."
+            val id = props.getProperty(prefix + "id")?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            PairedWifiDevice(
+                id = id,
+                displayName = props.getProperty(prefix + "displayName").orEmpty().ifBlank { id },
+                mdnsInstanceName = props.getProperty(prefix + "mdnsInstanceName")?.takeIf { it.isNotBlank() },
+                lastEndpoint = props.getProperty(prefix + "lastEndpoint")?.takeIf { it.isNotBlank() },
+                pairedAtMillis = props.getProperty(prefix + "pairedAtMillis")?.toLongOrNull() ?: 0L,
             )
         }
     }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
@@ -6,6 +6,11 @@ import app.andy.model.DeviceKind
 import app.andy.model.NetworkExchange
 import app.andy.model.NetworkRouteDiagnostics
 import app.andy.model.ProxyRule
+import app.andy.model.ProxyStartOptions
+import app.andy.model.ProxyWarning
+import app.andy.model.ProxyWarningKind
+import app.andy.model.isClientTlsRejectionError
+import app.andy.model.isUpstreamTlsVerificationError
 import app.andy.service.CommandResult
 import app.andy.service.ProxyService
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.UUID
 
 class DesktopProxyService(
     private val runner: CommandRunner,
@@ -29,6 +35,8 @@ class DesktopProxyService(
 ) : ProxyService {
     override val exchanges = MutableStateFlow<List<NetworkExchange>>(emptyList())
     override val status = MutableStateFlow("Proxy stopped")
+    override val warnings = MutableStateFlow<List<ProxyWarning>>(emptyList())
+    override val clientConnectionCount = MutableStateFlow(0)
     private val proxyDir = File(System.getProperty("user.home"), ".andy/proxy")
     private val rulesFile = File(proxyDir, "rules.json")
     private val addonFile = File(proxyDir, "andy_mitm_addon.py")
@@ -55,14 +63,20 @@ class DesktopProxyService(
         File(proxyDir, "mitmproxy-ca-cert.cer").absolutePath
     }
 
-    override suspend fun start(port: Int, rules: List<ProxyRule>): CommandResult = withContext(Dispatchers.IO) {
+    override suspend fun start(port: Int, rules: List<ProxyRule>, options: ProxyStartOptions): CommandResult = withContext(Dispatchers.IO) {
         val executable = mitmdumpExecutable() ?: return@withContext CommandResult.failure("mitmdump not found. Install mitmproxy with `brew install mitmproxy`.")
         stopCurrentProcess(updateStatus = false)
         killOrphanedProxies()
         proxyDir.mkdirs()
         writeAddon()
         writeRules(rules)
+        warnings.value = emptyList()
+        clientConnectionCount.value = 0
         val hostProxy = detectHostProxyState()
+        val trustedCa = options.upstreamTrustedCaPath?.trim()?.takeIf { it.isNotBlank() }?.let(::File)
+        if (trustedCa != null && !trustedCa.isFile) {
+            return@withContext CommandResult.failure("Corporate root CA not found at ${trustedCa.absolutePath}")
+        }
         val command = buildList {
             add(executable)
             hostProxy.upstreamProxy?.let { upstream ->
@@ -78,10 +92,22 @@ class DesktopProxyService(
                     "--set", "termlog_verbosity=warn",
                 ),
             )
+            if (options.sslInsecure) {
+                add("--ssl-insecure")
+            }
+            if (trustedCa != null) {
+                add("--set")
+                add("ssl_verify_upstream_trusted_ca=${trustedCa.absolutePath}")
+            }
         }
         runCatching {
             process = processStarter(command, proxyDir, mapOf("ANDY_RULES_PATH" to rulesFile.absolutePath))
-            status.value = "mitmdump listening on 0.0.0.0:$port" + hostProxy.upstreamProxy?.let { " via Mac proxy $it" }.orEmpty()
+            status.value = buildString {
+                append("mitmdump listening on 0.0.0.0:$port")
+                hostProxy.upstreamProxy?.let { append(" via Mac proxy $it") }
+                if (options.sslInsecure) append(" (insecure upstream)")
+                if (trustedCa != null) append(" (corp CA ${trustedCa.name})")
+            }
             pumpProcess(process!!)
             CommandResult.success(status.value)
         }.getOrElse { error ->
@@ -98,6 +124,8 @@ class DesktopProxyService(
 
     override suspend fun clearTraffic(): CommandResult = withContext(Dispatchers.IO) {
         exchanges.value = emptyList()
+        warnings.value = emptyList()
+        clientConnectionCount.value = 0
         CommandResult.success("Cleared network traffic")
     }
 
@@ -183,6 +211,19 @@ class DesktopProxyService(
             if (!proxyConfigured) add("Android global proxy is ${configuredProxy ?: "not set"}; expected $expectedProxy.")
             if (vpn.active) add("A VPN is active${vpn.name?.let { " ($it)" }.orEmpty()}; it can bypass Android's global HTTP proxy or route Andy's proxy endpoint into the tunnel.")
             if (routeUsesVpn) add("The route to Andy's proxy host appears to use a VPN interface: $routeSummary")
+            if (hostProxy.active && hostProxy.upstreamProxy != null) {
+                if (isLocalHostProxy(hostProxy.upstreamProxy)) {
+                    add(
+                        "Mac system proxy points at a local debug proxy (${hostProxy.upstreamProxy}) — often Proxyman/Charles. " +
+                            "Andy chains through it; if emulator traffic disappears, add localhost/127.0.0.1/10.0.2.2 to that tool's bypass list or quit it.",
+                    )
+                } else {
+                    add(
+                        "Mac system proxy detected (${hostProxy.upstreamProxy}). Andy chains mitmproxy through it; " +
+                            "if upstream TLS verification fails, add the corporate root CA or enable insecure-upstream.",
+                    )
+                }
+            }
             if (hostProxy.active && !hostProxy.bypassLooksSafe) add("Mac proxy bypass rules do not clearly include localhost/127.0.0.1/10.0.2.2; add them if emulator traffic still disappears.")
             if (hostVpn.active) add("Mac VPN-like interfaces are active (${hostVpn.summary}); emulator traffic may be routed by the host tunnel.")
         }
@@ -622,16 +663,36 @@ class DesktopProxyService(
         stdoutJob = kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
             proxyProcess.stdout.bufferedReader().useLines { lines ->
                 lines.forEach { line ->
-                    parseMitmproxyFlowLine(line)?.let { exchange ->
-                        val current = exchanges.value
-                        val index = current.indexOfFirst { it.id == exchange.id }
-                        if (index >= 0) {
-                            val mutable = current.toMutableList()
-                            mutable[index] = exchange
-                            exchanges.value = mutable
-                        } else {
-                            exchanges.value = (current + exchange).takeLast(MaxNetworkExchanges)
+                    when (val event = parseMitmproxyEvent(line)) {
+                        is MitmproxyEvent.Exchange -> {
+                            val exchange = event.exchange
+                            val current = exchanges.value
+                            val index = current.indexOfFirst { it.id == exchange.id }
+                            if (index >= 0) {
+                                val mutable = current.toMutableList()
+                                mutable[index] = exchange
+                                exchanges.value = mutable
+                            } else {
+                                exchanges.value = (current + exchange).takeLast(MaxNetworkExchanges)
+                            }
+                            if (isClientTlsRejectionError(exchange.error) || exchange.method == "TLS") {
+                                pushWarning(
+                                    ProxyWarningKind.ClientTlsFailure,
+                                    exchange.error ?: "Client TLS handshake failed",
+                                    sni = exchange.url.removePrefix("https://").substringBefore('/').takeIf { it.isNotBlank() },
+                                )
+                            } else if (isUpstreamTlsVerificationError(exchange.error)) {
+                                pushWarning(
+                                    ProxyWarningKind.UpstreamTlsFailure,
+                                    exchange.error ?: "Upstream TLS verification failed",
+                                )
+                            }
                         }
+                        is MitmproxyEvent.ClientConnected -> {
+                            clientConnectionCount.value = clientConnectionCount.value + 1
+                        }
+                        is MitmproxyEvent.ClientDisconnected -> Unit
+                        null -> Unit
                     }
                 }
             }
@@ -641,10 +702,39 @@ class DesktopProxyService(
             proxyProcess.stderr.bufferedReader().useLines { lines ->
                 lines.forEach { line ->
                     System.err.println("[Proxy stderr] $line")
-                    if (process === proxyProcess && line.isNotBlank() && !proxyProcess.isAlive()) status.value = line.take(220)
+                    if (process === proxyProcess && line.isNotBlank()) {
+                        classifyStderrWarning(line)?.let { (kind, message) ->
+                            pushWarning(kind, message)
+                        }
+                        if (!proxyProcess.isAlive()) status.value = line.take(220)
+                    }
                 }
             }
         }
+    }
+
+    private fun classifyStderrWarning(line: String): Pair<ProxyWarningKind, String>? {
+        return when {
+            isUpstreamTlsVerificationError(line) -> ProxyWarningKind.UpstreamTlsFailure to line.trim()
+            isClientTlsRejectionError(line) ||
+                line.contains("client TLS handshake failed", ignoreCase = true) ||
+                line.contains("Client TLS handshake failed", ignoreCase = false) ->
+                ProxyWarningKind.ClientTlsFailure to line.trim()
+            line.contains("TLS", ignoreCase = true) && line.contains("fail", ignoreCase = true) ->
+                ProxyWarningKind.Other to line.trim()
+            else -> null
+        }
+    }
+
+    private fun pushWarning(kind: ProxyWarningKind, message: String, sni: String? = null) {
+        val warning = ProxyWarning(
+            id = UUID.randomUUID().toString(),
+            atMillis = System.currentTimeMillis(),
+            kind = kind,
+            message = message.take(400),
+            sni = sni,
+        )
+        warnings.value = (warnings.value + warning).takeLast(50)
     }
 
     private fun writeRules(rules: List<ProxyRule>) {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -671,14 +672,13 @@ class DesktopProxyService(
                     when (val event = parseMitmproxyEvent(line)) {
                         is MitmproxyEvent.Exchange -> {
                             val exchange = event.exchange
-                            val current = exchanges.value
-                            val index = current.indexOfFirst { it.id == exchange.id }
-                            if (index >= 0) {
-                                val mutable = current.toMutableList()
-                                mutable[index] = exchange
-                                exchanges.value = mutable
-                            } else {
-                                exchanges.value = (current + exchange).takeLast(MaxNetworkExchanges)
+                            exchanges.update { current ->
+                                val index = current.indexOfFirst { it.id == exchange.id }
+                                if (index >= 0) {
+                                    current.toMutableList().also { it[index] = exchange }
+                                } else {
+                                    (current + exchange).takeLast(MaxNetworkExchanges)
+                                }
                             }
                             if (isClientTlsRejectionError(exchange.error) || exchange.method == "TLS") {
                                 pushWarning(
@@ -694,7 +694,7 @@ class DesktopProxyService(
                             }
                         }
                         is MitmproxyEvent.ClientConnected -> {
-                            clientConnectionCount.value = clientConnectionCount.value + 1
+                            clientConnectionCount.update { it + 1 }
                         }
                         is MitmproxyEvent.ClientDisconnected -> Unit
                         null -> Unit
@@ -739,7 +739,7 @@ class DesktopProxyService(
             message = message.take(400),
             sni = sni,
         )
-        warnings.value = (warnings.value + warning).takeLast(50)
+        warnings.update { (it + warning).takeLast(50) }
     }
 
     private fun writeRules(rules: List<ProxyRule>) {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
@@ -11,6 +11,7 @@ import app.andy.model.ProxyWarning
 import app.andy.model.ProxyWarningKind
 import app.andy.model.isClientTlsRejectionError
 import app.andy.model.isUpstreamTlsVerificationError
+import app.andy.model.isWirelessAdbSerial
 import app.andy.service.CommandResult
 import app.andy.service.ProxyService
 import kotlinx.coroutines.Dispatchers
@@ -608,6 +609,10 @@ class DesktopProxyService(
     }
 
     private suspend fun restartDeviceInternet(adb: String, serial: String): CommandResult {
+        // Disabling Wi-Fi on an ADB-over-Wi-Fi session drops the transport before re-enable can run.
+        if (isWirelessAdbSerial(serial)) {
+            return CommandResult.success("Skipped Wi-Fi restart for wireless ADB device to avoid dropping the connection")
+        }
         val wifiWasEnabled = readWifiEnabled(adb, serial) != false
         val disableWifi = runner.run(listOf(adb, "-s", serial, "shell", "cmd", "wifi", "set-wifi-enabled", "disabled"), 10)
             .takeIf { it.isSuccess }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/HostNetworkState.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/HostNetworkState.kt
@@ -70,16 +70,20 @@ internal fun proxyEndpoint(entries: Map<String, String>, prefix: String): String
     val host = entries["${prefix}Proxy"]?.takeIf { it.isNotBlank() } ?: return null
     val port = entries["${prefix}Port"]?.takeIf { it.isNotBlank() } ?: return null
     val scheme = if (prefix == "SOCKS") "socks5" else "http"
-    return "$scheme://$host:$port"
+    val authorityHost = if (':' in host && !host.startsWith("[")) "[$host]" else host
+    return "$scheme://$authorityHost:$port"
 }
 
 internal fun isLocalHostProxy(upstream: String?): Boolean {
     if (upstream.isNullOrBlank()) return false
-    val host = upstream
+    val authority = upstream
         .substringAfter("://", missingDelimiterValue = upstream)
         .substringBefore('/')
-        .substringBefore(':')
-        .lowercase()
+    val host = when {
+        authority.startsWith("[") -> authority.substringBefore(']') + "]"
+        authority.count { it == ':' } > 1 -> authority // unbracketed IPv6 without port, or already host-only
+        else -> authority.substringBefore(':')
+    }.lowercase()
     return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]"
 }
 

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/HostNetworkState.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/HostNetworkState.kt
@@ -73,6 +73,16 @@ internal fun proxyEndpoint(entries: Map<String, String>, prefix: String): String
     return "$scheme://$host:$port"
 }
 
+internal fun isLocalHostProxy(upstream: String?): Boolean {
+    if (upstream.isNullOrBlank()) return false
+    val host = upstream
+        .substringAfter("://", missingDelimiterValue = upstream)
+        .substringBefore('/')
+        .substringBefore(':')
+        .lowercase()
+    return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]"
+}
+
 internal fun proxyExceptionCovers(exception: String, expected: String): Boolean {
     val normalized = exception.trim().lowercase()
     val target = expected.lowercase()

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/ProxyJson.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/ProxyJson.kt
@@ -49,7 +49,16 @@ internal data class MitmproxyFlowLineDto(
     val error: String? = null,
     val tlsStatus: String? = null,
     val matchedRuleId: String? = null,
+    val sni: String? = null,
+    val peer: String? = null,
+    val reason: String? = null,
 )
+
+internal sealed interface MitmproxyEvent {
+    data class Exchange(val exchange: NetworkExchange) : MitmproxyEvent
+    data class ClientConnected(val id: String, val peer: String?, val atMillis: Long) : MitmproxyEvent
+    data class ClientDisconnected(val id: String, val peer: String?, val atMillis: Long) : MitmproxyEvent
+}
 
 internal object ProxyRuleJson {
     fun writeRules(rules: List<ProxyRule>): String {
@@ -58,30 +67,55 @@ internal object ProxyRuleJson {
     }
 }
 
-internal fun parseMitmproxyFlowLine(line: String): NetworkExchange? {
+internal fun parseMitmproxyFlowLine(line: String): NetworkExchange? =
+    (parseMitmproxyEvent(line) as? MitmproxyEvent.Exchange)?.exchange
+
+internal fun parseMitmproxyEvent(line: String): MitmproxyEvent? {
     if (!line.trimStart().startsWith("{")) return null
     val dto = runCatching {
         ProxyJsonFormat.decodeFromString(MitmproxyFlowLineDto.serializer(), line)
     }.getOrNull() ?: return null
-    if (dto.type != "flow") return null
+    return when (dto.type) {
+        "flow", "tls_failed" -> MitmproxyEvent.Exchange(dto.toNetworkExchange())
+        "client_connected" -> MitmproxyEvent.ClientConnected(
+            id = dto.id,
+            peer = dto.peer,
+            atMillis = dto.startedAtMillis ?: System.currentTimeMillis(),
+        )
+        "client_disconnected" -> MitmproxyEvent.ClientDisconnected(
+            id = dto.id,
+            peer = dto.peer,
+            atMillis = dto.startedAtMillis ?: System.currentTimeMillis(),
+        )
+        else -> null
+    }
+}
+
+private fun MitmproxyFlowLineDto.toNetworkExchange(): NetworkExchange {
+    val host = sni ?: url?.removePrefix("https://")?.substringBefore('/') ?: "unknown-host"
+    val synthesizedError = when {
+        type != "tls_failed" -> error
+        !error.isNullOrBlank() -> error
+        else -> "Client rejected Andy's CA for $host: ${reason ?: "client TLS handshake failed"}"
+    }
     return NetworkExchange(
-        id = dto.id,
-        flowId = dto.id,
-        startedAtMillis = dto.startedAtMillis ?: System.currentTimeMillis(),
-        completedAtMillis = dto.completedAtMillis,
-        method = dto.method ?: "-",
-        url = dto.url ?: "-",
-        statusCode = dto.statusCode,
-        contentType = dto.contentType,
-        sizeBytes = dto.sizeBytes,
-        durationMillis = dto.durationMillis,
-        requestHeaders = dto.requestHeaders,
-        responseHeaders = dto.responseHeaders,
-        requestBodyPreview = dto.requestBodyPreview,
-        responseBodyPreview = dto.responseBodyPreview,
-        error = dto.error,
-        tlsStatus = dto.tlsStatus,
-        matchedRuleId = dto.matchedRuleId,
+        id = id,
+        flowId = id,
+        startedAtMillis = startedAtMillis ?: System.currentTimeMillis(),
+        completedAtMillis = completedAtMillis,
+        method = method ?: if (type == "tls_failed") "TLS" else "-",
+        url = url ?: if (type == "tls_failed") "https://$host/" else "-",
+        statusCode = statusCode,
+        contentType = contentType,
+        sizeBytes = sizeBytes,
+        durationMillis = durationMillis,
+        requestHeaders = requestHeaders,
+        responseHeaders = responseHeaders,
+        requestBodyPreview = requestBodyPreview,
+        responseBodyPreview = responseBodyPreview,
+        error = synthesizedError,
+        tlsStatus = tlsStatus ?: if (type == "tls_failed") "tls" else null,
+        matchedRuleId = matchedRuleId,
     )
 }
 

--- a/src/desktopMain/resources/proxy/andy_mitm_addon.py
+++ b/src/desktopMain/resources/proxy/andy_mitm_addon.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import time
+import uuid
 from mitmproxy import http
 
 RULES_PATH = os.environ.get("ANDY_RULES_PATH")
@@ -70,6 +71,19 @@ def _match(rule, flow):
     return True
 
 
+def _emit_event(payload):
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+def _peer_address(conn):
+    peer = getattr(conn, "peername", None)
+    if isinstance(peer, (list, tuple)) and peer:
+        host = peer[0]
+        port = peer[1] if len(peer) > 1 else None
+        return f"{host}:{port}" if port is not None else str(host)
+    return str(peer) if peer else None
+
+
 def request(flow: http.HTTPFlow):
     flow.metadata["andy_started_at"] = int(time.time() * 1000)
     _emit(flow, is_request=True)
@@ -111,6 +125,73 @@ def error(flow: http.HTTPFlow):
     _emit(flow, None, str(flow.error) if flow.error else "proxy error")
 
 
+def client_connected(client):
+    _emit_event(
+        {
+            "type": "client_connected",
+            "id": getattr(client, "id", None) or str(uuid.uuid4()),
+            "startedAtMillis": int(time.time() * 1000),
+            "peer": _peer_address(client),
+        }
+    )
+
+
+def client_disconnected(client):
+    _emit_event(
+        {
+            "type": "client_disconnected",
+            "id": getattr(client, "id", None) or str(uuid.uuid4()),
+            "startedAtMillis": int(time.time() * 1000),
+            "peer": _peer_address(client),
+        }
+    )
+
+
+def tls_failed_client(data):
+    conn = getattr(data, "conn", None)
+    context = getattr(data, "context", None)
+    server = getattr(context, "server", None) if context is not None else None
+    sni = getattr(conn, "sni", None) if conn is not None else None
+    if not sni and server is not None:
+        address = getattr(server, "address", None)
+        if isinstance(address, (list, tuple)) and address:
+            sni = address[0]
+        elif address:
+            sni = str(address)
+    reason = None
+    if conn is not None:
+        reason = getattr(conn, "error", None)
+    if not reason:
+        reason = "client TLS handshake failed"
+    host = sni or "unknown-host"
+    now = int(time.time() * 1000)
+    flow_id = getattr(conn, "id", None) or str(uuid.uuid4())
+    _emit_event(
+        {
+            "type": "tls_failed",
+            "id": f"tls-failed-{flow_id}",
+            "startedAtMillis": now,
+            "completedAtMillis": now,
+            "durationMillis": 0,
+            "method": "TLS",
+            "url": f"https://{host}/",
+            "statusCode": None,
+            "contentType": None,
+            "sizeBytes": None,
+            "requestHeaders": {},
+            "responseHeaders": {},
+            "requestBodyPreview": None,
+            "responseBodyPreview": None,
+            "error": f"Client rejected Andy's CA for {host}: {reason}",
+            "tlsStatus": "tls",
+            "matchedRuleId": None,
+            "sni": sni,
+            "peer": _peer_address(conn) if conn is not None else None,
+            "reason": str(reason),
+        }
+    )
+
+
 def _emit(flow, matched_rule_id=None, error=None, is_request=False):
     response = flow.response if (hasattr(flow, 'response') and flow.response) else None
     started = flow.metadata.get("andy_started_at")
@@ -144,4 +225,4 @@ def _emit(flow, matched_rule_id=None, error=None, is_request=False):
         "tlsStatus": "tls" if flow.request.scheme == "https" else "plain",
         "matchedRuleId": matched_rule_id,
     }
-    print(json.dumps(payload, separators=(",", ":")), flush=True)
+    _emit_event(payload)

--- a/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AndroidParsersTest {
@@ -28,9 +29,83 @@ class AndroidParsersTest {
         assertEquals("SM S921U", devices[0].displayName)
         assertEquals(DeviceKind.Physical, devices[0].kind)
         assertEquals(DeviceConnectionState.Online, devices[0].state)
+        assertEquals(app.andy.model.DeviceTransport.Usb, devices[0].transport)
         assertEquals(DeviceKind.Emulator, devices[1].kind)
         assertEquals(DeviceConnectionState.Offline, devices[1].state)
+        assertEquals(app.andy.model.DeviceTransport.Unknown, devices[1].transport)
         assertEquals(DeviceConnectionState.Unauthorized, devices[2].state)
+    }
+
+    @Test
+    fun classifiesWifiTransportFromIpPortSerial() {
+        val output = """
+            List of devices attached
+            192.168.86.47:5555	device product:e3q model:SM_S921U device:e3q transport_id:4
+            emulator-5554	device
+            R3CXB056ZZB	device product:e3q model:SM_S921U device:e3q transport_id:5
+        """.trimIndent()
+
+        val devices = AndroidParsers.parseAdbDevices(output)
+
+        assertEquals(app.andy.model.DeviceTransport.Wifi, devices[0].transport)
+        assertEquals(DeviceKind.Physical, devices[0].kind)
+        assertEquals(app.andy.model.DeviceTransport.Unknown, devices[1].transport)
+        assertEquals(app.andy.model.DeviceTransport.Usb, devices[2].transport)
+    }
+
+    @Test
+    fun dedupesWifiIpAndMdnsAliasForSameDevice() {
+        val output = """
+            List of devices attached
+            192.168.86.150:35923	device product:blazer model:Pixel_10_Pro device:blazer transport_id:3
+            adb-5A080DLCH000UR-oVigq2._adb-tls-connect._tcp	device product:blazer model:Pixel_10_Pro device:blazer transport_id:4
+            emulator-5554	device product:sdk_gphone64_arm64 model:Pixel_9 device:emu64a transport_id:1
+        """.trimIndent()
+
+        val devices = AndroidParsers.parseAdbDevices(output)
+
+        assertEquals(2, devices.size)
+        assertEquals("192.168.86.150:35923", devices[0].serial)
+        assertEquals(app.andy.model.DeviceTransport.Wifi, devices[0].transport)
+        assertEquals("emulator-5554", devices[1].serial)
+        assertTrue(devices.none { it.serial.contains("_adb-tls-connect") })
+    }
+
+    @Test
+    fun keepsDistinctWifiDevicesWithDifferentModels() {
+        val output = """
+            List of devices attached
+            192.168.86.150:35923	device product:blazer model:Pixel_10_Pro device:blazer transport_id:3
+            192.168.86.200:5555	device product:e3q model:SM_S921U device:e3q transport_id:4
+            adb-OTHER._adb-tls-connect._tcp	device product:e3q model:SM_S921U device:e3q transport_id:5
+        """.trimIndent()
+
+        val devices = AndroidParsers.parseAdbDevices(output)
+
+        assertEquals(2, devices.size)
+        assertEquals(setOf("192.168.86.150:35923", "192.168.86.200:5555"), devices.map { it.serial }.toSet())
+    }
+
+    @Test
+    fun parsesMdnsServices() {
+        val output = """
+            List of discovered mdns services
+            adb-VAN10A203710441	_adb._tcp	192.168.86.47:5555
+            adb-VAN10A203710441	_adb-tls-connect._tcp	192.168.86.47:37123
+            adb-PAIRING	_adb-tls-pairing._tcp	192.168.86.47:37199
+        """.trimIndent()
+
+        val services = AndroidParsers.parseMdnsServices(output)
+
+        assertEquals(3, services.size)
+        assertEquals("adb-VAN10A203710441", services[0].instanceName)
+        assertEquals("_adb._tcp", services[0].serviceType)
+        assertEquals("192.168.86.47", services[0].host)
+        assertEquals(5555, services[0].port)
+        assertTrue(services[0].isConnect)
+        assertTrue(services[1].isConnect)
+        assertTrue(services[2].isPairing)
+        assertFalse(services[2].isConnect)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
@@ -5,6 +5,8 @@ import app.andy.model.DeviceKind
 import app.andy.model.LogLevel
 import app.andy.model.AvdProfileCategory
 import app.andy.model.VirtualDeviceType
+import app.andy.model.isMdnsAdbSerial
+import app.andy.model.isWifiIpSerial
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -54,7 +56,9 @@ class AndroidParsersTest {
     }
 
     @Test
-    fun dedupesWifiIpAndMdnsAliasForSameDevice() {
+    fun keepsWifiIpAndMdnsAliasUntilHardwareIdsAreKnown() {
+        // Parse-time rows only have a hardware id on the mDNS serial, so aliases stay until
+        // DesktopDeviceService enriches IP devices with ro.serialno and dedupes again.
         val output = """
             List of devices attached
             192.168.86.150:35923	device product:blazer model:Pixel_10_Pro device:blazer transport_id:3
@@ -64,26 +68,35 @@ class AndroidParsersTest {
 
         val devices = AndroidParsers.parseAdbDevices(output)
 
-        assertEquals(2, devices.size)
-        assertEquals("192.168.86.150:35923", devices[0].serial)
-        assertEquals(app.andy.model.DeviceTransport.Wifi, devices[0].transport)
-        assertEquals("emulator-5554", devices[1].serial)
-        assertTrue(devices.none { it.serial.contains("_adb-tls-connect") })
+        assertEquals(3, devices.size)
+        assertEquals(
+            setOf(
+                "192.168.86.150:35923",
+                "adb-5A080DLCH000UR-oVigq2._adb-tls-connect._tcp",
+                "emulator-5554",
+            ),
+            devices.map { it.serial }.toSet(),
+        )
+        assertEquals("5A080DLCH000UR-oVigq2", devices.first { isMdnsAdbSerial(it.serial) }.hardwareId)
+        assertNull(devices.first { isWifiIpSerial(it.serial) }.hardwareId)
     }
 
     @Test
-    fun keepsDistinctWifiDevicesWithDifferentModels() {
+    fun keepsDistinctSameModelWifiDevicesWithoutSharedHardwareId() {
         val output = """
             List of devices attached
             192.168.86.150:35923	device product:blazer model:Pixel_10_Pro device:blazer transport_id:3
             192.168.86.200:5555	device product:e3q model:SM_S921U device:e3q transport_id:4
-            adb-OTHER._adb-tls-connect._tcp	device product:e3q model:SM_S921U device:e3q transport_id:5
+            adb-OTHERSERIAL._adb-tls-connect._tcp	device product:e3q model:SM_S921U device:e3q transport_id:5
         """.trimIndent()
 
         val devices = AndroidParsers.parseAdbDevices(output)
 
-        assertEquals(2, devices.size)
-        assertEquals(setOf("192.168.86.150:35923", "192.168.86.200:5555"), devices.map { it.serial }.toSet())
+        assertEquals(3, devices.size)
+        assertEquals(
+            setOf("192.168.86.150:35923", "192.168.86.200:5555", "adb-OTHERSERIAL._adb-tls-connect._tcp"),
+            devices.map { it.serial }.toSet(),
+        )
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
@@ -1,0 +1,112 @@
+package app.andy.desktop.service
+
+import app.andy.model.ActionProject
+import app.andy.model.ActionsConfig
+import app.andy.model.ProjectAction
+import app.andy.model.ProjectNote
+import kotlinx.coroutines.runBlocking
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DesktopActionConfigStoreTest {
+    @Test
+    fun roundTripsProjectsActionsAndNotes() = runBlocking {
+        val dir = createTempDirectory("andy-actions-config").toFile()
+        val file = dir.resolve("actions.toml")
+        val store = DesktopActionConfigStore(file)
+        val config = ActionsConfig(
+            projects = listOf(
+                ActionProject(
+                    id = "proj-demo",
+                    name = "Demo",
+                    contextDir = "/tmp/demo",
+                    env = mapOf("FOO" to "bar"),
+                    actions = listOf(
+                        ProjectAction(
+                            id = "act-build",
+                            name = "Build",
+                            icon = "build",
+                            command = "./gradlew build",
+                            cwd = "/tmp/demo/app",
+                        ),
+                    ),
+                    notes = listOf(
+                        ProjectNote(
+                            id = "note-ship",
+                            title = "Ship checklist",
+                            body = "Verify release notes",
+                            completed = false,
+                        ),
+                        ProjectNote(
+                            id = "note-done",
+                            title = "Done item",
+                            body = "",
+                            completed = true,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        store.save(config)
+        val loaded = store.load()
+
+        assertEquals(1, loaded.projects.size)
+        val project = loaded.projects.single()
+        assertEquals("proj-demo", project.id)
+        assertEquals("Demo", project.name)
+        assertEquals("/tmp/demo", project.contextDir)
+        assertEquals(mapOf("FOO" to "bar"), project.env)
+        assertEquals(1, project.actions.size)
+        assertEquals("act-build", project.actions.single().id)
+        assertEquals("./gradlew build", project.actions.single().command)
+        assertEquals("/tmp/demo/app", project.actions.single().cwd)
+        assertEquals(2, project.notes.size)
+        assertEquals(
+            ProjectNote("note-ship", "Ship checklist", "Verify release notes", completed = false),
+            project.notes.first { it.id == "note-ship" },
+        )
+        assertEquals(
+            ProjectNote("note-done", "Done item", "", completed = true),
+            project.notes.first { it.id == "note-done" },
+        )
+        assertTrue(file.readText().contains("[[notes]]"))
+        assertTrue(file.readText().contains("title = \"Ship checklist\""))
+    }
+
+    @Test
+    fun loadsLegacyTomlWithoutNotesAsEmptyNotes() = runBlocking {
+        val dir = createTempDirectory("andy-actions-legacy").toFile()
+        val file = dir.resolve("actions.toml")
+        file.writeText(
+            """
+            version = 1
+            [[projects]]
+            id = "proj-legacy"
+            name = "Legacy"
+            contextDir = "/tmp/legacy"
+            env = { }
+            [[actions]]
+            id = "act-run"
+            projectId = "proj-legacy"
+            name = "Run"
+            icon = "run"
+            command = "echo hi"
+            cwd = ""
+            env = { }
+            """.trimIndent() + "\n",
+        )
+
+        val loaded = DesktopActionConfigStore(file).load()
+        assertEquals(1, loaded.projects.size)
+        val project = loaded.projects.single()
+        assertEquals("proj-legacy", project.id)
+        assertEquals(1, project.actions.size)
+        assertEquals("act-run", project.actions.single().id)
+        assertTrue(project.notes.isEmpty())
+        assertFalse(file.readText().contains("[[notes]]"))
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopBugServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopBugServiceTest.kt
@@ -149,4 +149,10 @@ private class FakeForegroundDeviceService : DeviceService {
             else -> CommandResult.success()
         }
     }
+    override suspend fun pair(host: String, port: Int, code: String): CommandResult = CommandResult.failure("Not supported")
+    override suspend fun connect(host: String, port: Int): CommandResult = CommandResult.failure("Not supported")
+    override suspend fun disconnect(serial: String): CommandResult = CommandResult.failure("Not supported")
+    override suspend fun listMdnsServices(): List<app.andy.model.MdnsService> = emptyList()
+    override suspend fun mdnsAvailable(): Boolean = false
+    override suspend fun generatePairingQr(content: String): ByteArray? = null
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
@@ -389,6 +389,28 @@ class DesktopProxyServiceTest {
     }
 
     @Test
+    fun routeDiagnosticsRecognizesIpv6LoopbackAsLocalDebugProxy() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+        env.macProxyOutput = """
+            <dictionary> {
+              HTTPEnable : 1
+              HTTPProxy : ::1
+              HTTPPort : 9090
+              HTTPSEnable : 1
+              HTTPSProxy : ::1
+              HTTPSPort : 9090
+            }
+        """.trimIndent()
+
+        val diagnostics = services.proxy.diagnoseDeviceProxyRoute("emulator-5554", "10.0.2.2", 8888)
+
+        assertTrue(diagnostics.hostProxyActive)
+        assertEquals("http://[::1]:9090", diagnostics.hostUpstreamProxy)
+        assertTrue(diagnostics.issues.any { it.contains("local debug proxy") })
+    }
+
+    @Test
     fun openVpnSettingsStartsAndroidVpnSettings() = runBlocking {
         val env = MockAndroidDeviceEnvironment()
         val services = env.services()

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
@@ -98,6 +98,15 @@ class DesktopProxyServiceTest {
                             responseBody = """{"error":"missing"}""",
                         ),
                     ),
+                    pairedWifiDevices = listOf(
+                        app.andy.model.PairedWifiDevice(
+                            id = "wifi-1",
+                            displayName = "adb-VAN10A203710441",
+                            mdnsInstanceName = "adb-VAN10A203710441",
+                            lastEndpoint = "192.168.86.47:5555",
+                            pairedAtMillis = 1_720_000_000_000L,
+                        ),
+                    ),
                 ),
             )
 
@@ -108,6 +117,10 @@ class DesktopProxyServiceTest {
             assertEquals(404, loadedRule.statusCode)
             assertEquals(mapOf("x-andy" to "missing", "content-type" to "application/json"), loadedRule.setHeaders)
             assertEquals(listOf("Server", "etag"), loadedRule.removeHeaders)
+            val loadedWifi = loaded.pairedWifiDevices.single()
+            assertEquals("wifi-1", loadedWifi.id)
+            assertEquals("adb-VAN10A203710441", loadedWifi.mdnsInstanceName)
+            assertEquals("192.168.86.47:5555", loadedWifi.lastEndpoint)
         } finally {
             System.setProperty("user.home", originalHome)
             testHome.deleteRecursively()

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
@@ -4,10 +4,14 @@ import app.andy.desktop.service.proxy.DesktopProxyService
 import app.andy.desktop.service.proxy.ProxyRuleJson
 import app.andy.desktop.service.proxy.parseMitmproxyFlowLine
 import app.andy.model.ProxyRule
+import app.andy.model.ProxyStartOptions
+import app.andy.model.ProxyWarningKind
 import app.andy.model.WorkspaceState
 import app.andy.model.matches
 import app.andy.service.CommandResult
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -176,6 +180,121 @@ class DesktopProxyServiceTest {
     }
 
     @Test
+    fun startAppliesCorporateUpstreamTrustOptions() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val originalHome = System.getProperty("user.home")
+        val testHome = kotlin.io.path.createTempDirectory("andy-proxy-corp-ca").toFile()
+        try {
+            System.setProperty("user.home", testHome.absolutePath)
+            val ca = File(testHome, "corp-root.pem").apply { writeText("CORP-CA") }
+            val service = DesktopProxyService(
+                env.runner,
+                env.devices,
+                mitmdumpExecutable = { "/usr/bin/mitmdump" },
+                processStarter = { command, _, _ ->
+                    env.proxyCommands += command
+                    MockProxyProcess()
+                },
+                hostOsName = { env.hostOsName },
+            )
+
+            val result = service.start(
+                8888,
+                emptyList(),
+                ProxyStartOptions(sslInsecure = true, upstreamTrustedCaPath = ca.absolutePath),
+            )
+
+            assertTrue(result.isSuccess)
+            val command = env.proxyCommands.single()
+            assertTrue(command.contains("--ssl-insecure"))
+            assertTrue(command.windowed(2).any { it == listOf("--set", "ssl_verify_upstream_trusted_ca=${ca.absolutePath}") })
+            assertTrue(result.stdout.contains("insecure upstream"))
+            assertTrue(result.stdout.contains("corp CA"))
+        } finally {
+            System.setProperty("user.home", originalHome)
+            testHome.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun liveStderrTlsWarningsArePublishedWhileProcessIsAlive() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val service = DesktopProxyService(
+            env.runner,
+            env.devices,
+            mitmdumpExecutable = { "/usr/bin/mitmdump" },
+            processStarter = { _, _, _ ->
+                MockProxyProcess(
+                    stdoutText = "",
+                    stderrText = "Client TLS handshake failed. The client does not trust the proxy's certificate.\n",
+                )
+            },
+            hostOsName = { env.hostOsName },
+        )
+
+        assertTrue(service.start(8888, emptyList()).isSuccess)
+        val warnings = withTimeout(2_000) {
+            service.warnings.first { it.isNotEmpty() }
+        }
+        assertTrue(warnings.any { it.kind == ProxyWarningKind.ClientTlsFailure })
+        service.stop()
+        Unit
+    }
+
+    @Test
+    fun tlsFailedAddonEventsAppearInExchanges() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val service = DesktopProxyService(
+            env.runner,
+            env.devices,
+            mitmdumpExecutable = { "/usr/bin/mitmdump" },
+            processStarter = { _, _, _ ->
+                MockProxyProcess(
+                    stdoutText = """
+                        {"type":"client_connected","id":"c1","startedAtMillis":1,"peer":"10.0.2.15:1"}
+                        {"type":"tls_failed","id":"tls-failed-1","startedAtMillis":2,"completedAtMillis":2,"durationMillis":0,"method":"TLS","url":"https://pinned.example/","statusCode":null,"contentType":null,"sizeBytes":null,"requestHeaders":{},"responseHeaders":{},"requestBodyPreview":null,"responseBodyPreview":null,"error":"Client rejected Andy's CA for pinned.example: unknown ca","tlsStatus":"tls","matchedRuleId":null,"sni":"pinned.example","peer":"10.0.2.15:1","reason":"unknown ca"}
+                    """.trimIndent(),
+                )
+            },
+            hostOsName = { env.hostOsName },
+        )
+
+        assertTrue(service.start(8888, emptyList()).isSuccess)
+        val exchanges = withTimeout(2_000) {
+            service.exchanges.first { it.any { exchange -> exchange.method == "TLS" } }
+        }
+        assertEquals(1, service.clientConnectionCount.value)
+        assertEquals("https://pinned.example/", exchanges.single().url)
+        assertTrue(exchanges.single().error!!.contains("rejected Andy's CA"))
+        service.stop()
+        Unit
+    }
+
+    @Test
+    fun routeDiagnosticsFlagsDetectedMacCorporateProxy() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+        env.macProxyOutput = """
+            <dictionary> {
+              HTTPEnable : 1
+              HTTPProxy : proxy.example.test
+              HTTPPort : 8080
+              ExceptionsList : <array> {
+                0 : localhost
+                1 : 127.0.0.1
+                2 : 10.0.2.2
+              }
+            }
+        """.trimIndent()
+
+        val diagnostics = services.proxy.diagnoseDeviceProxyRoute("emulator-5554", "10.0.2.2", 8888)
+
+        assertTrue(diagnostics.hostProxyActive)
+        assertEquals("http://proxy.example.test:8080", diagnostics.hostUpstreamProxy)
+        assertTrue(diagnostics.issues.any { it.contains("Mac system proxy detected") })
+    }
+
+    @Test
     fun deviceProxyHostUsesEmulatorLoopbackAliasOnlyForEmulators() = runBlocking {
         val env = MockAndroidDeviceEnvironment()
         val services = env.services()
@@ -241,6 +360,32 @@ class DesktopProxyServiceTest {
         assertFalse(diagnostics.vpnActive)
         assertFalse(diagnostics.routeUsesVpn)
         assertTrue(diagnostics.issues.isEmpty())
+    }
+
+    @Test
+    fun routeDiagnosticsDescribesLocalDebugProxyWithoutCorporateLabel() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+        env.macProxyOutput = """
+            <dictionary> {
+              HTTPEnable : 1
+              HTTPProxy : 127.0.0.1
+              HTTPPort : 9090
+              HTTPSEnable : 1
+              HTTPSProxy : 127.0.0.1
+              HTTPSPort : 9090
+              ExceptionsList : <array> {
+                0 : dns.google
+              }
+            }
+        """.trimIndent()
+
+        val diagnostics = services.proxy.diagnoseDeviceProxyRoute("emulator-5554", "10.0.2.2", 8888)
+
+        assertTrue(diagnostics.hostProxyActive)
+        assertEquals("http://127.0.0.1:9090", diagnostics.hostUpstreamProxy)
+        assertTrue(diagnostics.issues.any { it.contains("local debug proxy") })
+        assertTrue(diagnostics.issues.none { it.contains("corporate", ignoreCase = true) })
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
@@ -193,6 +193,44 @@ class DesktopServicesMockDeviceTest {
     }
 
     @Test
+    fun wifiPairConnectAndMdnsUseMockAdb() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+
+        assertTrue(services.devices.mdnsAvailable())
+        val mdns = services.devices.listMdnsServices()
+        assertEquals(3, mdns.size)
+        assertTrue(mdns.any { it.isPairing })
+        assertTrue(mdns.any { it.isConnect })
+
+        val paired = services.devices.pair("192.168.86.47", 37199, "123456")
+        assertTrue(paired.isSuccess)
+        assertTrue(paired.stdout.contains("Successfully paired"))
+
+        env.pairShouldSucceed = false
+        val failedPair = services.devices.pair("192.168.86.47", 37199, "000000")
+        assertFalse(failedPair.isSuccess)
+
+        val connected = services.devices.connect("192.168.86.47", 5555)
+        assertTrue(connected.isSuccess)
+        assertTrue(connected.stdout.contains("connected to"))
+        assertTrue(env.ran("connect", "192.168.86.47:5555"))
+
+        env.connectShouldSucceed = false
+        val failedConnect = services.devices.connect("192.168.86.47", 5555)
+        assertFalse(failedConnect.isSuccess)
+
+        env.connectShouldSucceed = true
+        val disconnected = services.devices.disconnect("192.168.86.47:5555")
+        assertTrue(disconnected.isSuccess)
+        assertTrue(env.ran("disconnect", "192.168.86.47:5555"))
+
+        val qr = services.devices.generatePairingQr("WIFI:T:ADB;S:Andy123;P:654321;;")
+        assertNotNull(qr)
+        assertTrue(qr.size > 100)
+    }
+
+    @Test
     fun avdCatalogAndLifecycleUseMockSdkTools() = runBlocking {
         val env = MockAndroidDeviceEnvironment()
         val services = env.services()

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
@@ -542,4 +542,58 @@ class DesktopServicesMockDeviceTest {
         assertEquals(2, env.commands.count { command -> command.takeLast(5) == listOf("shell", "cmd", "wifi", "set-wifi-enabled", "disabled") })
         assertEquals(2, env.commands.count { command -> command.takeLast(5) == listOf("shell", "cmd", "wifi", "set-wifi-enabled", "enabled") })
     }
+
+    @Test
+    fun configureDeviceProxySkipsWifiRestartForWirelessAdb() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+        val wirelessSerial = "192.168.86.47:5555"
+
+        val configured = services.proxy.configureDeviceProxy(wirelessSerial, "192.168.86.10", 8888)
+        val cleared = services.proxy.clearDeviceProxy(wirelessSerial)
+
+        assertTrue(configured.isSuccess)
+        assertTrue(cleared.isSuccess)
+        assertTrue(configured.stdout.contains("Skipped Wi-Fi restart", ignoreCase = true))
+        assertTrue(cleared.stdout.contains("Skipped Wi-Fi restart", ignoreCase = true))
+        assertEquals(0, env.commands.count { command -> command.takeLast(5) == listOf("shell", "cmd", "wifi", "set-wifi-enabled", "disabled") })
+        assertEquals(0, env.commands.count { command -> command.takeLast(5) == listOf("shell", "cmd", "wifi", "set-wifi-enabled", "enabled") })
+        assertEquals(0, env.commands.count { command -> command.takeLast(4) == listOf("shell", "svc", "data", "disable") })
+    }
+
+    @Test
+    fun listDevicesDedupesWifiIpAndMdnsUsingHardwareId() = runBlocking {
+        val env = MockAndroidDeviceEnvironment().apply {
+            adbDevicesOutput = """
+                List of devices attached
+                192.168.86.150:35923	device product:blazer model:Pixel_10_Pro device:blazer transport_id:3
+                adb-5A080DLCH000UR-oVigq2._adb-tls-connect._tcp	device product:blazer model:Pixel_10_Pro device:blazer transport_id:4
+                emulator-5554	device product:sdk_gphone64_arm64 model:Pixel_9 device:emu64a transport_id:1
+            """.trimIndent()
+            // Force both wireless rows to share the same ro.serialno so enrichment can alias them.
+            getpropOverrides = mapOf(
+                "192.168.86.150:35923" to """
+                    [ro.build.version.sdk]: [35]
+                    [ro.product.cpu.abi]: [arm64-v8a]
+                    [ro.product.model]: [Pixel 10 Pro]
+                    [ro.product.name]: [blazer]
+                    [ro.serialno]: [5A080DLCH000UR]
+                """.trimIndent(),
+                "adb-5A080DLCH000UR-oVigq2._adb-tls-connect._tcp" to """
+                    [ro.build.version.sdk]: [35]
+                    [ro.product.cpu.abi]: [arm64-v8a]
+                    [ro.product.model]: [Pixel 10 Pro]
+                    [ro.product.name]: [blazer]
+                    [ro.serialno]: [5A080DLCH000UR]
+                """.trimIndent(),
+            )
+        }
+        val services = env.services()
+
+        val devices = services.devices.listDevices()
+
+        assertEquals(2, devices.size)
+        assertEquals(setOf("192.168.86.150:35923", "emulator-5554"), devices.map { it.serial }.toSet())
+        assertTrue(devices.none { it.serial.contains("_adb-tls-connect") })
+    }
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MitmAddonSourceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MitmAddonSourceTest.kt
@@ -16,7 +16,7 @@ class MitmAddonSourceTest {
     companion object {
         /** SHA-256 of `src/desktopMain/resources/proxy/andy_mitm_addon.py` (runtime source). */
         const val EXPECTED_RESOURCE_SHA256 =
-            "9873513a43d1986934cc51d6e2c6edec2616c5fb6db54843a3876d6ed6b788a6"
+            "7972e62dc6ba215cd6dd4d4189dd2a5bfafdc5f598c560afc11ce6e5aecafe02"
     }
 
     @Test
@@ -24,7 +24,11 @@ class MitmAddonSourceTest {
         val bytes = MitmAddon.getAddonSource()
         assertEquals(EXPECTED_RESOURCE_SHA256, sha256Hex(bytes))
         assertTrue(bytes.isNotEmpty())
-        assertTrue(String(bytes, Charsets.UTF_8).contains("def request("))
+        val source = String(bytes, Charsets.UTF_8)
+        assertTrue(source.contains("def request("))
+        assertTrue(source.contains("def tls_failed_client("))
+        assertTrue(source.contains("tls_failed"))
+        assertTrue(source.contains("def client_connected("))
     }
 
     private fun sha256Hex(bytes: ByteArray): String {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -463,13 +463,14 @@ internal class MockAndroidDeviceEnvironment {
     """.trimIndent()
 }
 
-internal class MockProxyProcess : ProxyProcess {
-    override val stdout: InputStream = ByteArrayInputStream(
-        """
+internal class MockProxyProcess(
+    stdoutText: String = """
         {"type":"flow","id":"flow-1","startedAtMillis":1000,"completedAtMillis":1042,"durationMillis":42,"method":"GET","url":"https://example.test/api","statusCode":201,"contentType":"application/json","sizeBytes":17,"requestHeaders":{"accept":"application/json"},"responseHeaders":{"content-type":"application/json"},"requestBodyPreview":null,"responseBodyPreview":"{\"ok\":true}","error":null,"tlsStatus":"tls","matchedRuleId":"rule-1"}
-        """.trimIndent().encodeToByteArray(),
-    )
-    override val stderr: InputStream = ByteArrayInputStream(ByteArray(0))
+        """.trimIndent(),
+    stderrText: String = "",
+) : ProxyProcess {
+    override val stdout: InputStream = ByteArrayInputStream(stdoutText.encodeToByteArray())
+    override val stderr: InputStream = ByteArrayInputStream(stderrText.encodeToByteArray())
     private var alive = true
     override fun isAlive(): Boolean = alive
     override fun destroy() {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -32,6 +32,14 @@ internal class MockAndroidDeviceEnvironment {
         OFFLINE	offline
         UNAUTH	unauthorized
     """.trimIndent()
+    var mdnsServicesOutput: String = """
+        List of discovered mdns services
+        adb-VAN10A203710441	_adb._tcp	192.168.86.47:5555
+        adb-VAN10A203710441	_adb-tls-connect._tcp	192.168.86.47:37123
+        adb-PAIRING	_adb-tls-pairing._tcp	192.168.86.47:37199
+    """.trimIndent()
+    var pairShouldSucceed: Boolean = true
+    var connectShouldSucceed: Boolean = true
     var rootResult: CommandResult = CommandResult.failure("adbd cannot run as root in production builds")
     var runtimeCaInjectionResult: CommandResult = CommandResult.success("Injected CA")
     var chromeFlagsResult: CommandResult = CommandResult.success()
@@ -144,6 +152,39 @@ internal class MockAndroidDeviceEnvironment {
     private fun runAdb(command: List<String>): CommandResult {
         if (command.drop(1) == listOf("devices", "-l")) {
             return CommandResult.success(adbDevicesOutput)
+        }
+        if (command.drop(1) == listOf("mdns", "check")) {
+            return CommandResult.success("mdns daemon version ...")
+        }
+        if (command.drop(1) == listOf("mdns", "services")) {
+            return CommandResult.success(mdnsServicesOutput)
+        }
+        if (command.getOrNull(1) == "pair") {
+            val endpoint = command.getOrNull(2).orEmpty()
+            val code = command.getOrNull(3).orEmpty()
+            return if (pairShouldSucceed && code.isNotBlank()) {
+                CommandResult.success("Successfully paired to $endpoint [guid=mock-guid]")
+            } else {
+                CommandResult(0, "Failed: Wrong password or connection was dropped.", "")
+            }
+        }
+        if (command.getOrNull(1) == "connect") {
+            val endpoint = command.getOrNull(2).orEmpty()
+            return if (connectShouldSucceed) {
+                if (!adbDevicesOutput.contains(endpoint)) {
+                    adbDevicesOutput = adbDevicesOutput.trimEnd() + "\n$endpoint\tdevice product:wifi model:Wifi_Device device:wifi transport_id:9"
+                }
+                CommandResult.success("connected to $endpoint")
+            } else {
+                CommandResult(0, "failed to connect to $endpoint", "")
+            }
+        }
+        if (command.getOrNull(1) == "disconnect") {
+            val serial = command.getOrNull(2).orEmpty()
+            adbDevicesOutput = adbDevicesOutput.lineSequence()
+                .filterNot { it.trimStart().startsWith("$serial\t") || it.trimStart().startsWith("$serial ") }
+                .joinToString("\n")
+            return CommandResult.success("disconnected $serial")
         }
 
         val serial = command.getOrNull(2)

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -58,6 +58,7 @@ internal class MockAndroidDeviceEnvironment {
     """.trimIndent()
     var hostIfconfigOutput: String = "lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST>\n"
     var hostOsName: String = "Mac OS X"
+    var getpropOverrides: Map<String, String> = emptyMap()
 
     init {
         File(avdHome, "Pixel_8_API_36.avd").apply {
@@ -401,6 +402,7 @@ internal class MockAndroidDeviceEnvironment {
     }
 
     private fun getprop(serial: String): String {
+        getpropOverrides[serial]?.let { return it }
         return if (serial.startsWith("emulator-")) {
             """
             [ro.boot.qemu.avd_name]: [Pixel_8_API_36]
@@ -408,13 +410,20 @@ internal class MockAndroidDeviceEnvironment {
             [ro.product.cpu.abi]: [arm64-v8a]
             [ro.product.model]: [sdk_gphone64_arm64]
             [ro.product.name]: [sdk_gphone64_arm64]
+            [ro.serialno]: [$serial]
             """.trimIndent()
         } else {
+            val hardwareId = when {
+                serial.startsWith("adb-") -> serial.substringAfter("adb-").substringBefore("._").substringBefore('-').ifBlank { serial }
+                serial.contains(':') -> "WIFI-${serial.substringBefore(':').replace('.', '-')}"
+                else -> serial
+            }
             """
             [ro.build.version.sdk]: [35]
             [ro.product.cpu.abi]: [arm64-v8a]
             [ro.product.model]: [Galaxy S24]
             [ro.product.name]: [e3q]
+            [ro.serialno]: [$hardwareId]
             """.trimIndent()
         }
     }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/ProxyJsonGoldenTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/ProxyJsonGoldenTest.kt
@@ -1,12 +1,16 @@
 package app.andy.desktop.service
 
+import app.andy.desktop.service.proxy.MitmproxyEvent
 import app.andy.desktop.service.proxy.ProxyRuleJson
+import app.andy.desktop.service.proxy.parseMitmproxyEvent
 import app.andy.desktop.service.proxy.parseMitmproxyFlowLine
 import app.andy.model.ProxyRule
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Golden fixtures for [ProxyRuleJson] and [parseMitmproxyFlowLine] captured before
@@ -47,6 +51,9 @@ class ProxyJsonGoldenTest {
 
     private val errorFlowLine =
         """{"type":"flow","id":"flow-err","startedAtMillis":1,"completedAtMillis":2,"durationMillis":1,"method":"POST","url":"https://example.test/fail","statusCode":null,"contentType":null,"sizeBytes":null,"requestHeaders":{},"responseHeaders":{},"requestBodyPreview":null,"responseBodyPreview":null,"error":"connection reset","tlsStatus":"tls","matchedRuleId":null}"""
+
+    private val tlsFailedLine =
+        """{"type":"tls_failed","id":"tls-failed-abc","startedAtMillis":10,"completedAtMillis":10,"durationMillis":0,"method":"TLS","url":"https://api.example.com/","statusCode":null,"contentType":null,"sizeBytes":null,"requestHeaders":{},"responseHeaders":{},"requestBodyPreview":null,"responseBodyPreview":null,"error":"Client rejected Andy's CA for api.example.com: The client does not trust the proxy's certificate.","tlsStatus":"tls","matchedRuleId":null,"sni":"api.example.com","peer":"10.0.2.15:51234","reason":"The client does not trust the proxy's certificate."}"""
 
     @Test
     fun writeRulesMatchesGoldenFixture() {
@@ -97,6 +104,28 @@ class ProxyJsonGoldenTest {
         assertNotNull(exchange)
         assertEquals("connection reset", exchange.error)
         assertNull(exchange.statusCode)
+    }
+
+    @Test
+    fun parseTlsFailedClientLine() {
+        val exchange = parseMitmproxyFlowLine(tlsFailedLine)
+        assertNotNull(exchange)
+        assertEquals("tls-failed-abc", exchange.id)
+        assertEquals("TLS", exchange.method)
+        assertEquals("https://api.example.com/", exchange.url)
+        assertEquals("tls", exchange.tlsStatus)
+        assertTrue(exchange.error!!.contains("api.example.com"))
+        assertTrue(exchange.error!!.contains("does not trust the proxy"))
+    }
+
+    @Test
+    fun parseClientConnectedEvent() {
+        val event = parseMitmproxyEvent(
+            """{"type":"client_connected","id":"c1","startedAtMillis":9,"peer":"10.0.2.15:1"}""",
+        )
+        assertIs<MitmproxyEvent.ClientConnected>(event)
+        assertEquals("c1", event.id)
+        assertEquals("10.0.2.15:1", event.peer)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add QR-based Wi-Fi pairing for devices, including pairing dialog UI and ADB pairing flow support.
- Add action notes so saved actions can carry optional notes through the Actions UI and config store.
- Expand Network proxy rewrite/diagnostics with richer diagnosis models, mitm addon updates, settings/shell wiring, and coverage tests.

## Test plan
- [x] `./gradlew desktopTest` (local, passed)
- [ ] Confirm PR desktop checks pass on Linux, macOS, and Windows
- [ ] Smoke: open Devices → Pair over Wi-Fi and verify QR/pairing dialog renders
- [ ] Smoke: add/edit an action note and confirm it persists after restart
- [ ] Smoke: Network proxy rewrite/diagnostics surfaces expected status when proxy is running


Made with [Cursor](https://cursor.com)