### PR TITLE
Add device file transfer, proxy addon diagnostics, and AVD home scanning

### DIFF
--- a/src/commonMain/kotlin/app/andy/DirectoryPicker.kt
+++ b/src/commonMain/kotlin/app/andy/DirectoryPicker.kt
@@ -1,3 +1,9 @@
 package app.andy
 
 expect suspend fun pickDirectory(initialDir: String? = null): String?
+
+expect suspend fun pickFiles(initialDir: String? = null, allowMultiple: Boolean = true): List<String>
+
+expect fun downloadsDirectory(): String
+
+expect fun uniqueLocalPath(directory: String, fileName: String): String

--- a/src/commonMain/kotlin/app/andy/ExternalFileDrop.kt
+++ b/src/commonMain/kotlin/app/andy/ExternalFileDrop.kt
@@ -1,0 +1,8 @@
+package app.andy
+
+import androidx.compose.ui.Modifier
+
+expect fun Modifier.onExternalFileDrop(
+    enabled: Boolean = true,
+    onDrop: (paths: List<String>) -> Unit,
+): Modifier

--- a/src/commonMain/kotlin/app/andy/model/NetworkModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/NetworkModels.kt
@@ -42,6 +42,9 @@ data class ProxyWarning(
 enum class ProxyWarningKind {
     ClientTlsFailure,
     UpstreamTlsFailure,
+    CaptureDropped,
+    AddonMismatch,
+    AddonError,
     Other,
 }
 
@@ -163,15 +166,17 @@ fun diagnoseNetworkTraffic(
     val successfulAny = exchanges.any { it.error == null && (it.statusCode != null || it.method != "TLS") }
     if (successfulHttps || (successfulAny && exchanges.none { it.error != null })) {
         val chaining = routeDiagnostics?.hostUpstreamProxy
-        return listOf(
-            NetworkDiagnosis(
-                mode = null,
-                severity = NetworkDiagnosisSeverity.Green,
-                title = if (chaining != null) "Capturing traffic (chaining through $chaining)" else "Capturing traffic",
-                detail = "HTTPS flows are reaching Andy and completing successfully.",
-                fix = "",
-            ),
-        )
+        return (
+            listOf(
+                NetworkDiagnosis(
+                    mode = null,
+                    severity = NetworkDiagnosisSeverity.Green,
+                    title = if (chaining != null) "Capturing traffic (chaining through $chaining)" else "Capturing traffic",
+                    detail = "HTTPS flows are reaching Andy and completing successfully.",
+                    fix = "",
+                ),
+            ) + addonOperationalDiagnoses(warnings)
+            ).distinctBy { it.mode to it.title }
     }
 
     val diagnoses = mutableListOf<NetworkDiagnosis>()
@@ -209,34 +214,7 @@ fun diagnoseNetworkTraffic(
         )
     }
 
-    if (!caInstalled && exchanges.none { it.tlsStatus == "tls" && it.error == null }) {
-        diagnoses += NetworkDiagnosis(
-            mode = NetworkFailureMode.CaNotInstalled,
-            severity = NetworkDiagnosisSeverity.Red,
-            title = "Andy CA is not installed as a system trust",
-            detail = "Without system (or verified user) CA trust, HTTPS clients will reject Andy's MITM certificate and produce no decryptable traffic.",
-            fix = "Use System CA (root) on a writable emulator, or Prepare phone CA and finish the install on-device for debug apps that trust user CAs.",
-        )
-    }
-
-    val routeIssues = routeDiagnostics?.issues.orEmpty()
     val noHttpTraffic = exchanges.none { it.method != "TLS" }
-    if (noHttpTraffic && (routeIssues.isNotEmpty() || !proxyConfigured || clientConnectionsObserved == 0)) {
-        val detail = when {
-            routeIssues.isNotEmpty() -> routeIssues.joinToString(" ")
-            !proxyConfigured -> "Android's global HTTP proxy is not pointed at Andy."
-            clientConnectionsObserved == 0 -> "No TCP client has connected to mitmdump yet — traffic is not reaching Andy (VPN, proxy override, or QUIC/UDP)."
-            else -> "Clients connected but no HTTP request was captured — the app may bypass the proxy or use QUIC/HTTP3."
-        }
-        diagnoses += NetworkDiagnosis(
-            mode = NetworkFailureMode.NotRouted,
-            severity = NetworkDiagnosisSeverity.Red,
-            title = "No client traffic is reaching Andy",
-            detail = detail,
-            fix = "Repair proxy route, disable/split-tunnel VPN, remove app-level Proxy.NO_PROXY, and force HTTP/1.1 if the app prefers QUIC.",
-        )
-    }
-
     if (noHttpTraffic && clientConnectionsObserved > 0 && tlsFailed.isEmpty() && upstreamErrors.isEmpty()) {
         diagnoses += NetworkDiagnosis(
             mode = NetworkFailureMode.UnsupportedProtocol,
@@ -246,6 +224,8 @@ fun diagnoseNetworkTraffic(
             fix = "Disable Private DNS / QUIC in the debug app or force HTTP/1.1 for the endpoints you need to inspect.",
         )
     }
+
+    diagnoses += addonOperationalDiagnoses(warnings)
 
     if (diagnoses.isEmpty()) {
         diagnoses += NetworkDiagnosis(
@@ -257,4 +237,37 @@ fun diagnoseNetworkTraffic(
         )
     }
     return diagnoses.distinctBy { it.mode to it.title }
+}
+
+/** Surfaced from mitm addon stdout events so Python-side failures stay visible even when capture works. */
+internal fun addonOperationalDiagnoses(warnings: List<ProxyWarning>): List<NetworkDiagnosis> {
+    val diagnoses = mutableListOf<NetworkDiagnosis>()
+    warnings.filter { it.kind == ProxyWarningKind.AddonError }.takeLast(3).forEach { warning ->
+        diagnoses += NetworkDiagnosis(
+            mode = null,
+            severity = NetworkDiagnosisSeverity.Amber,
+            title = "mitm addon error",
+            detail = warning.message,
+            fix = "Traffic may still flow; Stop/Start the proxy if capture looks wrong. Check Proxy stderr for details.",
+        )
+    }
+    warnings.lastOrNull { it.kind == ProxyWarningKind.CaptureDropped }?.let { warning ->
+        diagnoses += NetworkDiagnosis(
+            mode = null,
+            severity = NetworkDiagnosisSeverity.Amber,
+            title = "Network capture dropped events",
+            detail = warning.message,
+            fix = "Proxied traffic was not blocked. Andy may be missing some rows in the traffic list under load.",
+        )
+    }
+    warnings.lastOrNull { it.kind == ProxyWarningKind.AddonMismatch }?.let { warning ->
+        diagnoses += NetworkDiagnosis(
+            mode = null,
+            severity = NetworkDiagnosisSeverity.Amber,
+            title = "mitm addon version mismatch",
+            detail = warning.message,
+            fix = "Stop/Start the proxy from this Andy build, and quit any duplicate Andy/mitmdump instances.",
+        )
+    }
+    return diagnoses
 }

--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -64,6 +64,7 @@ interface AppService {
     suspend fun clearData(serial: String, packageName: String): CommandResult
     suspend fun resetPermissions(serial: String, packageName: String): CommandResult
     suspend fun uninstall(serial: String, packageName: String): CommandResult
+    suspend fun install(serial: String, apkPath: String, replace: Boolean = false): CommandResult
     suspend fun listPermissions(serial: String, packageName: String): List<AndroidPermission>
     suspend fun listActivities(serial: String, packageName: String): List<AndroidActivity>
     suspend fun getIcon(serial: String, packageName: String): ByteArray?

--- a/src/commonMain/kotlin/app/andy/transfer/DeviceTransferCoordinator.kt
+++ b/src/commonMain/kotlin/app/andy/transfer/DeviceTransferCoordinator.kt
@@ -1,0 +1,243 @@
+package app.andy.transfer
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.andy.service.AppService
+import app.andy.service.CommandResult
+import app.andy.service.FileService
+import app.andy.uniqueLocalPath
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+
+enum class LocalDropKind {
+    Empty,
+    Apks,
+    Files,
+    Mixed,
+}
+
+fun isApkPath(path: String): Boolean {
+    val name = path.trimEnd('/', '\\').substringAfterLast('/').substringAfterLast('\\')
+    return name.endsWith(".apk", ignoreCase = true)
+}
+
+fun localPathName(path: String): String =
+    path.trimEnd('/', '\\').substringAfterLast('/').substringAfterLast('\\')
+
+fun classifyLocalPaths(paths: List<String>): LocalDropKind {
+    if (paths.isEmpty()) return LocalDropKind.Empty
+    val apkCount = paths.count(::isApkPath)
+    return when {
+        apkCount == paths.size -> LocalDropKind.Apks
+        apkCount == 0 -> LocalDropKind.Files
+        else -> LocalDropKind.Mixed
+    }
+}
+
+fun joinRemotePath(directory: String, name: String): String {
+    val base = if (directory == "/") "" else directory.trimEnd('/')
+    return "$base/$name"
+}
+
+fun CommandResult.isAlreadyInstalledConflict(): Boolean {
+    if (isSuccess) return false
+    val text = "$stdout\n$stderr".uppercase()
+    return "INSTALL_FAILED_ALREADY_EXISTS" in text ||
+        ("ALREADY EXISTS" in text && "INSTALL" in text)
+}
+
+class DeviceTransferCoordinator {
+    var busy by mutableStateOf(false)
+        private set
+    var status by mutableStateOf("")
+        private set
+
+    private var activeJob: Job? = null
+    private var pendingConfirm: Continuation<Boolean>? = null
+
+    var confirmationTitle by mutableStateOf<String?>(null)
+        private set
+    var confirmationMessage by mutableStateOf("")
+        private set
+
+    fun cancel() {
+        pendingConfirm?.resume(false)
+        pendingConfirm = null
+        confirmationTitle = null
+        confirmationMessage = ""
+        activeJob?.cancel()
+        activeJob = null
+        busy = false
+        status = "Cancelled"
+    }
+
+    fun dismissConfirmation() {
+        pendingConfirm?.resume(false)
+        pendingConfirm = null
+        confirmationTitle = null
+        confirmationMessage = ""
+    }
+
+    fun acceptConfirmation() {
+        pendingConfirm?.resume(true)
+        pendingConfirm = null
+        confirmationTitle = null
+        confirmationMessage = ""
+    }
+
+    private suspend fun confirm(title: String, message: String): Boolean {
+        return suspendCancellableCoroutine { cont ->
+            pendingConfirm?.resume(false)
+            pendingConfirm = cont
+            confirmationTitle = title
+            confirmationMessage = message
+            cont.invokeOnCancellation {
+                if (pendingConfirm === cont) {
+                    pendingConfirm = null
+                    confirmationTitle = null
+                    confirmationMessage = ""
+                }
+            }
+        }
+    }
+
+    fun tryStart(scope: CoroutineScope, initialStatus: String, block: suspend TransferOps.() -> Unit): Boolean {
+        if (busy) {
+            status = "Wait for the current transfer to finish"
+            return false
+        }
+        busy = true
+        status = initialStatus
+        activeJob = scope.launch {
+            try {
+                TransferOps().block()
+            } catch (_: kotlinx.coroutines.CancellationException) {
+                status = "Cancelled"
+            } catch (error: Throwable) {
+                status = error.message ?: "Transfer failed"
+            } finally {
+                busy = false
+                activeJob = null
+                pendingConfirm?.resume(false)
+                pendingConfirm = null
+                confirmationTitle = null
+                confirmationMessage = ""
+            }
+        }
+        return true
+    }
+
+    inner class TransferOps {
+        fun setStatus(message: String) {
+            status = message
+        }
+
+        suspend fun askConfirm(title: String, message: String): Boolean = confirm(title, message)
+
+        suspend fun pullAll(
+            files: FileService,
+            serial: String,
+            remotePaths: List<String>,
+            downloadsDir: String,
+        ) {
+            var completed = 0
+            for (remote in remotePaths) {
+                val name = localPathName(remote)
+                setStatus("Pulling $name…")
+                val local = uniqueLocalPath(downloadsDir, name)
+                val result = files.pull(serial, remote, local)
+                if (!result.isSuccess) {
+                    setStatus("Pull failed: ${result.stderr.ifBlank { result.stdout }.ifBlank { name }}")
+                    return
+                }
+                completed++
+            }
+            setStatus(
+                if (completed == 1) "Downloaded ${localPathName(remotePaths.first())} to Downloads"
+                else "Downloaded $completed items to Downloads",
+            )
+        }
+
+        suspend fun pushAll(
+            files: FileService,
+            serial: String,
+            localPaths: List<String>,
+            remoteDirectory: String,
+            existingNames: Set<String>,
+            onSuccess: suspend () -> Unit,
+        ) {
+            var completed = 0
+            val remainingNames = existingNames.toMutableSet()
+            for (local in localPaths) {
+                val name = localPathName(local)
+                if (name in remainingNames) {
+                    val replace = askConfirm("Replace existing file?", "$name already exists on the device.")
+                    if (!replace) {
+                        setStatus("Cancelled")
+                        return
+                    }
+                }
+                setStatus("Pushing $name…")
+                val remote = joinRemotePath(remoteDirectory, name)
+                val result = files.push(serial, local, remote)
+                if (!result.isSuccess) {
+                    setStatus("Push failed: ${result.stderr.ifBlank { result.stdout }.ifBlank { name }}")
+                    return
+                }
+                remainingNames.add(name)
+                completed++
+            }
+            setStatus(if (completed == 1) "Pushed ${localPathName(localPaths.first())}" else "Pushed $completed items")
+            onSuccess()
+        }
+
+        suspend fun installAll(
+            apps: AppService,
+            serial: String,
+            apkPaths: List<String>,
+        ) {
+            var completed = 0
+            var replaced = 0
+            for (apk in apkPaths) {
+                val name = localPathName(apk)
+                setStatus("Installing $name…")
+                val first = apps.install(serial, apk, replace = false)
+                if (first.isSuccess) {
+                    completed++
+                    continue
+                }
+                if (first.isAlreadyInstalledConflict()) {
+                    val replace = askConfirm("Replace existing app?", "$name is already installed. Replace it?")
+                    if (!replace) {
+                        setStatus("Cancelled")
+                        return
+                    }
+                    setStatus("Replacing $name…")
+                    val second = apps.install(serial, apk, replace = true)
+                    if (!second.isSuccess) {
+                        setStatus("Install failed: ${second.stderr.ifBlank { second.stdout }.ifBlank { name }}")
+                        return
+                    }
+                    completed++
+                    replaced++
+                } else {
+                    setStatus("Install failed: ${first.stderr.ifBlank { first.stdout }.ifBlank { name }}")
+                    return
+                }
+            }
+            setStatus(
+                when {
+                    completed == 1 && replaced == 1 -> "App replaced: ${localPathName(apkPaths.first())}"
+                    completed == 1 -> "App installed: ${localPathName(apkPaths.first())}"
+                    replaced == completed -> "Replaced $completed apps"
+                    else -> "Installed $completed apps"
+                },
+            )
+        }
+    }
+}

--- a/src/commonMain/kotlin/app/andy/ui/components/Dialogs.kt
+++ b/src/commonMain/kotlin/app/andy/ui/components/Dialogs.kt
@@ -13,6 +13,7 @@ import app.andy.ui.theme.TextSecondary
 internal data class PendingConfirmation(
     val title: String,
     val message: String,
+    val confirmLabel: String = "Confirm",
     val onConfirm: () -> Unit,
 )
 
@@ -23,7 +24,7 @@ internal fun ConfirmationDialog(confirmation: PendingConfirmation, onDismiss: ()
         containerColor = Panel,
         title = { Text(confirmation.title, color = TextPrimary, fontWeight = FontWeight.Bold) },
         text = { Text(confirmation.message, color = TextSecondary) },
-        confirmButton = { Button(onClick = onConfirm, colors = ButtonDefaults.buttonColors(containerColor = Red)) { Text("Confirm") } },
+        confirmButton = { Button(onClick = onConfirm, colors = ButtonDefaults.buttonColors(containerColor = Red)) { Text(confirmation.confirmLabel) } },
         dismissButton = { OutlinedButton(onClick = onDismiss) { Text("Cancel") } },
     )
 }

--- a/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
@@ -1,13 +1,18 @@
 package app.andy.ui.files
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,11 +22,32 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isCtrlPressed
+import androidx.compose.ui.input.pointer.isMetaPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.isShiftPressed
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import app.andy.downloadsDirectory
 import app.andy.model.DeviceFile
+import app.andy.onExternalFileDrop
+import app.andy.pickFiles
+import app.andy.service.AppService
 import app.andy.service.FileService
+import app.andy.transfer.DeviceTransferCoordinator
+import app.andy.transfer.LocalDropKind
+import app.andy.transfer.classifyLocalPaths
 import app.andy.ui.components.Button
 import app.andy.ui.components.FilterPill
 import app.andy.ui.components.MonoCell
@@ -31,51 +57,261 @@ import app.andy.ui.components.TableRow
 import app.andy.ui.components.TextField
 import app.andy.ui.components.fieldColors
 import app.andy.ui.theme.Cyan
+import app.andy.ui.theme.PanelSoft
 import app.andy.ui.theme.Rust
 import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
 import kotlinx.coroutines.launch
 
 @Composable
-internal fun FilesScreen(files: FileService, serial: String?) {
+internal fun FilesScreen(
+    files: FileService,
+    apps: AppService,
+    serial: String?,
+    transfer: DeviceTransferCoordinator,
+) {
     val scope = rememberCoroutineScope()
     var path by remember { mutableStateOf("/sdcard") }
     var rows by remember { mutableStateOf<List<DeviceFile>>(emptyList()) }
     var message by remember { mutableStateOf("") }
+    var selectedPaths by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var anchorIndex by remember { mutableStateOf<Int?>(null) }
+    var contextMenuPath by remember { mutableStateOf<String?>(null) }
+
     fun load(targetPath: String = path) {
         if (serial == null) return
         scope.launch {
             path = targetPath
             runCatching { files.list(serial, targetPath) }
-                .onSuccess { rows = it; message = "${it.size} entries" }
+                .onSuccess {
+                    rows = it
+                    selectedPaths = selectedPaths.filter { selected -> it.any { file -> file.path == selected } }.toSet()
+                    message = "${it.size} entries"
+                }
                 .onFailure { message = it.message ?: "Failed" }
         }
     }
-    LaunchedEffect(serial) { load() }
-    Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            TextField(path, { path = it }, singleLine = true, modifier = Modifier.weight(1f).height(54.dp), textStyle = LocalTextStyle.current.copy(color = TextPrimary, fontFamily = FontFamily.Monospace), colors = fieldColors())
+
+    fun openDirectory(file: DeviceFile) {
+        if (file.isDirectory) {
+            selectedPaths = emptySet()
+            anchorIndex = null
+            load(file.path)
+        }
+    }
+
+    fun selectRow(index: Int, file: DeviceFile, meta: Boolean, shift: Boolean) {
+        when {
+            shift && anchorIndex != null -> {
+                val from = minOf(anchorIndex!!, index)
+                val to = maxOf(anchorIndex!!, index)
+                selectedPaths = rows.slice(from..to).map { it.path }.toSet()
+            }
+            meta -> {
+                selectedPaths = if (file.path in selectedPaths) selectedPaths - file.path else selectedPaths + file.path
+                anchorIndex = index
+            }
+            else -> {
+                selectedPaths = setOf(file.path)
+                anchorIndex = index
+            }
+        }
+    }
+
+    fun startDownload(targets: List<DeviceFile>) {
+        if (serial == null) {
+            message = "Select an online device"
+            return
+        }
+        if (targets.isEmpty()) {
+            message = "Select files to download"
+            return
+        }
+        transfer.tryStart(scope, "Pulling…") {
+            pullAll(files, serial, targets.map { it.path }, downloadsDirectory())
+        }
+    }
+
+    fun handleIncoming(localPaths: List<String>) {
+        if (serial == null) {
+            message = "Select an online device"
+            return
+        }
+        when (classifyLocalPaths(localPaths)) {
+            LocalDropKind.Empty -> Unit
+            LocalDropKind.Mixed -> {
+                message = "Drop APKs or other files separately — mixed drops are not allowed"
+            }
+            LocalDropKind.Apks -> {
+                transfer.tryStart(scope, "Installing…") {
+                    installAll(apps, serial, localPaths)
+                }
+            }
+            LocalDropKind.Files -> {
+                val existing = rows.map { it.name }.toSet()
+                transfer.tryStart(scope, "Pushing…") {
+                    pushAll(files, serial, localPaths, path, existing) { load() }
+                }
+            }
+        }
+    }
+
+    fun startUpload() {
+        if (serial == null) {
+            message = "Select an online device"
+            return
+        }
+        if (transfer.busy) {
+            message = "Wait for the current transfer to finish"
+            return
+        }
+        scope.launch {
+            val picked = pickFiles()
+            if (picked.isNotEmpty()) handleIncoming(picked)
+        }
+    }
+
+    LaunchedEffect(serial) {
+        selectedPaths = emptySet()
+        anchorIndex = null
+        load()
+    }
+
+    LaunchedEffect(transfer.status) {
+        if (transfer.status.isNotBlank()) message = transfer.status
+    }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .onExternalFileDrop(enabled = serial != null) { handleIncoming(it) }
+            .onPreviewKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                if (event.key == Key.Enter || event.key == Key.NumPadEnter) {
+                    val directory = rows.filter { it.path in selectedPaths }.singleOrNull()?.takeIf { it.isDirectory }
+                    if (directory != null) {
+                        openDirectory(directory)
+                        return@onPreviewKeyEvent true
+                    }
+                }
+                false
+            },
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            TextField(
+                path,
+                { path = it },
+                singleLine = true,
+                modifier = Modifier.weight(1f).height(54.dp),
+                textStyle = LocalTextStyle.current.copy(color = TextPrimary, fontFamily = FontFamily.Monospace),
+                colors = fieldColors(),
+            )
             Button(onClick = { load() }) { Text("Browse") }
             OutlinedButton(onClick = { load(parentPath(path)) }) { Text("Up") }
+            Button(
+                onClick = { startDownload(rows.filter { it.path in selectedPaths }) },
+                enabled = serial != null && selectedPaths.isNotEmpty() && !transfer.busy,
+            ) { Text("Download") }
+            OutlinedButton(
+                onClick = { startUpload() },
+                enabled = serial != null && !transfer.busy,
+            ) { Text("Upload…") }
+            if (transfer.busy) {
+                OutlinedButton(onClick = { transfer.cancel() }) { Text("Cancel") }
+            }
         }
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             listOf("/", "/sdcard", "/data/local/tmp", "/storage/emulated/0").forEach { root ->
                 FilterPill(root, path == root, Cyan) { load(root) }
             }
         }
-        if (message.isNotBlank()) Text(message, color = Rust)
+        if (message.isNotBlank()) {
+            Text(
+                message,
+                color = when {
+                    message.startsWith("App installed") ||
+                        message.startsWith("App replaced") ||
+                        message.startsWith("Installed ") ||
+                        message.startsWith("Replaced ") ||
+                        message.startsWith("Downloaded ") ||
+                        message.startsWith("Pushed ") -> Cyan
+                    message.contains("failed", ignoreCase = true) ||
+                        message.contains("rejected", ignoreCase = true) ||
+                        message.contains("not allowed", ignoreCase = true) -> Rust
+                    else -> Rust
+                },
+                fontWeight = if (
+                    message.startsWith("App installed") ||
+                    message.startsWith("App replaced") ||
+                    message.startsWith("Installed ") ||
+                    message.startsWith("Replaced ")
+                ) FontWeight.Bold else FontWeight.Normal,
+            )
+        }
         TableHeader(listOf("MODE" to 120.dp, "SIZE" to 100.dp, "MODIFIED" to 190.dp, "NAME" to 1.dp))
-        LazyColumn {
-            items(rows) { file ->
-                TableRow(modifier = Modifier.clickable {
-                    if (file.isDirectory) {
-                        load(file.path)
+        LazyColumn(Modifier.fillMaxSize()) {
+            itemsIndexed(rows, key = { _, file -> file.path }) { index, file ->
+                val selected = file.path in selectedPaths
+                Box {
+                    TableRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(if (selected) PanelSoft else Color.Transparent)
+                            .pointerInput(file.path, rows, selectedPaths, anchorIndex) {
+                                awaitPointerEventScope {
+                                    while (true) {
+                                        val event = awaitPointerEvent()
+                                        if (event.type != PointerEventType.Press) continue
+                                        val change = event.changes.firstOrNull() ?: continue
+                                        if (event.buttons.isSecondaryPressed) {
+                                            if (file.path !in selectedPaths) {
+                                                selectedPaths = setOf(file.path)
+                                                anchorIndex = index
+                                            }
+                                            contextMenuPath = file.path
+                                            change.consume()
+                                            continue
+                                        }
+                                        val meta = event.keyboardModifiers.isCtrlPressed || event.keyboardModifiers.isMetaPressed
+                                        val shift = event.keyboardModifiers.isShiftPressed
+                                        selectRow(index, file, meta, shift)
+                                    }
+                                }
+                            }
+                            .pointerInput(file.path) {
+                                detectTapGestures(
+                                    onDoubleTap = {
+                                        if (file.isDirectory) openDirectory(file)
+                                    },
+                                )
+                            },
+                    ) {
+                        MonoCell(file.permissions ?: "-", 120.dp, TextSecondary)
+                        MonoCell(file.sizeBytes?.toString() ?: "-", 100.dp, TextSecondary)
+                        MonoCell(file.modified ?: "-", 190.dp, TextSecondary)
+                        MonoCell(
+                            if (file.isDirectory) "${file.name}/" else file.name,
+                            1.dp,
+                            if (file.isDirectory) Cyan else TextPrimary,
+                            Modifier.weight(1f),
+                        )
                     }
-                }) {
-                    MonoCell(file.permissions ?: "-", 120.dp, TextSecondary)
-                    MonoCell(file.sizeBytes?.toString() ?: "-", 100.dp, TextSecondary)
-                    MonoCell(file.modified ?: "-", 190.dp, TextSecondary)
-                    MonoCell(if (file.isDirectory) "${file.name}/" else file.name, 1.dp, if (file.isDirectory) Cyan else TextPrimary, Modifier.weight(1f))
+                    DropdownMenu(
+                        expanded = contextMenuPath == file.path,
+                        onDismissRequest = { contextMenuPath = null },
+                        containerColor = PanelSoft,
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Download", color = TextPrimary) },
+                            onClick = {
+                                contextMenuPath = null
+                                val targets = rows.filter { it.path in selectedPaths }.ifEmpty { listOf(file) }
+                                startDownload(targets)
+                            },
+                            enabled = !transfer.busy,
+                        )
+                    }
                 }
             }
         }

--- a/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
@@ -38,10 +38,14 @@ import app.andy.model.AndroidDevice
 import app.andy.model.BugCaptureDraft
 import app.andy.model.DeviceConnectionState
 import app.andy.model.DeviceKind
+import app.andy.onExternalFileDrop
 import app.andy.service.AndyServices
 import app.andy.service.CommandResult
 import app.andy.service.MirrorInput
 import app.andy.service.MirrorVideoConfig
+import app.andy.transfer.DeviceTransferCoordinator
+import app.andy.transfer.LocalDropKind
+import app.andy.transfer.classifyLocalPaths
 import app.andy.ui.components.Button
 import app.andy.ui.components.FilterPill
 import app.andy.ui.components.HorizontalPaneDivider
@@ -62,6 +66,18 @@ import app.andy.ui.theme.Yellow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+private fun transferStatusColor(status: String): Color = when {
+    status.startsWith("App installed") ||
+        status.startsWith("App replaced") ||
+        status.startsWith("Installed ") ||
+        status.startsWith("Replaced ") -> Green
+    status.contains("failed", ignoreCase = true) ||
+        status.contains("rejected", ignoreCase = true) ||
+        status.contains("not allowed", ignoreCase = true) -> Rust
+    status == "Cancelled" || status.startsWith("Wait for") -> Yellow
+    else -> TextSecondary
+}
+
 @Composable
 internal fun LiveScreen(
     services: AndyServices,
@@ -79,6 +95,7 @@ internal fun LiveScreen(
     onPopOutMirror: () -> Unit,
     selectedPackage: String?,
     onSelectedPackageChange: (String?) -> Unit,
+    transfer: DeviceTransferCoordinator,
 ) {
     val scope = rememberCoroutineScope()
     var mirrorStatus by remember { mutableStateOf("Disconnected") }
@@ -96,6 +113,23 @@ internal fun LiveScreen(
     fun sendHardware(input: MirrorInput) {
         sendMirrorInput(input)
     }
+    fun handleApkDrop(paths: List<String>) {
+        if (serial == null) {
+            liveActionStatus = "Select an online device"
+            return
+        }
+        when (classifyLocalPaths(paths)) {
+            LocalDropKind.Empty -> Unit
+            LocalDropKind.Apks -> {
+                transfer.tryStart(scope, "Installing…") {
+                    installAll(services.apps, serial, paths)
+                }
+            }
+            LocalDropKind.Files, LocalDropKind.Mixed -> {
+                liveActionStatus = "Live accepts APK files only — drop rejected"
+            }
+        }
+    }
     fun runLiveAction(label: String, block: suspend () -> CommandResult) {
         if (serial == null) {
             liveActionStatus = "Select an online device"
@@ -105,6 +139,9 @@ internal fun LiveScreen(
             val result = block()
             liveActionStatus = "$label: " + if (result.isSuccess) result.stdout.ifBlank { "ok" } else result.stderr.ifBlank { result.stdout }
         }
+    }
+    LaunchedEffect(transfer.status) {
+        if (transfer.status.isNotBlank()) liveActionStatus = transfer.status
     }
     fun applyPreset(size: String, mbps: String, fps: String = "60") {
         maxSize = size
@@ -142,7 +179,11 @@ internal fun LiveScreen(
                 frameFlow = visibleFrameFlow,
                 mirrorStatus = mirrorStatus,
                 connectResult = connectResult,
-                modifier = Modifier.width(localDevicePaneWidth.dp).fillMaxHeight().padding(end = 6.dp),
+                modifier = Modifier
+                    .width(localDevicePaneWidth.dp)
+                    .fillMaxHeight()
+                    .padding(end = 6.dp)
+                    .onExternalFileDrop(enabled = serial != null) { handleApkDrop(it) },
                 onPower = { sendHardware(MirrorInput.Power) },
                 onVolumeUp = { sendHardware(MirrorInput.Key(24)) },
                 onVolumeDown = { sendHardware(MirrorInput.Key(25)) },
@@ -191,10 +232,21 @@ internal fun LiveScreen(
                     }
                 }
                 Text("Bug capture", color = TextSecondary, fontWeight = FontWeight.Bold, fontSize = 11.sp)
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
                     CompactHardwareButton("Save bug", serial) { bugDialogVisible = true }
+                    if (transfer.busy) {
+                        OutlinedButton(onClick = { transfer.cancel() }) { Text("Cancel transfer") }
+                    }
                     if (liveActionStatus.isNotBlank()) {
-                        Text(liveActionStatus, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 11.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                        Text(
+                            liveActionStatus,
+                            color = transferStatusColor(liveActionStatus),
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 12.sp,
+                            fontWeight = if (liveActionStatus.startsWith("App installed") || liveActionStatus.startsWith("App replaced") || liveActionStatus.startsWith("Installed ") || liveActionStatus.startsWith("Replaced ")) FontWeight.Bold else FontWeight.Normal,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
                     }
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {

--- a/src/commonMain/kotlin/app/andy/ui/network/NetworkScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/network/NetworkScreen.kt
@@ -11,10 +11,11 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,12 +25,14 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.LocalTextStyle
@@ -45,6 +48,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -87,15 +92,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
-
-private data class SetupRequirement(
-    val label: String,
-    val ok: Boolean,
-    val readyText: String,
-    val missingText: String,
-    val installCommand: String? = null,
-)
-
 
 private val DebugNetworkSecurityConfigSnippet = """
 res/xml/network_security_config.xml
@@ -410,36 +406,10 @@ internal fun NetworkScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             PanelCard(Modifier.animateContentSize()) {
+                val clipboardManager = LocalClipboardManager.current
+                var configCopied by remember { mutableStateOf(false) }
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
                     Text("Debug-app HTTPS proxy", color = TextPrimary, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
-                    TextField(
-                        portText,
-                        {
-                            portText = it.filter(Char::isDigit).take(5)
-                            it.toIntOrNull()?.takeIf { value -> value in 1..65535 }?.let(onPortChange)
-                        },
-                        singleLine = true,
-                        modifier = Modifier.width(86.dp).height(54.dp),
-                        textStyle = LocalTextStyle.current.copy(color = TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 14.sp),
-                        colors = fieldColors(),
-                    )
-                    Button(onClick = {
-                        persistPort()
-                        scope.launch {
-                            proxy.ensureCertificateAuthority()
-                            val result = proxy.start(currentPort, rules, currentStartOptions())
-                            val message = if (result.isSuccess) result.stdout else result.stderr
-                            state.status = message
-                            if (result.isSuccess) state.proxyStatus = message
-                        }
-                    }) { Text("Start") }
-                    OutlinedButton(onClick = {
-                        scope.launch {
-                            val result = proxy.stop()
-                            state.status = result.stdout
-                            state.proxyStatus = result.stdout
-                        }
-                    }) { Text("Stop") }
                     OutlinedButton(onClick = ::clearCapturedTraffic) { Text("Clear traffic") }
                     Text(
                         if (state.setupExpanded) "Hide setup" else "Show setup",
@@ -482,88 +452,204 @@ internal fun NetworkScreen(
                     state.routeDiagnostics?.proxyConfigured == false -> "Proxy route needs repair"
                     else -> "No VPN route issue detected"
                 }
-                val setupRequirements = listOf(
-                    SetupRequirement(
-                        label = "Android SDK platform-tools",
-                        ok = sdk.hasAdb,
-                        readyText = "ADB is available through Andy's SDK selection",
-                        missingText = "Install Android Studio or command-line tools",
-                    ),
-                    SetupRequirement(
-                        label = "scrcpy-server",
-                        ok = true,
-                        readyText = "Bundled with Andy for embedded mirroring",
-                        missingText = "Packaged builds include scrcpy-server",
-                    ),
-                    SetupRequirement(
-                        label = "mitmproxy",
-                        ok = state.engineReady,
-                        readyText = state.engineStatus,
-                        missingText = "Required for Network capture and rewrite rules",
-                        installCommand = "brew install mitmproxy",
-                    ),
-                )
-                val networkStatusRequirements = listOf(
-                    SetupRequirement(
-                        label = "Proxy Status",
-                        ok = proxyStarted,
-                        readyText = "Listening on port $currentPort",
-                        missingText = "Click Start to start",
-                    ),
-                    SetupRequirement(
-                        label = "CA Trust",
-                        ok = serial != null && (state.caInstalled || state.proxyTrafficObservedForDevice),
-                        readyText = caText,
-                        missingText = caText,
-                    ),
-                    SetupRequirement(
-                        label = "Device Proxy Routing",
-                        ok = serial != null && state.proxyConfigured,
-                        readyText = configText,
-                        missingText = configText,
-                    ),
-                    SetupRequirement(
-                        label = "VPN / Route",
-                        ok = serial != null &&
-                            state.routeDiagnostics?.vpnActive != true &&
-                            state.routeDiagnostics?.routeUsesVpn != true &&
-                            (
-                                state.routeDiagnostics?.hostProxyBypassLooksSafe != false ||
-                                    state.routeDiagnostics?.hostUpstreamProxy.orEmpty().let { upstream ->
-                                        upstream.contains("127.0.0.1") || upstream.contains("localhost")
-                                    }
-                            ),
-                        readyText = routeText,
-                        missingText = routeText,
-                    ),
-                )
+                val routeOk = serial != null &&
+                    state.routeDiagnostics?.vpnActive != true &&
+                    state.routeDiagnostics?.routeUsesVpn != true &&
+                    (
+                        state.routeDiagnostics?.hostProxyBypassLooksSafe != false ||
+                            state.routeDiagnostics?.hostUpstreamProxy.orEmpty().let { upstream ->
+                                upstream.contains("127.0.0.1") || upstream.contains("localhost")
+                            }
+                    )
                 val showRouteWarning = state.routeDiagnostics?.hasBlockingIssue == true && proxyStarted && !state.proxyTrafficObservedForDevice
+                val proxyHostDisplay = state.proxyHost.ifBlank { "this Mac's LAN IP" }
                 AnimatedVisibility(state.setupExpanded) {
                     Column(
                         Modifier
                             .fillMaxWidth()
-                            .heightIn(max = 360.dp)
+                            .heightIn(max = 480.dp)
                             .verticalScroll(rememberScrollState()),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
+                        @OptIn(ExperimentalLayoutApi::class)
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            SetupStepCard(
+                                step = 1,
+                                title = "Install mitmproxy",
+                                ok = state.engineReady,
+                                instruction = if (state.engineReady) {
+                                    state.engineStatus
+                                } else {
+                                    "Required for Network capture and rewrite rules. Install on the host, then Andy will start mitmdump automatically."
+                                },
+                                modifier = Modifier.widthIn(min = 260.dp).weight(1f),
+                            ) {
+                                Text("brew install mitmproxy", color = Rust, fontFamily = MonoFont, fontSize = 11.sp)
+                            }
+                            SetupStepCard(
+                                step = 2,
+                                title = "Add network security config",
+                                ok = null,
+                                instruction = "Debug builds must trust user CAs. Add the XML below as res/xml/network_security_config.xml, then reference it in AndroidManifest.xml with android:networkSecurityConfig=\"@xml/network_security_config\".",
+                                modifier = Modifier.widthIn(min = 320.dp).weight(1f),
+                            ) {
+                                SelectionContainer {
+                                    Text(
+                                        DebugNetworkSecurityConfigSnippet,
+                                        color = TextPrimary,
+                                        fontFamily = FontFamily.Monospace,
+                                        fontSize = 10.sp,
+                                        lineHeight = 13.sp,
+                                    )
+                                }
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    OutlinedButton(onClick = {
+                                        clipboardManager.setText(AnnotatedString(DebugNetworkSecurityConfigSnippet))
+                                        configCopied = true
+                                        state.status = "Network security config copied to clipboard"
+                                    }) { Text("Copy") }
+                                    if (configCopied) {
+                                        Text("Copied", color = Green, fontSize = 11.sp)
+                                    }
+                                }
+                                Text(
+                                    "Use this only in debug builds that trust user CAs. Certificate pinning and arbitrary third-party app bypass are out of scope.",
+                                    color = TextSecondary,
+                                    fontSize = 11.sp,
+                                    lineHeight = 14.sp,
+                                )
+                            }
+                            SetupStepCard(
+                                step = 3,
+                                title = "Start / stop HTTP proxy",
+                                ok = proxyStarted,
+                                instruction = if (proxyStarted) {
+                                    "Listening on port $currentPort"
+                                } else {
+                                    "Andy runs mitmdump on this port. Click Start to begin capturing HTTPS traffic."
+                                },
+                                modifier = Modifier.widthIn(min = 260.dp).weight(1f),
+                            ) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    TextField(
+                                        portText,
+                                        {
+                                            portText = it.filter(Char::isDigit).take(5)
+                                            it.toIntOrNull()?.takeIf { value -> value in 1..65535 }?.let(onPortChange)
+                                        },
+                                        singleLine = true,
+                                        modifier = Modifier.width(86.dp).height(54.dp),
+                                        textStyle = LocalTextStyle.current.copy(color = TextPrimary, fontFamily = FontFamily.Monospace, fontSize = 14.sp),
+                                        colors = fieldColors(),
+                                    )
+                                    Button(onClick = {
+                                        persistPort()
+                                        scope.launch {
+                                            proxy.ensureCertificateAuthority()
+                                            val result = proxy.start(currentPort, rules, currentStartOptions())
+                                            val message = if (result.isSuccess) result.stdout else result.stderr
+                                            state.status = message
+                                            if (result.isSuccess) state.proxyStatus = message
+                                        }
+                                    }) { Text("Start") }
+                                    OutlinedButton(onClick = {
+                                        scope.launch {
+                                            val result = proxy.stop()
+                                            state.status = result.stdout
+                                            state.proxyStatus = result.stdout
+                                        }
+                                    }) { Text("Stop") }
+                                }
+                            }
+                            SetupStepCard(
+                                step = 4,
+                                title = "Install cert to device",
+                                ok = null,
+                                instruction = "One-time step per device (Andy's CA lasts ~10 years unless you wipe the emulator/device or regenerate ~/.andy/proxy). System CA (root) installs into the system trust store and requires adb root (emulator). Prepare phone CA only pushes the cert to Downloads and opens Security settings — you must still manually complete the CA install on the device (Settings > Security > Install a certificate > CA certificate).",
+                                modifier = Modifier.widthIn(min = 260.dp).weight(1f),
+                            ) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    OutlinedButton(
+                                        enabled = serial != null,
+                                        onClick = {
+                                            if (serial != null) scope.launch {
+                                                val result = proxy.installSystemCertificateAuthority(serial)
+                                                state.status = if (result.isSuccess) result.stdout else result.stderr
+                                                state.caInstalled = proxy.isCertificateInstalled(serial)
+                                            }
+                                        },
+                                    ) { Text("System CA (root)") }
+                                    OutlinedButton(
+                                        enabled = serial != null,
+                                        onClick = {
+                                            if (serial != null) scope.launch {
+                                                proxy.ensureCertificateAuthority()
+                                                val result = proxy.prepareUserCertificateInstall(serial)
+                                                state.status = if (result.isSuccess) result.stdout else result.stderr
+                                            }
+                                        },
+                                    ) { Text("Prepare phone CA") }
+                                }
+                            }
+                            SetupStepCard(
+                                step = 5,
+                                title = "Configure device proxy",
+                                ok = serial != null && state.proxyConfigured,
+                                instruction = "$configText. Sets Android's global http_proxy to $proxyHostDisplay:$currentPort so device traffic routes through Andy.",
+                                modifier = Modifier.widthIn(min = 260.dp).weight(1f),
+                            ) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    OutlinedButton(
+                                        enabled = serial != null,
+                                        onClick = {
+                                            if (serial != null) scope.launch {
+                                                val host = proxy.resolveDeviceProxyHost(serial)
+                                                state.proxyHost = host
+                                                val result = proxy.configureDeviceProxy(serial, host, currentPort)
+                                                state.status = if (result.isSuccess) result.stdout else result.stderr
+                                                state.proxyConfigured = proxy.isDeviceProxyConfigured(serial, host, currentPort)
+                                                state.routeDiagnostics = proxy.diagnoseDeviceProxyRoute(serial, host, currentPort)
+                                            }
+                                        },
+                                    ) { Text("Configure device proxy") }
+                                    OutlinedButton(
+                                        enabled = serial != null,
+                                        onClick = {
+                                            if (serial != null) scope.launch {
+                                                val result = proxy.clearDeviceProxy(serial)
+                                                state.status = if (result.isSuccess) result.stdout else result.stderr
+                                                val host = proxy.resolveDeviceProxyHost(serial)
+                                                state.proxyConfigured = proxy.isDeviceProxyConfigured(serial, host, currentPort)
+                                            }
+                                        },
+                                    ) { Text("Clear proxy") }
+                                }
+                            }
+                        }
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(AndyColors.Neutral850, RoundedCornerShape(AndyRadius.R3))
+                                .border(1.dp, Border, RoundedCornerShape(AndyRadius.R3))
+                                .padding(horizontal = 12.dp, vertical = 10.dp),
                         ) {
-                            OutlinedButton(
-                                enabled = serial != null,
-                                onClick = {
-                                    if (serial != null) scope.launch {
-                                        val host = proxy.resolveDeviceProxyHost(serial)
-                                        state.proxyHost = host
-                                        val result = proxy.configureDeviceProxy(serial, host, currentPort)
-                                        state.status = if (result.isSuccess) result.stdout else result.stderr
-                                        state.proxyConfigured = proxy.isDeviceProxyConfigured(serial, host, currentPort)
-                                        state.routeDiagnostics = proxy.diagnoseDeviceProxyRoute(serial, host, currentPort)
-                                    }
-                                },
-                            ) { Text("Configure device proxy") }
+                            GlowingDot(routeOk, Modifier.padding(top = 2.dp))
+                            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                Text("VPN / Route", color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+                                Text(routeText, color = if (routeOk) Green else Red, fontSize = 11.sp, lineHeight = 15.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                            }
                             OutlinedButton(
                                 enabled = serial != null,
                                 onClick = {
@@ -600,40 +686,7 @@ internal fun NetworkScreen(
                                     }
                                 },
                             ) { Text("Open VPN settings") }
-                            OutlinedButton(
-                                enabled = serial != null,
-                                onClick = {
-                                    if (serial != null) scope.launch {
-                                        val result = proxy.clearDeviceProxy(serial)
-                                        state.status = if (result.isSuccess) result.stdout else result.stderr
-                                        val host = proxy.resolveDeviceProxyHost(serial)
-                                        state.proxyConfigured = proxy.isDeviceProxyConfigured(serial, host, currentPort)
-                                    }
-                                },
-                            ) { Text("Clear proxy") }
-                            OutlinedButton(
-                                enabled = serial != null,
-                                onClick = {
-                                    if (serial != null) scope.launch {
-                                        val result = proxy.installSystemCertificateAuthority(serial)
-                                        state.status = if (result.isSuccess) result.stdout else result.stderr
-                                        state.caInstalled = proxy.isCertificateInstalled(serial)
-                                    }
-                                },
-                            ) { Text("System CA (root)") }
-                            OutlinedButton(
-                                enabled = serial != null,
-                                onClick = {
-                                    if (serial != null) scope.launch {
-                                        proxy.ensureCertificateAuthority()
-                                        val result = proxy.prepareUserCertificateInstall(serial)
-                                        state.status = if (result.isSuccess) result.stdout else result.stderr
-                                    }
-                                },
-                            ) { Text("Prepare phone CA") }
                         }
-                        SetupChecklist(setupRequirements)
-                        SetupChecklist(networkStatusRequirements)
                         CorporateUpstreamSettings(
                             sslInsecure = state.sslInsecure,
                             upstreamTrustedCaPath = state.upstreamTrustedCaPath,
@@ -685,20 +738,10 @@ internal fun NetworkScreen(
                             maxLines = 4,
                             overflow = TextOverflow.Ellipsis,
                         )
-                        Text("Debug app config", color = TextSecondary, fontWeight = FontWeight.Bold, fontSize = 11.sp)
-                        Text(
-                            DebugNetworkSecurityConfigSnippet,
-                            color = TextPrimary,
-                            fontFamily = FontFamily.Monospace,
-                            fontSize = 10.sp,
-                            lineHeight = 13.sp,
-                            maxLines = 12,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text("Use this only in debug builds that trust user CAs. Certificate pinning and arbitrary third-party app bypass are out of scope.", color = TextSecondary, fontSize = 12.sp)
                     }
                 }
             }
+
             NetworkDiagnosisStrip(state.diagnoses)
             Column(
                 Modifier
@@ -1077,39 +1120,34 @@ private fun InstallStepsCard(title: String, steps: List<String>, modifier: Modif
 }
 
 @Composable
-private fun SetupChecklist(requirements: List<SetupRequirement>, modifier: Modifier = Modifier) {
-    Row(
+private fun SetupStepCard(
+    step: Int,
+    title: String,
+    ok: Boolean?,
+    instruction: String,
+    modifier: Modifier = Modifier,
+    action: @Composable () -> Unit,
+) {
+    Column(
         modifier
-            .fillMaxWidth()
             .background(AndyColors.Neutral850, RoundedCornerShape(AndyRadius.R3))
             .border(1.dp, Border, RoundedCornerShape(AndyRadius.R3))
-            .padding(horizontal = 12.dp, vertical = 10.dp),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-        verticalAlignment = Alignment.Top,
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        requirements.forEach { requirement ->
-            Row(
-                Modifier.weight(1f),
-                verticalAlignment = Alignment.Top,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                GlowingDot(requirement.ok, Modifier.padding(top = 2.dp))
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(requirement.label, color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    Text(
-                        if (requirement.ok) requirement.readyText else requirement.missingText,
-                        color = if (requirement.ok) Green else Red,
-                        fontSize = 11.sp,
-                        lineHeight = 15.sp,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    if (!requirement.ok && requirement.installCommand != null) {
-                        Text(requirement.installCommand, color = Rust, fontFamily = MonoFont, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    }
-                }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("$step.", color = Rust, fontFamily = MonoFont, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+            Text(title, color = TextPrimary, fontWeight = FontWeight.Bold, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+            if (ok != null) {
+                GlowingDot(ok)
             }
         }
+        Text(instruction, color = TextSecondary, fontSize = 12.sp, lineHeight = 16.sp)
+        action()
     }
 }
 

--- a/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -26,7 +26,9 @@ import app.andy.ui.actions.ActionsScreen
 import app.andy.ui.apps.AppsScreen
 import app.andy.ui.bugs.BugsScreen
 import app.andy.ui.catalog.CatalogScreen
+import app.andy.ui.components.ConfirmationDialog
 import app.andy.ui.components.FilterPill
+import app.andy.ui.components.PendingConfirmation
 import app.andy.ui.components.PlaceholderScreen
 import app.andy.ui.components.noiseGridOverlay
 import app.andy.ui.controls.ControlsScreen
@@ -202,7 +204,8 @@ internal fun AndyShell(
                                 onPopOutMirror(state.selectedSerial, selectedDevice?.displayName ?: state.selectedSerial)
                             },
                             selectedPackage = state.workspaceState.selectedPackage,
-                            onSelectedPackageChange = { pkg -> state.updateWorkspace { it.copy(selectedPackage = pkg) } }
+                            onSelectedPackageChange = { pkg -> state.updateWorkspace { it.copy(selectedPackage = pkg) } },
+                            transfer = state.transfer,
                         )
                         AndyDestination.Apps -> AppsScreen(
                             services,
@@ -220,7 +223,12 @@ internal fun AndyShell(
                             onSelectedPackageChange = { pkg -> state.updateWorkspace { it.copy(selectedPackage = pkg) } }
                         )
                         AndyDestination.Intents -> IntentsScreen(services, state.selectedSerial)
-                        AndyDestination.Files -> FilesScreen(services.files, state.selectedSerial)
+                        AndyDestination.Files -> FilesScreen(
+                            files = services.files,
+                            apps = services.apps,
+                            serial = state.selectedSerial,
+                            transfer = state.transfer,
+                        )
                         AndyDestination.ComputerFiles -> HostFilesScreen(
                             service = services.hostFiles,
                             workspaceState = state.workspaceState,
@@ -296,6 +304,18 @@ internal fun AndyShell(
                 update = update,
                 onDismiss = { services.updates.respondToInstallConfirmation(false) },
                 onConfirm = { services.updates.respondToInstallConfirmation(true) }
+            )
+        }
+        state.transfer.confirmationTitle?.let { title ->
+            ConfirmationDialog(
+                confirmation = PendingConfirmation(
+                    title = title,
+                    message = state.transfer.confirmationMessage,
+                    confirmLabel = "Replace",
+                    onConfirm = { state.transfer.acceptConfirmation() },
+                ),
+                onDismiss = { state.transfer.dismissConfirmation() },
+                onConfirm = { state.transfer.acceptConfirmation() },
             )
         }
     }

--- a/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
@@ -18,6 +18,7 @@ import app.andy.model.RunningAction
 import app.andy.model.SdkDiscovery
 import app.andy.model.WorkspaceState
 import app.andy.service.AndyServices
+import app.andy.transfer.DeviceTransferCoordinator
 import app.andy.ui.accessibility.AccessibilityState
 import app.andy.ui.devices.reconnectPairedWifiDevice
 import app.andy.ui.logcat.LogcatState
@@ -67,6 +68,7 @@ internal class ShellState(
     val logcatState = LogcatState()
     val liveLogcatState = LogcatState()
     val accessibilityState = AccessibilityState()
+    val transfer = DeviceTransferCoordinator()
 
     fun setDestination(value: AndyDestination) {
         destination = value

--- a/src/commonTest/kotlin/app/andy/model/NetworkDiagnosisTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/NetworkDiagnosisTest.kt
@@ -91,17 +91,18 @@ class NetworkDiagnosisTest {
     }
 
     @Test
-    fun notRoutedWhenNoClientConnected() {
+    fun idleTabDoesNotShowPrematureCaOrRoutingErrors() {
         val diagnoses = diagnoseNetworkTraffic(
             proxyStarted = true,
-            caInstalled = true,
+            caInstalled = false,
             proxyConfigured = false,
             routeDiagnostics = NetworkRouteDiagnostics(
                 expectedProxy = "10.0.2.2:8888",
                 configuredProxy = null,
                 proxyConfigured = false,
-                vpnActive = false,
-                issues = listOf("Android global proxy is not set; expected 10.0.2.2:8888."),
+                vpnActive = true,
+                vpnName = "epc.tmobile.com",
+                issues = listOf("A VPN is active (epc.tmobile.com); it can bypass Android's global HTTP proxy."),
             ),
             exchanges = emptyList(),
             warnings = emptyList(),
@@ -110,6 +111,67 @@ class NetworkDiagnosisTest {
             upstreamTrustedCaPath = null,
         )
 
-        assertTrue(diagnoses.any { it.mode == NetworkFailureMode.NotRouted && it.severity == NetworkDiagnosisSeverity.Red })
+        assertTrue(diagnoses.none { it.mode == NetworkFailureMode.NotRouted })
+        assertTrue(diagnoses.none { it.mode == NetworkFailureMode.CaNotInstalled })
+        assertTrue(diagnoses.any { it.title == "Waiting for traffic" })
+    }
+
+    @Test
+    fun addonErrorsSurfaceAlongsideHealthyCapture() {
+        val diagnoses = diagnoseNetworkTraffic(
+            proxyStarted = true,
+            caInstalled = true,
+            proxyConfigured = true,
+            routeDiagnostics = null,
+            exchanges = listOf(
+                NetworkExchange(
+                    id = "flow-ok",
+                    flowId = "flow-ok",
+                    startedAtMillis = 1,
+                    completedAtMillis = 2,
+                    method = "GET",
+                    url = "https://example.test/",
+                    statusCode = 200,
+                    contentType = "application/json",
+                    sizeBytes = 2,
+                    durationMillis = 1,
+                    requestHeaders = emptyMap(),
+                    responseHeaders = emptyMap(),
+                    requestBodyPreview = null,
+                    responseBodyPreview = "{}",
+                    error = null,
+                    tlsStatus = "tls",
+                    matchedRuleId = null,
+                ),
+            ),
+            warnings = listOf(
+                ProxyWarning(
+                    id = "w1",
+                    atMillis = 3,
+                    kind = ProxyWarningKind.AddonError,
+                    message = "response hook: NameError: x",
+                ),
+                ProxyWarning(
+                    id = "w2",
+                    atMillis = 4,
+                    kind = ProxyWarningKind.CaptureDropped,
+                    message = "Network capture dropped 3 event(s) under load; proxied traffic was not blocked.",
+                ),
+                ProxyWarning(
+                    id = "w3",
+                    atMillis = 5,
+                    kind = ProxyWarningKind.AddonMismatch,
+                    message = "Running mitm addon SHA-256 deadbeef does not match Andy's resource abc.",
+                ),
+            ),
+            clientConnectionsObserved = 1,
+            sslInsecure = false,
+            upstreamTrustedCaPath = null,
+        )
+
+        assertTrue(diagnoses.any { it.severity == NetworkDiagnosisSeverity.Green && it.title.contains("Capturing") })
+        assertTrue(diagnoses.any { it.title == "mitm addon error" && it.detail.contains("NameError") })
+        assertTrue(diagnoses.any { it.title == "Network capture dropped events" })
+        assertTrue(diagnoses.any { it.title == "mitm addon version mismatch" })
     }
 }

--- a/src/commonTest/kotlin/app/andy/transfer/DeviceTransferHelpersTest.kt
+++ b/src/commonTest/kotlin/app/andy/transfer/DeviceTransferHelpersTest.kt
@@ -1,0 +1,38 @@
+package app.andy.transfer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import app.andy.service.CommandResult
+
+class DeviceTransferHelpersTest {
+    @Test
+    fun classifiesApkOnlyDrops() {
+        assertEquals(LocalDropKind.Apks, classifyLocalPaths(listOf("/tmp/app.apk", "/tmp/other.APK")))
+    }
+
+    @Test
+    fun classifiesFileDrops() {
+        assertEquals(LocalDropKind.Files, classifyLocalPaths(listOf("/tmp/notes.txt", "/tmp/assets")))
+    }
+
+    @Test
+    fun classifiesMixedDrops() {
+        assertEquals(LocalDropKind.Mixed, classifyLocalPaths(listOf("/tmp/app.apk", "/tmp/notes.txt")))
+    }
+
+    @Test
+    fun detectsAlreadyInstalledConflict() {
+        val result = CommandResult.failure("Failure [INSTALL_FAILED_ALREADY_EXISTS: Package com.example already exists]")
+        assertTrue(result.isAlreadyInstalledConflict())
+        assertFalse(CommandResult.failure("INSTALL_FAILED_UPDATE_INCOMPATIBLE").isAlreadyInstalledConflict())
+        assertFalse(CommandResult.success("Success").isAlreadyInstalledConflict())
+    }
+
+    @Test
+    fun joinsRemotePaths() {
+        assertEquals("/sdcard/Download/report.txt", joinRemotePath("/sdcard/Download", "report.txt"))
+        assertEquals("/report.txt", joinRemotePath("/", "report.txt"))
+    }
+}

--- a/src/commonTest/kotlin/app/andy/ui/files/FilesPathHelpersTest.kt
+++ b/src/commonTest/kotlin/app/andy/ui/files/FilesPathHelpersTest.kt
@@ -1,0 +1,14 @@
+package app.andy.ui.files
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FilesPathHelpersTest {
+    @Test
+    fun parentPathHandlesRootsAndNestedPaths() {
+        assertEquals("/", parentPath("/"))
+        assertEquals("/", parentPath("/sdcard"))
+        assertEquals("/sdcard", parentPath("/sdcard/Download"))
+        assertEquals("/sdcard/Download", parentPath("/sdcard/Download/report.txt"))
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/DirectoryPicker.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/DirectoryPicker.desktop.kt
@@ -20,9 +20,56 @@ actual suspend fun pickDirectory(initialDir: String?): String? = withContext(Dis
     }
 }
 
+actual suspend fun pickFiles(initialDir: String?, allowMultiple: Boolean): List<String> = withContext(Dispatchers.IO) {
+    val initial = initialDir?.takeIf { it.isNotBlank() }
+    when (val result = nativeFilePicker(initial, allowMultiple)) {
+        is MultiPickerResult.Selected -> result.paths
+        MultiPickerResult.Cancelled -> emptyList()
+        null -> swingFilePicker(initial, allowMultiple)
+    }
+}
+
+actual fun downloadsDirectory(): String {
+    val home = System.getProperty("user.home") ?: "."
+    val os = System.getProperty("os.name").orEmpty().lowercase()
+    val candidate = when {
+        os.contains("win") -> {
+            val userProfile = System.getenv("USERPROFILE")
+            userProfile?.let { File(it, "Downloads") }?.takeIf { it.exists() || it.mkdirs() }
+                ?: File(home, "Downloads")
+        }
+        else -> File(home, "Downloads")
+    }
+    if (!candidate.exists()) {
+        candidate.mkdirs()
+    }
+    return candidate.absolutePath
+}
+
+actual fun uniqueLocalPath(directory: String, fileName: String): String {
+    val dir = File(directory)
+    dir.mkdirs()
+    val base = File(fileName).name
+    val dot = base.lastIndexOf('.')
+    val stem = if (dot > 0) base.substring(0, dot) else base
+    val ext = if (dot > 0) base.substring(dot) else ""
+    var candidate = File(dir, base)
+    var index = 1
+    while (candidate.exists()) {
+        candidate = File(dir, "$stem ($index)$ext")
+        index++
+    }
+    return candidate.absolutePath
+}
+
 private sealed class PickerResult {
     data class Selected(val path: String) : PickerResult()
     data object Cancelled : PickerResult()
+}
+
+private sealed class MultiPickerResult {
+    data class Selected(val paths: List<String>) : MultiPickerResult()
+    data object Cancelled : MultiPickerResult()
 }
 
 private fun nativeDirectoryPicker(initialDir: String?): PickerResult? {
@@ -31,6 +78,16 @@ private fun nativeDirectoryPicker(initialDir: String?): PickerResult? {
         os.contains("mac") || os.contains("darwin") -> macDirectoryPicker(initialDir)
         os.contains("win") -> windowsDirectoryPicker(initialDir)
         os.contains("linux") -> linuxDirectoryPicker(initialDir)
+        else -> null
+    }
+}
+
+private fun nativeFilePicker(initialDir: String?, allowMultiple: Boolean): MultiPickerResult? {
+    val os = System.getProperty("os.name").lowercase()
+    return when {
+        os.contains("mac") || os.contains("darwin") -> macFilePicker(initialDir, allowMultiple)
+        os.contains("win") -> windowsFilePicker(initialDir, allowMultiple)
+        os.contains("linux") -> linuxFilePicker(initialDir, allowMultiple)
         else -> null
     }
 }
@@ -45,6 +102,30 @@ private fun macDirectoryPicker(initialDir: String?): PickerResult? {
         POSIX path of chosenFolder
     """.trimIndent()
     return runPickerCommand(listOf("osascript", "-e", script))
+}
+
+private fun macFilePicker(initialDir: String?, allowMultiple: Boolean): MultiPickerResult? {
+    val defaultLocation = initialDir
+        ?.takeIf { File(it).exists() }
+        ?.let { """ default location POSIX file "${it.escapeAppleScript()}"""" }
+        .orEmpty()
+    val multiple = if (allowMultiple) " with multiple selections allowed" else ""
+    val script = if (allowMultiple) {
+        """
+            set chosenFiles to choose file with prompt "Choose files"$defaultLocation$multiple
+            set output to ""
+            repeat with f in chosenFiles
+                set output to output & POSIX path of f & linefeed
+            end repeat
+            return output
+        """.trimIndent()
+    } else {
+        """
+            set chosenFile to choose file with prompt "Choose file"$defaultLocation
+            POSIX path of chosenFile
+        """.trimIndent()
+    }
+    return runMultiPickerCommand(listOf("osascript", "-e", script))
 }
 
 private fun windowsDirectoryPicker(initialDir: String?): PickerResult? {
@@ -65,11 +146,44 @@ private fun windowsDirectoryPicker(initialDir: String?): PickerResult? {
     return runPickerCommand(listOf("pwsh", "-NoProfile", "-Command", command))
 }
 
+private fun windowsFilePicker(initialDir: String?, allowMultiple: Boolean): MultiPickerResult? {
+    val initial = initialDir
+        ?.takeIf { File(it).exists() }
+        ?.let { "\$dialog.InitialDirectory = '${it.escapePowerShellSingleQuoted()}'" }
+        .orEmpty()
+    val multi = if (allowMultiple) "\$dialog.Multiselect = \$true;" else ""
+    val command = """
+        Add-Type -AssemblyName System.Windows.Forms;
+        ${'$'}dialog = New-Object System.Windows.Forms.OpenFileDialog;
+        ${'$'}dialog.Title = 'Choose files';
+        ${'$'}dialog.CheckFileExists = ${'$'}true;
+        $multi
+        $initial
+        if (${'$'}dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+          foreach (${'$'}f in ${'$'}dialog.FileNames) { [Console]::Out.WriteLine(${'$'}f) }
+        }
+    """.trimIndent()
+    val powershell = runMultiPickerCommand(listOf("powershell", "-NoProfile", "-STA", "-Command", command))
+    if (powershell != null) return powershell
+    return runMultiPickerCommand(listOf("pwsh", "-NoProfile", "-Command", command))
+}
+
 private fun linuxDirectoryPicker(initialDir: String?): PickerResult? {
     val zenity = mutableListOf("zenity", "--file-selection", "--directory", "--title=Choose folder")
     initialDir?.takeIf { it.isNotBlank() }?.let { zenity += "--filename=$it" }
     return runPickerCommand(zenity)
         ?: runPickerCommand(listOf("kdialog", "--getexistingdirectory", initialDir.orEmpty()))
+}
+
+private fun linuxFilePicker(initialDir: String?, allowMultiple: Boolean): MultiPickerResult? {
+    val zenity = mutableListOf("zenity", "--file-selection", "--title=Choose files")
+    if (allowMultiple) zenity += "--multiple"
+    initialDir?.takeIf { it.isNotBlank() }?.let { zenity += "--filename=$it" }
+    val zenityResult = runMultiPickerCommand(zenity, splitOn = "|")
+    if (zenityResult != null) return zenityResult
+    val kdialog = mutableListOf("kdialog", "--getopenfilename", initialDir.orEmpty().ifBlank { "." })
+    if (allowMultiple) kdialog += "--multiple"
+    return runMultiPickerCommand(kdialog, splitOn = " ")
 }
 
 /**
@@ -97,6 +211,25 @@ private fun runPickerCommand(command: List<String>): PickerResult? {
     }
 }
 
+private fun runMultiPickerCommand(command: List<String>, splitOn: String? = null): MultiPickerResult? {
+    val process = runCatching {
+        ProcessBuilder(command).redirectErrorStream(true).start()
+    }.getOrNull() ?: return null
+
+    if (!process.waitFor(24, TimeUnit.HOURS)) {
+        process.destroyForcibly()
+        return MultiPickerResult.Cancelled
+    }
+    val output = process.inputStream.bufferedReader().readText().trim()
+    if (process.exitValue() != 0 || output.isBlank()) return MultiPickerResult.Cancelled
+    val paths = if (splitOn != null && !output.contains('\n')) {
+        output.split(splitOn).map { it.trim() }.filter { it.isNotBlank() }
+    } else {
+        output.lineSequence().map { it.trim() }.filter { it.isNotBlank() }.toList()
+    }
+    return if (paths.isEmpty()) MultiPickerResult.Cancelled else MultiPickerResult.Selected(paths)
+}
+
 private fun swingDirectoryPicker(initialDir: String?): String? {
     var selected: File? = null
     val task = Runnable {
@@ -115,6 +248,31 @@ private fun swingDirectoryPicker(initialDir: String?): String? {
         SwingUtilities.invokeAndWait(task)
     }
     return selected?.absolutePath
+}
+
+private fun swingFilePicker(initialDir: String?, allowMultiple: Boolean): List<String> {
+    var selected: List<String> = emptyList()
+    val task = Runnable {
+        val chooser = JFileChooser(initialDir?.let(::File)).apply {
+            fileSelectionMode = JFileChooser.FILES_AND_DIRECTORIES
+            isMultiSelectionEnabled = allowMultiple
+            dialogTitle = if (allowMultiple) "Choose files" else "Choose file"
+            approveButtonText = "Choose"
+        }
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+            selected = if (allowMultiple) {
+                chooser.selectedFiles.map { it.absolutePath }
+            } else {
+                listOfNotNull(chooser.selectedFile?.absolutePath)
+            }
+        }
+    }
+    if (SwingUtilities.isEventDispatchThread()) {
+        task.run()
+    } else {
+        SwingUtilities.invokeAndWait(task)
+    }
+    return selected
 }
 
 private fun String.escapeAppleScript(): String = replace("\\", "\\\\").replace("\"", "\\\"")

--- a/src/desktopMain/kotlin/app/andy/ExternalFileDrop.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ExternalFileDrop.desktop.kt
@@ -1,0 +1,52 @@
+package app.andy
+
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.DragData
+import androidx.compose.ui.draganddrop.dragData
+import androidx.compose.ui.ExperimentalComposeUiApi
+import java.io.File
+import java.net.URI
+
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun Modifier.onExternalFileDrop(
+    enabled: Boolean,
+    onDrop: (paths: List<String>) -> Unit,
+): Modifier = composed {
+    val target = remember(onDrop) {
+        object : DragAndDropTarget {
+            override fun onDrop(event: DragAndDropEvent): Boolean {
+                val paths = event.filePaths()
+                if (paths.isEmpty()) return false
+                onDrop(paths)
+                return true
+            }
+        }
+    }
+    if (!enabled) return@composed this
+    dragAndDropTarget(
+        shouldStartDragAndDrop = { event ->
+            event.dragData() is DragData.FilesList
+        },
+        target = target,
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun DragAndDropEvent.filePaths(): List<String> {
+    val data = dragData() as? DragData.FilesList ?: return emptyList()
+    return data.readFiles().mapNotNull { uriString ->
+        runCatching {
+            val uri = URI(uriString)
+            if (uri.scheme.equals("file", ignoreCase = true)) {
+                File(uri).absolutePath
+            } else {
+                uriString
+            }
+        }.getOrNull()
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/Main.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/Main.kt
@@ -76,7 +76,17 @@ fun main() {
             LaunchedEffect(window) {
                 configureMacTitleBar(window)
             }
-            MenuBar {}
+            MenuBar {
+                Menu("Go") {
+                    AndyDestination.entries.forEach { destination ->
+                        Item(
+                            destination.label,
+                            shortcut = destination.menuShortcut(),
+                            onClick = { open(destination) },
+                        )
+                    }
+                }
+            }
             AndyApp(
                 services = services,
                 requestedDestination = requestedDestination,
@@ -161,3 +171,29 @@ private fun removeDockReopenHandler(listener: SystemEventListener?) {
 
 private fun isMacOs(): Boolean =
     System.getProperty("os.name").orEmpty().contains("mac", ignoreCase = true)
+
+/** Cmd/Ctrl+1–0 for the first ten pages; letter shortcuts for the rest. */
+private fun AndyDestination.menuShortcut(): KeyShortcut {
+    val meta = isMacOs()
+    val ctrl = !isMacOs()
+    return when (this) {
+        AndyDestination.Devices -> KeyShortcut(Key.One, meta = meta, ctrl = ctrl)
+        AndyDestination.Catalog -> KeyShortcut(Key.Two, meta = meta, ctrl = ctrl)
+        AndyDestination.Live -> KeyShortcut(Key.Three, meta = meta, ctrl = ctrl)
+        AndyDestination.Apps -> KeyShortcut(Key.Four, meta = meta, ctrl = ctrl)
+        AndyDestination.Logcat -> KeyShortcut(Key.Five, meta = meta, ctrl = ctrl)
+        AndyDestination.Intents -> KeyShortcut(Key.Six, meta = meta, ctrl = ctrl)
+        AndyDestination.Files -> KeyShortcut(Key.Seven, meta = meta, ctrl = ctrl)
+        AndyDestination.ComputerFiles -> KeyShortcut(Key.Eight, meta = meta, ctrl = ctrl)
+        AndyDestination.Network -> KeyShortcut(Key.Nine, meta = meta, ctrl = ctrl)
+        AndyDestination.Actions -> KeyShortcut(Key.Zero, meta = meta, ctrl = ctrl)
+        AndyDestination.Snapshots -> KeyShortcut(Key.S, meta = meta, ctrl = ctrl, shift = true)
+        AndyDestination.Controls -> KeyShortcut(Key.C, meta = meta, ctrl = ctrl, shift = true)
+        AndyDestination.Performance -> KeyShortcut(Key.P, meta = meta, ctrl = ctrl, shift = true)
+        // Shift+D is already used by the mirror pop-out "Show controls" toggle.
+        AndyDestination.Design -> KeyShortcut(Key.E, meta = meta, ctrl = ctrl, shift = true)
+        AndyDestination.Accessibility -> KeyShortcut(Key.A, meta = meta, ctrl = ctrl, shift = true)
+        AndyDestination.Bugs -> KeyShortcut(Key.B, meta = meta, ctrl = ctrl, shift = true)
+        AndyDestination.Settings -> KeyShortcut(Key.Comma, meta = meta, ctrl = ctrl)
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/service/AvdHomeScanner.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/AvdHomeScanner.kt
@@ -1,0 +1,80 @@
+package app.andy.desktop.service
+
+import app.andy.desktop.parser.AndroidParsers
+import app.andy.model.VirtualDevice
+import java.io.File
+
+/**
+ * Lists AVDs by reading Android's AVD metadata on disk.
+ *
+ * Prefer this over `avdmanager list avd` for discovery: packaged Andy launched from
+ * Finder/Dock often has no usable `JAVA_HOME`, so the Java-based cmdline tools fail
+ * and Devices would otherwise show zero AVDs.
+ */
+object AvdHomeScanner {
+    fun avdHome(
+        env: Map<String, String> = System.getenv(),
+        userHome: File = File(System.getProperty("user.home")),
+    ): File {
+        env["ANDROID_AVD_HOME"]?.takeIf { it.isNotBlank() }?.let { return File(it) }
+        env["ANDROID_USER_HOME"]?.takeIf { it.isNotBlank() }?.let { return File(it, "avd") }
+        return File(userHome, ".android/avd")
+    }
+
+    fun listVirtualDevices(
+        env: Map<String, String> = System.getenv(),
+        userHome: File = File(System.getProperty("user.home")),
+    ): List<VirtualDevice> {
+        val home = avdHome(env, userHome)
+        if (!home.isDirectory) return emptyList()
+        return home.listFiles()
+            .orEmpty()
+            .filter { it.isFile && it.name.endsWith(".ini") }
+            .mapNotNull { ini -> runCatching { parseAvdIni(ini) }.getOrNull() }
+            .sortedBy { it.name.lowercase() }
+    }
+
+    private fun parseAvdIni(ini: File): VirtualDevice? {
+        val props = readIni(ini)
+        val name = ini.name.removeSuffix(".ini")
+        val path = props["path"]?.takeIf { it.isNotBlank() }
+            ?: File(ini.parentFile, "$name.avd").takeIf { it.isDirectory }?.absolutePath
+            ?: return null
+        if (!File(path).isDirectory) return null
+        val config = File(path, "config.ini").takeIf { it.exists() }?.let(::readIni).orEmpty()
+        val target = props["target"]
+            ?: config["image.sysdir.1"]
+            ?: config["tag.display"]
+        val abi = config["abi.type"] ?: config["hw.cpu.arch"]
+        val apiLevel = Regex("""android-(\d+)""", RegexOption.IGNORE_CASE)
+            .find(target.orEmpty())
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toIntOrNull()
+            ?: Regex("""android-(\d+)""", RegexOption.IGNORE_CASE)
+                .find(config["image.sysdir.1"].orEmpty())
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.toIntOrNull()
+        return VirtualDevice(
+            name = name,
+            path = path,
+            target = target,
+            abi = abi,
+            running = false,
+            apiLevel = apiLevel,
+            deviceType = AndroidParsers.classifyVirtualDevice(name, target.orEmpty(), config),
+            config = config,
+        )
+    }
+
+    private fun readIni(file: File): Map<String, String> {
+        return file.readLines()
+            .mapNotNull { line ->
+                val trimmed = line.trim()
+                if (trimmed.isBlank() || trimmed.startsWith("#") || "=" !in trimmed) null
+                else trimmed.substringBefore("=") to trimmed.substringAfter("=")
+            }
+            .toMap()
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/service/CommandRunner.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/CommandRunner.kt
@@ -1,12 +1,15 @@
 package app.andy.desktop.service
 
 import app.andy.service.CommandResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.coroutineContext
 
 class CommandRunner(
     private val defaultTimeoutSeconds: Long = 20,
@@ -22,19 +25,32 @@ class CommandRunner(
             val readerPool = Executors.newFixedThreadPool(2)
             val stdoutFuture = readerPool.submit(Callable { process.inputStream.bufferedReader().readText() })
             val stderrFuture = readerPool.submit(Callable { process.errorStream.bufferedReader().readText() })
-            val completed = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
-            if (!completed) {
+            try {
+                val deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
+                while (true) {
+                    coroutineContext.ensureActive()
+                    val remainingNs = deadlineNs - System.nanoTime()
+                    if (remainingNs <= 0L) {
+                        process.destroyForcibly()
+                        readerPool.shutdownNow()
+                        return@withContext CommandResult.failure("Command timed out: ${command.joinToString(" ")}", 124)
+                    }
+                    val sliceMs = minOf(250L, TimeUnit.NANOSECONDS.toMillis(remainingNs).coerceAtLeast(1L))
+                    if (process.waitFor(sliceMs, TimeUnit.MILLISECONDS)) break
+                }
+                readerPool.shutdown()
+                CommandResult(
+                    exitCode = process.exitValue(),
+                    stdout = stdoutFuture.get(1, TimeUnit.SECONDS),
+                    stderr = stderrFuture.get(1, TimeUnit.SECONDS),
+                )
+            } catch (cancelled: CancellationException) {
                 process.destroyForcibly()
                 readerPool.shutdownNow()
-                return@withContext CommandResult.failure("Command timed out: ${command.joinToString(" ")}", 124)
+                throw cancelled
             }
-            readerPool.shutdown()
-            CommandResult(
-                exitCode = process.exitValue(),
-                stdout = stdoutFuture.get(1, TimeUnit.SECONDS),
-                stderr = stderrFuture.get(1, TimeUnit.SECONDS),
-            )
         }.getOrElse { error ->
+            if (error is CancellationException) throw error
             CommandResult.failure(error.message ?: "Command failed")
         }
     }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopAppService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopAppService.kt
@@ -142,6 +142,19 @@ class DesktopAppService(
         return runner.run(listOf(adb, "-s", serial, "uninstall", packageName), 60)
     }
 
+    override suspend fun install(serial: String, apkPath: String, replace: Boolean): CommandResult {
+        val adb = devices.adbPath() ?: return CommandResult.failure("ADB not found")
+        val command = buildList {
+            add(adb)
+            add("-s")
+            add(serial)
+            add("install")
+            if (replace) add("-r")
+            add(apkPath)
+        }
+        return runner.run(command, 180)
+    }
+
     override suspend fun listPermissions(serial: String, packageName: String): List<AndroidPermission> {
         val output = devices.shell(serial, listOf("dumpsys", "package", packageName)).stdout
         return AndroidParsers.parsePackagePermissions(output)

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopAvdService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopAvdService.kt
@@ -8,6 +8,7 @@ import app.andy.model.DeviceKind
 import app.andy.model.EmulatorSnapshot
 import app.andy.model.SystemImage
 import app.andy.model.VirtualDevice
+import app.andy.model.VirtualDeviceType
 import app.andy.service.AvdService
 import app.andy.service.CommandResult
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +22,8 @@ import kotlin.math.roundToInt
 class DesktopAvdService(
     private val runner: CommandRunner,
     private val locator: SdkLocator,
+    private val listAvdsFromDisk: () -> List<VirtualDevice> = { AvdHomeScanner.listVirtualDevices() },
+    private val resolveAvdHome: () -> File = { AvdHomeScanner.avdHome() },
     private val preferredSdkPath: suspend () -> String? = { null },
 ) : AvdService {
     private fun getDirectorySize(dir: File): Long {
@@ -77,15 +80,19 @@ class DesktopAvdService(
     }
 
     override suspend fun listVirtualDevices(): List<VirtualDevice> {
-        val avdManager = locator.discover(preferredSdkPath()).avdManagerPath ?: return emptyList()
-        val avds = AndroidParsers.parseAvdList(runner.run(listOf(avdManager, "list", "avd"), 20).stdout)
+        val avds = listAvdsFromDisk()
         val running = runningEmulatorNames()
         return avds.map { avd ->
-            val config = loadAvdConfig(avd).orEmpty()
+            val config = avd.config.ifEmpty { loadAvdConfig(avd).orEmpty() }
             avd.copy(
                 running = running.any { namesMatch(it, avd.name) },
-                apiLevel = avd.apiLevel ?: Regex("""android-(\d+)""").find(config["image.sysdir.1"].orEmpty())?.groupValues?.getOrNull(1)?.toIntOrNull(),
-                deviceType = AndroidParsers.classifyVirtualDevice(avd.name, avd.target.orEmpty(), config),
+                apiLevel = avd.apiLevel
+                    ?: Regex("""android-(\d+)""").find(config["image.sysdir.1"].orEmpty())?.groupValues?.getOrNull(1)?.toIntOrNull(),
+                deviceType = if (avd.deviceType != VirtualDeviceType.Unknown) {
+                    avd.deviceType
+                } else {
+                    AndroidParsers.classifyVirtualDevice(avd.name, avd.target.orEmpty(), config)
+                },
                 config = config,
             )
         }
@@ -450,7 +457,7 @@ class DesktopAvdService(
         val path = avd.path?.let(::File) ?: return null
         return listOf(
             File(path.parentFile, "${avd.name}.ini"),
-            File(File(System.getProperty("user.home"), ".android/avd"), "${avd.name}.ini"),
+            File(resolveAvdHome(), "${avd.name}.ini"),
         ).firstOrNull { it.exists() }
     }
 

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
@@ -137,7 +137,7 @@ class DesktopMcpServerService(
         "create_avd", "clone_avd", "delete_avd", "start_emulator", "stop_emulator",
         "install_system_image", "tap", "swipe", "input_text", "press_key",
         "screenshot", "ui_dump", "list_apps", "launch_app", "stop_app",
-        "clear_app_data", "uninstall_app", "list_permissions", "list_activities",
+        "clear_app_data", "uninstall_app", "install_app", "list_permissions", "list_activities",
         "send_intent", "file_list_dir", "file_pull", "file_push", "file_delete",
         "start_network_proxy", "list_network_mock_rules", "upsert_network_mock_rule",
         "set_network_mock_rules", "delete_network_mock_rule", "stop_network_proxy",
@@ -566,6 +566,26 @@ class DesktopMcpServerService(
             val packageName = args["packageName"]?.jsonPrimitive?.content ?: throw IllegalArgumentException("packageName is required")
             val resolved = resolveSerial(args["serial"]?.jsonPrimitive?.contentOrNull)
             val result = apps.uninstall(resolved, packageName)
+            CallToolResult(
+                content = listOf(TextContent(text = "Result: ${result.exitCode}\nStdout: ${result.stdout}\nStderr: ${result.stderr}")),
+                isError = !result.isSuccess
+            )
+        }
+
+        mcpServer.registerTool(
+            "install_app",
+            "Install an APK onto the device",
+            mapOf(
+                "apkPath" to stringProp("Local path to the APK file"),
+                "replace" to boolProp("Replace an existing installation (adb install -r)"),
+                "serial" to stringProp("Optional target device serial")
+            ),
+            listOf("apkPath")
+        ) { args ->
+            val apkPath = args["apkPath"]?.jsonPrimitive?.content ?: throw IllegalArgumentException("apkPath is required")
+            val replace = args["replace"]?.jsonPrimitive?.booleanOrNull ?: false
+            val resolved = resolveSerial(args["serial"]?.jsonPrimitive?.contentOrNull)
+            val result = apps.install(resolved, apkPath, replace)
             CallToolResult(
                 content = listOf(TextContent(text = "Result: ${result.exitCode}\nStdout: ${result.stdout}\nStderr: ${result.stderr}")),
                 isError = !result.isSuccess

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/DesktopProxyService.kt
@@ -19,10 +19,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.LinkedHashMap
 import java.util.UUID
+import kotlin.coroutines.coroutineContext
 
 class DesktopProxyService(
     private val runner: CommandRunner,
@@ -45,6 +48,11 @@ class DesktopProxyService(
     private var process: ProxyProcess? = null
     private var stdoutJob: Job? = null
     private var stderrJob: Job? = null
+    private var publishJob: Job? = null
+    private val exchangeLock = Any()
+    private val exchangeById = LinkedHashMap<String, NetworkExchange>()
+    @Volatile private var exchangesDirty = false
+    private val expectedAddonSha256: String by lazy { MitmAddon.getAddonSourceSha256() }
 
     override suspend fun detectMitmproxy(): CommandResult = withContext(Dispatchers.IO) {
         val executable = mitmdumpExecutable()
@@ -92,6 +100,14 @@ class DesktopProxyService(
                     "--set", "confdir=${proxyDir.absolutePath}",
                     "-s", addonFile.absolutePath,
                     "--set", "termlog_verbosity=warn",
+                    // Defer upstream dial until after ClientHello so server_connect
+                    // can remap unreachable IPv6 literals using SNI (NCEI, etc.).
+                    "--set", "connection_strategy=lazy",
+                    // Passthrough Android network-validation hosts so generate_204
+                    // succeeds with system CAs. MITM on these marks the network
+                    // PARTIAL_CONNECTIVITY and can make apps feel offline/slow.
+                    "--set",
+                    "ignore_hosts=^(.+\\.)?(google\\.com|gstatic\\.com|googleapis\\.com|googleusercontent\\.com):443$",
                 ),
             )
             if (options.sslInsecure) {
@@ -125,6 +141,10 @@ class DesktopProxyService(
     }
 
     override suspend fun clearTraffic(): CommandResult = withContext(Dispatchers.IO) {
+        synchronized(exchangeLock) {
+            exchangeById.clear()
+            exchangesDirty = false
+        }
         exchanges.value = emptyList()
         warnings.value = emptyList()
         clientConnectionCount.value = 0
@@ -139,8 +159,10 @@ class DesktopProxyService(
     private fun stopCurrentProcess(updateStatus: Boolean) {
         stdoutJob?.cancel()
         stderrJob?.cancel()
+        publishJob?.cancel()
         stdoutJob = null
         stderrJob = null
+        publishJob = null
         process?.destroy()
         process = null
         if (updateStatus) status.value = "Proxy stopped"
@@ -666,20 +688,19 @@ class DesktopProxyService(
     }
 
     private fun pumpProcess(proxyProcess: ProxyProcess) {
+        publishJob = kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
+            while (coroutineContext.isActive) {
+                publishExchangesIfDirty()
+                delay(ExchangePublishIntervalMs)
+            }
+        }
         stdoutJob = kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
             proxyProcess.stdout.bufferedReader().useLines { lines ->
                 lines.forEach { line ->
                     when (val event = parseMitmproxyEvent(line)) {
                         is MitmproxyEvent.Exchange -> {
                             val exchange = event.exchange
-                            exchanges.update { current ->
-                                val index = current.indexOfFirst { it.id == exchange.id }
-                                if (index >= 0) {
-                                    current.toMutableList().also { it[index] = exchange }
-                                } else {
-                                    (current + exchange).takeLast(MaxNetworkExchanges)
-                                }
-                            }
+                            upsertExchange(exchange)
                             if (isClientTlsRejectionError(exchange.error) || exchange.method == "TLS") {
                                 pushWarning(
                                     ProxyWarningKind.ClientTlsFailure,
@@ -697,10 +718,34 @@ class DesktopProxyService(
                             clientConnectionCount.update { it + 1 }
                         }
                         is MitmproxyEvent.ClientDisconnected -> Unit
+                        is MitmproxyEvent.AddonHello -> {
+                            val reported = event.sha256?.lowercase()
+                            if (reported != null && reported != expectedAddonSha256) {
+                                pushWarning(
+                                    ProxyWarningKind.AddonMismatch,
+                                    "Running mitm addon SHA-256 $reported does not match Andy's resource $expectedAddonSha256. Stop/Start the proxy (or quit duplicate Andy instances).",
+                                )
+                            }
+                        }
+                        is MitmproxyEvent.EventsDropped -> {
+                            if (event.count > 0) {
+                                pushWarning(
+                                    ProxyWarningKind.CaptureDropped,
+                                    "Network capture dropped ${event.count} event(s) under load; proxied traffic was not blocked.",
+                                )
+                            }
+                        }
+                        is MitmproxyEvent.AddonError -> {
+                            pushWarning(
+                                ProxyWarningKind.AddonError,
+                                event.error?.takeIf { it.isNotBlank() } ?: "mitm addon error",
+                            )
+                        }
                         null -> Unit
                     }
                 }
             }
+            publishExchangesIfDirty()
             if (process === proxyProcess && !proxyProcess.isAlive()) status.value = "mitmdump exited"
         }
         stderrJob = kotlinx.coroutines.CoroutineScope(Dispatchers.IO).launch {
@@ -716,6 +761,30 @@ class DesktopProxyService(
                 }
             }
         }
+    }
+
+    private fun upsertExchange(exchange: NetworkExchange) {
+        synchronized(exchangeLock) {
+            if (exchangeById.containsKey(exchange.id)) {
+                exchangeById[exchange.id] = exchange
+            } else {
+                exchangeById[exchange.id] = exchange
+                while (exchangeById.size > MaxNetworkExchanges) {
+                    val oldest = exchangeById.keys.firstOrNull() ?: break
+                    exchangeById.remove(oldest)
+                }
+            }
+            exchangesDirty = true
+        }
+    }
+
+    private fun publishExchangesIfDirty() {
+        val snapshot = synchronized(exchangeLock) {
+            if (!exchangesDirty) return
+            exchangesDirty = false
+            exchangeById.values.toList()
+        }
+        exchanges.value = snapshot
     }
 
     private fun classifyStderrWarning(line: String): Pair<ProxyWarningKind, String>? {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/MitmAddon.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/MitmAddon.kt
@@ -1,5 +1,7 @@
 package app.andy.desktop.service.proxy
 
+import java.security.MessageDigest
+
 /**
  * Loads the mitmproxy addon from the classpath resource `proxy/andy_mitm_addon.py`.
  * The resource is the sole source of truth; missing resource fails clearly.
@@ -18,4 +20,10 @@ object MitmAddon {
 
     /** Returns the addon source as UTF-8 text. */
     fun getAddonSourceText(): String = getAddonSource().toString(Charsets.UTF_8)
+
+    /** SHA-256 hex digest of the classpath addon source. */
+    fun getAddonSourceSha256(): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(getAddonSource())
+        return digest.joinToString("") { "%02x".format(it) }
+    }
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/ProxyJson.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/ProxyJson.kt
@@ -33,7 +33,7 @@ internal data class ProxyRuleDto(
 @Serializable
 internal data class MitmproxyFlowLineDto(
     val type: String,
-    val id: String,
+    val id: String? = null,
     val startedAtMillis: Long? = null,
     val completedAtMillis: Long? = null,
     val method: String? = null,
@@ -52,12 +52,18 @@ internal data class MitmproxyFlowLineDto(
     val sni: String? = null,
     val peer: String? = null,
     val reason: String? = null,
+    val sha256: String? = null,
+    val version: Int? = null,
+    val count: Long? = null,
 )
 
 internal sealed interface MitmproxyEvent {
     data class Exchange(val exchange: NetworkExchange) : MitmproxyEvent
     data class ClientConnected(val id: String, val peer: String?, val atMillis: Long) : MitmproxyEvent
     data class ClientDisconnected(val id: String, val peer: String?, val atMillis: Long) : MitmproxyEvent
+    data class AddonHello(val sha256: String?, val version: Int?, val atMillis: Long) : MitmproxyEvent
+    data class EventsDropped(val count: Long) : MitmproxyEvent
+    data class AddonError(val id: String, val error: String?, val atMillis: Long) : MitmproxyEvent
 }
 
 internal object ProxyRuleJson {
@@ -76,22 +82,36 @@ internal fun parseMitmproxyEvent(line: String): MitmproxyEvent? {
         ProxyJsonFormat.decodeFromString(MitmproxyFlowLineDto.serializer(), line)
     }.getOrNull() ?: return null
     return when (dto.type) {
-        "flow", "tls_failed" -> MitmproxyEvent.Exchange(dto.toNetworkExchange())
+        "flow", "tls_failed" -> {
+            val id = dto.id ?: return null
+            MitmproxyEvent.Exchange(dto.toNetworkExchange(id))
+        }
         "client_connected" -> MitmproxyEvent.ClientConnected(
-            id = dto.id,
+            id = dto.id ?: return null,
             peer = dto.peer,
             atMillis = dto.startedAtMillis ?: System.currentTimeMillis(),
         )
         "client_disconnected" -> MitmproxyEvent.ClientDisconnected(
-            id = dto.id,
+            id = dto.id ?: return null,
             peer = dto.peer,
+            atMillis = dto.startedAtMillis ?: System.currentTimeMillis(),
+        )
+        "addon_hello" -> MitmproxyEvent.AddonHello(
+            sha256 = dto.sha256,
+            version = dto.version,
+            atMillis = dto.startedAtMillis ?: System.currentTimeMillis(),
+        )
+        "events_dropped" -> MitmproxyEvent.EventsDropped(count = dto.count ?: 0L)
+        "addon_error" -> MitmproxyEvent.AddonError(
+            id = dto.id ?: "addon-error",
+            error = dto.error,
             atMillis = dto.startedAtMillis ?: System.currentTimeMillis(),
         )
         else -> null
     }
 }
 
-private fun MitmproxyFlowLineDto.toNetworkExchange(): NetworkExchange {
+private fun MitmproxyFlowLineDto.toNetworkExchange(id: String): NetworkExchange {
     val host = sni ?: url?.removePrefix("https://")?.substringBefore('/') ?: "unknown-host"
     val synthesizedError = when {
         type != "tls_failed" -> error

--- a/src/desktopMain/kotlin/app/andy/desktop/service/proxy/ProxyProcess.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/proxy/ProxyProcess.kt
@@ -49,6 +49,7 @@ class RealProxyProcess(command: List<String>, directory: File, environment: Map<
 }
 
 internal const val MaxNetworkExchanges = 20_000
+internal const val ExchangePublishIntervalMs = 100L
 
 internal fun findMitmdumpExecutable(): String? {
     val pathCandidates = System.getenv("PATH").orEmpty()

--- a/src/desktopMain/resources/proxy/andy_mitm_addon.py
+++ b/src/desktopMain/resources/proxy/andy_mitm_addon.py
@@ -1,27 +1,256 @@
+import asyncio
+import hashlib
 import json
 import os
+import queue
 import re
+import socket
+import sys
+import threading
 import time
 import uuid
 from mitmproxy import http
 
 RULES_PATH = os.environ.get("ANDY_RULES_PATH")
-PREVIEW_LIMIT = 262144
+# Keep previews small: each flow is one JSON line on stdout. Dumping full
+# bodies (256KB+) fills the OS pipe and blocks mitmdump mid-response.
+PREVIEW_LIMIT = 8192
+EVENT_QUEUE_MAX = 2000
+IPV4_CACHE_TTL_SEC = 300
+ADDON_VERSION = 1
+
+_event_queue = queue.Queue(maxsize=EVENT_QUEUE_MAX)
+_dropped_count = 0
+_dropped_lock = threading.Lock()
+_writer_started = False
+_writer_lock = threading.Lock()
+
+_rules_cache = []
+_rules_mtime_ns = None
+
+_ipv4_cache = {}
+_ipv4_cache_lock = threading.Lock()
+
+
+def _addon_sha256():
+    path = os.path.abspath(__file__)
+    try:
+        with open(path, "rb") as handle:
+            return hashlib.sha256(handle.read()).hexdigest()
+    except Exception:
+        return None
+
+
+def _is_ipv4_literal(host):
+    try:
+        socket.inet_pton(socket.AF_INET, host)
+        return True
+    except OSError:
+        return False
+
+
+def _is_ipv6_literal(host):
+    try:
+        socket.inet_pton(socket.AF_INET6, str(host).strip("[]"))
+        return True
+    except OSError:
+        return False
+
+
+def _lookup_hostname(server, host):
+    """Hostname to A-resolve. Prefer SNI when address is already an IP literal."""
+    if host and not _is_ipv4_literal(host) and not _is_ipv6_literal(host):
+        return host
+    for attr in ("sni", "server_name"):
+        value = getattr(server, attr, None)
+        if isinstance(value, str) and value and not _is_ipv4_literal(value) and not _is_ipv6_literal(value):
+            return value
+    return None
+
+
+def _write_stdout_bytes(data):
+    """Best-effort non-blocking write so a slow Andy reader cannot stall mitmdump."""
+    if not data:
+        return True
+    try:
+        fd = sys.stdout.fileno()
+    except Exception:
+        try:
+            sys.stdout.write(data.decode("utf-8", errors="replace"))
+            sys.stdout.flush()
+            return True
+        except Exception:
+            return False
+    try:
+        os.set_blocking(fd, False)
+    except Exception:
+        pass
+    view = memoryview(data)
+    offset = 0
+    idle_spins = 0
+    while offset < len(view):
+        try:
+            written = os.write(fd, view[offset:])
+            if written:
+                offset += written
+                idle_spins = 0
+                continue
+        except BlockingIOError:
+            pass
+        except BrokenPipeError:
+            return False
+        except Exception:
+            return False
+        idle_spins += 1
+        if idle_spins > 40:
+            # Pipe stayed full — drop remaining bytes rather than blocking forever.
+            return False
+        time.sleep(0.001)
+    return True
+
+
+def _writer_loop():
+    global _dropped_count
+    while True:
+        payload = _event_queue.get()
+        if payload is None:
+            break
+        try:
+            line = json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+        except Exception:
+            continue
+        if not _write_stdout_bytes(line):
+            with _dropped_lock:
+                _dropped_count += 1
+            continue
+        with _dropped_lock:
+            dropped = _dropped_count
+            if dropped:
+                _dropped_count = 0
+            else:
+                dropped = 0
+        if dropped:
+            drop_line = (
+                json.dumps({"type": "events_dropped", "count": dropped}, separators=(",", ":")).encode("utf-8")
+                + b"\n"
+            )
+            _write_stdout_bytes(drop_line)
+
+
+def _ensure_writer():
+    global _writer_started
+    with _writer_lock:
+        if _writer_started:
+            return
+        thread = threading.Thread(target=_writer_loop, name="andy-mitm-writer", daemon=True)
+        thread.start()
+        _writer_started = True
+
+
+def _emit_event(payload):
+    global _dropped_count
+    _ensure_writer()
+    # Under backpressure, strip bulky fields before enqueue so hooks stay cheap.
+    if _event_queue.qsize() >= EVENT_QUEUE_MAX // 2:
+        payload = dict(payload)
+        payload["requestBodyPreview"] = None
+        payload["responseBodyPreview"] = None
+        if len(payload.get("requestHeaders") or {}) > 20:
+            payload["requestHeaders"] = {}
+        if len(payload.get("responseHeaders") or {}) > 20:
+            payload["responseHeaders"] = {}
+    try:
+        _event_queue.put_nowait(payload)
+    except queue.Full:
+        with _dropped_lock:
+            _dropped_count += 1
+
+
+def load(loader):
+    _ensure_writer()
+    _emit_event(
+        {
+            "type": "addon_hello",
+            "sha256": _addon_sha256(),
+            "version": ADDON_VERSION,
+            "startedAtMillis": int(time.time() * 1000),
+        }
+    )
+
+
+def _cached_ipv4(host):
+    now = time.time()
+    with _ipv4_cache_lock:
+        entry = _ipv4_cache.get(host)
+        if entry and entry[1] > now:
+            return entry[0]
+        if entry:
+            _ipv4_cache.pop(host, None)
+    return None
+
+
+def _store_ipv4(host, ipv4):
+    with _ipv4_cache_lock:
+        _ipv4_cache[host] = (ipv4, time.time() + IPV4_CACHE_TTL_SEC)
+
+
+async def server_connect(data):
+    # mitmproxy / Happy Eyeballs may dial AAAA first. Some hosts (e.g. NCEI)
+    # publish unreachable IPv6 and hang ~15s, stalling apps that await that
+    # source. Prefer IPv4 — including when address is already an IPv6 literal
+    # (recover the hostname from SNI and remap).
+    try:
+        server = getattr(data, "server", None)
+        address = getattr(server, "address", None) if server is not None else None
+        if not address or len(address) < 2:
+            return
+        host, port = address[0], address[1]
+        if not host or _is_ipv4_literal(host):
+            return
+        lookup_host = _lookup_hostname(server, host)
+        if not lookup_host:
+            return
+        cached = _cached_ipv4(lookup_host)
+        if cached:
+            server.address = (cached, port)
+            return
+        loop = asyncio.get_running_loop()
+        infos = await asyncio.wait_for(
+            loop.getaddrinfo(lookup_host, port, family=socket.AF_INET, type=socket.SOCK_STREAM),
+            timeout=2.0,
+        )
+        if not infos:
+            return
+        ipv4 = infos[0][4][0]
+        _store_ipv4(lookup_host, ipv4)
+        server.address = (ipv4, port)
+    except Exception:
+        return
 
 
 def _load_rules():
+    global _rules_cache, _rules_mtime_ns
     if not RULES_PATH or not os.path.exists(RULES_PATH):
-        return []
+        _rules_cache = []
+        _rules_mtime_ns = None
+        return _rules_cache
     try:
+        mtime_ns = os.stat(RULES_PATH).st_mtime_ns
+        if _rules_mtime_ns == mtime_ns:
+            return _rules_cache
         with open(RULES_PATH, "r", encoding="utf-8") as handle:
-            return json.load(handle).get("rules", [])
+            _rules_cache = json.load(handle).get("rules", [])
+        _rules_mtime_ns = mtime_ns
+        return _rules_cache
     except Exception:
-        return []
+        return _rules_cache if _rules_cache is not None else []
 
 
 def _preview(content):
     if not content:
         return None
+    if isinstance(content, str):
+        return content[:PREVIEW_LIMIT]
     data = content[:PREVIEW_LIMIT]
     try:
         return data.decode("utf-8", errors="replace")
@@ -30,15 +259,18 @@ def _preview(content):
 
 
 def _message_preview(message):
-    if not message or not message.raw_content:
+    if not message:
         return None
+    # Prefer decompressed content so gzip/br responses are readable in Andy.
+    # Skip decompressing huge bodies — that only stalls the response path.
+    raw = getattr(message, "raw_content", None)
+    if raw is not None and len(raw) > 512 * 1024:
+        return f"[body {len(raw)} bytes; preview skipped]"
     try:
-        text = message.get_text(strict=False)
-        if text is not None:
-            return text[:PREVIEW_LIMIT]
+        content = message.content
     except Exception:
-        pass
-    return _preview(message.raw_content)
+        content = raw
+    return _preview(content)
 
 
 def _headers(headers):
@@ -71,10 +303,6 @@ def _match(rule, flow):
     return True
 
 
-def _emit_event(payload):
-    print(json.dumps(payload, separators=(",", ":")), flush=True)
-
-
 def _peer_address(conn):
     peer = getattr(conn, "peername", None)
     if isinstance(peer, (list, tuple)) and peer:
@@ -85,115 +313,158 @@ def _peer_address(conn):
 
 
 def request(flow: http.HTTPFlow):
-    flow.metadata["andy_started_at"] = int(time.time() * 1000)
-    _emit(flow, is_request=True)
+    try:
+        flow.metadata["andy_started_at"] = int(time.time() * 1000)
+        # In-flight marker without bodies — keeps stdout small under parallel fetches.
+        _emit(flow, is_request=True, include_bodies=False)
+    except Exception as e:
+        _emit_event(
+            {
+                "type": "addon_error",
+                "id": getattr(flow, "id", None) or str(uuid.uuid4()),
+                "startedAtMillis": int(time.time() * 1000),
+                "error": f"request hook: {e}",
+            }
+        )
 
 
 def response(flow: http.HTTPFlow):
-    if not flow.response:
-        return
-    matched_rule_id = None
-    error_msg = None
     try:
-        for rule in _load_rules():
-            if not _match(rule, flow):
-                continue
-            matched_rule_id = rule.get("id")
-            print(f"[Proxy addon] Rule matched: {matched_rule_id}")
-            if rule.get("statusCode") is not None:
-                flow.response.status_code = int(rule["statusCode"])
-            for header, value in (rule.get("setHeaders") or {}).items():
-                flow.response.headers[header] = value
-            for header in rule.get("removeHeaders") or []:
-                _remove_header(flow.response.headers, header)
-            if rule.get("responseBody") is not None:
-                # Remove any encoding/length/transfer headers case-insensitively
-                for name in list(flow.response.headers.keys()):
-                    if name.lower() in ("content-encoding", "content-length", "transfer-encoding"):
-                        flow.response.headers.pop(name, None)
-                body = rule["responseBody"]
-                flow.response.content = body.encode("utf-8") if isinstance(body, str) else body
-                print(f"[Proxy addon] Set response content, size: {len(flow.response.content)}")
-            break
+        if not flow.response:
+            return
+        matched_rule_id = None
+        error_msg = None
+        try:
+            for rule in _load_rules():
+                if not _match(rule, flow):
+                    continue
+                matched_rule_id = rule.get("id")
+                if rule.get("statusCode") is not None:
+                    flow.response.status_code = int(rule["statusCode"])
+                for header, value in (rule.get("setHeaders") or {}).items():
+                    flow.response.headers[header] = value
+                for header in rule.get("removeHeaders") or []:
+                    _remove_header(flow.response.headers, header)
+                if rule.get("responseBody") is not None:
+                    for name in list(flow.response.headers.keys()):
+                        if name.lower() in ("content-encoding", "content-length", "transfer-encoding"):
+                            flow.response.headers.pop(name, None)
+                    body = rule["responseBody"]
+                    flow.response.content = body.encode("utf-8") if isinstance(body, str) else body
+                break
+        except Exception as e:
+            error_msg = f"Rule error: {e}"
+        _emit(flow, matched_rule_id, error_msg)
     except Exception as e:
-        error_msg = f"Rule error: {e}"
-        print(f"[Proxy addon] Exception in response: {e}")
-    _emit(flow, matched_rule_id, error_msg)
+        _emit_event(
+            {
+                "type": "addon_error",
+                "id": getattr(flow, "id", None) or str(uuid.uuid4()),
+                "startedAtMillis": int(time.time() * 1000),
+                "error": f"response hook: {e}",
+            }
+        )
 
 
 def error(flow: http.HTTPFlow):
-    _emit(flow, None, str(flow.error) if flow.error else "proxy error")
+    try:
+        _emit(flow, None, str(flow.error) if flow.error else "proxy error")
+    except Exception as e:
+        _emit_event(
+            {
+                "type": "addon_error",
+                "id": getattr(flow, "id", None) or str(uuid.uuid4()),
+                "startedAtMillis": int(time.time() * 1000),
+                "error": f"error hook: {e}",
+            }
+        )
 
 
 def client_connected(client):
-    _emit_event(
-        {
-            "type": "client_connected",
-            "id": getattr(client, "id", None) or str(uuid.uuid4()),
-            "startedAtMillis": int(time.time() * 1000),
-            "peer": _peer_address(client),
-        }
-    )
+    try:
+        _emit_event(
+            {
+                "type": "client_connected",
+                "id": getattr(client, "id", None) or str(uuid.uuid4()),
+                "startedAtMillis": int(time.time() * 1000),
+                "peer": _peer_address(client),
+            }
+        )
+    except Exception:
+        pass
 
 
 def client_disconnected(client):
-    _emit_event(
-        {
-            "type": "client_disconnected",
-            "id": getattr(client, "id", None) or str(uuid.uuid4()),
-            "startedAtMillis": int(time.time() * 1000),
-            "peer": _peer_address(client),
-        }
-    )
+    try:
+        _emit_event(
+            {
+                "type": "client_disconnected",
+                "id": getattr(client, "id", None) or str(uuid.uuid4()),
+                "startedAtMillis": int(time.time() * 1000),
+                "peer": _peer_address(client),
+            }
+        )
+    except Exception:
+        pass
 
 
 def tls_failed_client(data):
-    conn = getattr(data, "conn", None)
-    context = getattr(data, "context", None)
-    server = getattr(context, "server", None) if context is not None else None
-    sni = getattr(conn, "sni", None) if conn is not None else None
-    if not sni and server is not None:
-        address = getattr(server, "address", None)
-        if isinstance(address, (list, tuple)) and address:
-            sni = address[0]
-        elif address:
-            sni = str(address)
-    reason = None
-    if conn is not None:
-        reason = getattr(conn, "error", None)
-    if not reason:
-        reason = "client TLS handshake failed"
-    host = sni or "unknown-host"
-    now = int(time.time() * 1000)
-    flow_id = getattr(conn, "id", None) or str(uuid.uuid4())
-    _emit_event(
-        {
-            "type": "tls_failed",
-            "id": f"tls-failed-{flow_id}",
-            "startedAtMillis": now,
-            "completedAtMillis": now,
-            "durationMillis": 0,
-            "method": "TLS",
-            "url": f"https://{host}/",
-            "statusCode": None,
-            "contentType": None,
-            "sizeBytes": None,
-            "requestHeaders": {},
-            "responseHeaders": {},
-            "requestBodyPreview": None,
-            "responseBodyPreview": None,
-            "error": f"Client rejected Andy's CA for {host}: {reason}",
-            "tlsStatus": "tls",
-            "matchedRuleId": None,
-            "sni": sni,
-            "peer": _peer_address(conn) if conn is not None else None,
-            "reason": str(reason),
-        }
-    )
+    try:
+        conn = getattr(data, "conn", None)
+        context = getattr(data, "context", None)
+        server = getattr(context, "server", None) if context is not None else None
+        sni = getattr(conn, "sni", None) if conn is not None else None
+        if not sni and server is not None:
+            address = getattr(server, "address", None)
+            if isinstance(address, (list, tuple)) and address:
+                sni = address[0]
+            elif address:
+                sni = str(address)
+        reason = None
+        if conn is not None:
+            reason = getattr(conn, "error", None)
+        if not reason:
+            reason = "client TLS handshake failed"
+        host = sni or "unknown-host"
+        now = int(time.time() * 1000)
+        flow_id = getattr(conn, "id", None) or str(uuid.uuid4())
+        _emit_event(
+            {
+                "type": "tls_failed",
+                "id": f"tls-failed-{flow_id}",
+                "startedAtMillis": now,
+                "completedAtMillis": now,
+                "durationMillis": 0,
+                "method": "TLS",
+                "url": f"https://{host}/",
+                "statusCode": None,
+                "contentType": None,
+                "sizeBytes": None,
+                "requestHeaders": {},
+                "responseHeaders": {},
+                "requestBodyPreview": None,
+                "responseBodyPreview": None,
+                "error": f"Client rejected Andy's CA for {host}: {reason}",
+                "tlsStatus": "tls",
+                "matchedRuleId": None,
+                "sni": sni,
+                "peer": _peer_address(conn) if conn is not None else None,
+                "reason": str(reason),
+            }
+        )
+    except Exception as e:
+        _emit_event(
+            {
+                "type": "addon_error",
+                "id": str(uuid.uuid4()),
+                "startedAtMillis": int(time.time() * 1000),
+                "error": f"tls_failed_client hook: {e}",
+            }
+        )
 
 
-def _emit(flow, matched_rule_id=None, error=None, is_request=False):
-    response = flow.response if (hasattr(flow, 'response') and flow.response) else None
+def _emit(flow, matched_rule_id=None, error=None, is_request=False, include_bodies=True):
+    response = flow.response if (hasattr(flow, "response") and flow.response) else None
     started = flow.metadata.get("andy_started_at")
     if started is None:
         started = int(time.time() * 1000)
@@ -206,6 +477,21 @@ def _emit(flow, matched_rule_id=None, error=None, is_request=False):
         completed = int(time.time() * 1000)
         duration = max(0, completed - started)
 
+    size_bytes = None
+    if response is not None:
+        raw = getattr(response, "raw_content", None)
+        if raw is not None:
+            size_bytes = len(raw)
+        else:
+            try:
+                content = response.content
+                size_bytes = len(content) if content is not None else None
+            except Exception:
+                size_bytes = None
+
+    busy = _event_queue.qsize() >= EVENT_QUEUE_MAX // 2
+    include_bodies = include_bodies and not busy
+    include_headers = not busy
     payload = {
         "type": "flow",
         "id": flow.id,
@@ -215,12 +501,12 @@ def _emit(flow, matched_rule_id=None, error=None, is_request=False):
         "method": flow.request.method,
         "url": flow.request.pretty_url,
         "statusCode": response.status_code if response else None,
-        "contentType": response.headers.get("content-type") if response else None,
-        "sizeBytes": len(response.raw_content or b"") if response else None,
-        "requestHeaders": _headers(flow.request.headers),
-        "responseHeaders": _headers(response.headers) if response else {},
-        "requestBodyPreview": _message_preview(flow.request),
-        "responseBodyPreview": _message_preview(response) if response else None,
+        "contentType": response.headers.get("content-type") if response and include_headers else None,
+        "sizeBytes": size_bytes,
+        "requestHeaders": _headers(flow.request.headers) if include_headers else {},
+        "responseHeaders": _headers(response.headers) if response and include_headers else {},
+        "requestBodyPreview": _message_preview(flow.request) if include_bodies and not is_request else None,
+        "responseBodyPreview": _message_preview(response) if include_bodies and response and not is_request else None,
         "error": error,
         "tlsStatus": "tls" if flow.request.scheme == "https" else "plain",
         "matchedRuleId": matched_rule_id,

--- a/src/desktopTest/kotlin/app/andy/HostPathHelpersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/HostPathHelpersTest.kt
@@ -1,0 +1,36 @@
+package app.andy
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HostPathHelpersTest {
+    @Test
+    fun uniqueLocalPathAutoRenamesConflicts() {
+        val dir = File.createTempFile("andy-downloads", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        try {
+            File(dir, "report.txt").writeText("one")
+            val first = uniqueLocalPath(dir.absolutePath, "report.txt")
+            assertEquals(File(dir, "report (1).txt").absolutePath, first)
+            File(first).writeText("two")
+            val second = uniqueLocalPath(dir.absolutePath, "report.txt")
+            assertEquals(File(dir, "report (2).txt").absolutePath, second)
+            assertFalse(File(dir, "report.txt").absolutePath == first)
+            assertTrue(File(dir, "fresh.bin").let { uniqueLocalPath(dir.absolutePath, "fresh.bin") == it.absolutePath })
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun downloadsDirectoryIsWritable() {
+        val path = downloadsDirectory()
+        val dir = File(path)
+        assertTrue(dir.isDirectory || dir.mkdirs())
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/AvdHomeScannerTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/AvdHomeScannerTest.kt
@@ -1,0 +1,138 @@
+package app.andy.desktop.service
+
+import app.andy.model.VirtualDeviceType
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AvdHomeScannerTest {
+    @Test
+    fun listsAvdsFromIniAndConfig() {
+        val root = createTempDir("andy-avd-home")
+        val avdHome = File(root, "avd").also { it.mkdirs() }
+        val pixel = File(avdHome, "Pixel_6.avd").also { it.mkdirs() }
+        File(pixel, "config.ini").writeText(
+            """
+            abi.type=arm64-v8a
+            image.sysdir.1=system-images/android-36/google_apis/arm64-v8a/
+            hw.device.name=pixel_6
+            """.trimIndent(),
+        )
+        File(avdHome, "Pixel_6.ini").writeText(
+            """
+            avd.ini.encoding=UTF-8
+            path=${pixel.absolutePath}
+            target=android-36
+            """.trimIndent(),
+        )
+
+        val avds = AvdHomeScanner.listVirtualDevices(env = mapOf("ANDROID_AVD_HOME" to avdHome.absolutePath))
+
+        assertEquals(1, avds.size)
+        assertEquals("Pixel_6", avds.single().name)
+        assertEquals(pixel.absolutePath, avds.single().path)
+        assertEquals("android-36", avds.single().target)
+        assertEquals("arm64-v8a", avds.single().abi)
+        assertEquals(36, avds.single().apiLevel)
+        assertEquals(VirtualDeviceType.Phone, avds.single().deviceType)
+    }
+
+    @Test
+    fun resolvesAvdHomeFromAndroidUserHome() {
+        val root = createTempDir("andy-user-home")
+        val userHome = File(root, "android-user").also { it.mkdirs() }
+        val avdHome = File(userHome, "avd").also { it.mkdirs() }
+        val pixel = File(avdHome, "Wear_OS.avd").also { it.mkdirs() }
+        File(pixel, "config.ini").writeText("hw.device.name=wear_os_square\n")
+        File(avdHome, "Wear_OS.ini").writeText("path=${pixel.absolutePath}\n")
+
+        val resolved = AvdHomeScanner.avdHome(env = mapOf("ANDROID_USER_HOME" to userHome.absolutePath))
+        val avds = AvdHomeScanner.listVirtualDevices(env = mapOf("ANDROID_USER_HOME" to userHome.absolutePath))
+
+        assertEquals(avdHome.absolutePath, resolved.absolutePath)
+        assertEquals(listOf("Wear_OS"), avds.map { it.name })
+        assertEquals(VirtualDeviceType.Watch, avds.single().deviceType)
+    }
+
+    @Test
+    fun prefersAndroidAvdHomeOverUserHome() {
+        val root = createTempDir("andy-avd-override")
+        val preferred = File(root, "preferred/avd").also { it.mkdirs() }
+        val ignored = File(root, "ignored/avd").also { it.mkdirs() }
+        val pixel = File(preferred, "Preferred.avd").also { it.mkdirs() }
+        File(pixel, "config.ini").writeText("hw.device.name=pixel_8\n")
+        File(preferred, "Preferred.ini").writeText("path=${pixel.absolutePath}\n")
+        File(ignored, "Ignored.ini").writeText("path=${File(ignored, "Ignored.avd").absolutePath}\n")
+
+        val avds = AvdHomeScanner.listVirtualDevices(
+            env = mapOf(
+                "ANDROID_AVD_HOME" to preferred.absolutePath,
+                "ANDROID_USER_HOME" to File(root, "ignored").absolutePath,
+            ),
+        )
+
+        assertEquals(listOf("Preferred"), avds.map { it.name })
+    }
+
+    @Test
+    fun sortsByNameAndSkipsMalformedEntries() {
+        val root = createTempDir("andy-avd-sort")
+        val avdHome = File(root, "avd").also { it.mkdirs() }
+
+        val zebra = File(avdHome, "Zebra.avd").also { it.mkdirs() }
+        File(zebra, "config.ini").writeText("hw.device.name=pixel_9\n")
+        File(avdHome, "Zebra.ini").writeText("path=${zebra.absolutePath}\n")
+
+        val alpha = File(avdHome, "Alpha.avd").also { it.mkdirs() }
+        File(alpha, "config.ini").writeText("hw.device.name=pixel_6\n")
+        File(avdHome, "Alpha.ini").writeText("path=${alpha.absolutePath}\n")
+
+        File(avdHome, "Broken.ini").writeText("path=/definitely/missing/Broken.avd\n")
+        File(avdHome, "Empty.ini").writeText("# no path\n")
+        File(avdHome, "not-an-ini.txt").writeText("ignore me\n")
+
+        val avds = AvdHomeScanner.listVirtualDevices(env = mapOf("ANDROID_AVD_HOME" to avdHome.absolutePath))
+
+        assertEquals(listOf("Alpha", "Zebra"), avds.map { it.name })
+    }
+
+    @Test
+    fun returnsEmptyWhenAvdHomeMissing() {
+        val root = createTempDir("andy-missing-avd")
+        val avds = AvdHomeScanner.listVirtualDevices(
+            env = mapOf("ANDROID_AVD_HOME" to File(root, "missing").absolutePath),
+        )
+        assertTrue(avds.isEmpty())
+    }
+
+    @Test
+    fun usesDefaultUserHomeWhenEnvMissing() {
+        val root = createTempDir("andy-default-home")
+        val avdHome = File(root, ".android/avd").also { it.mkdirs() }
+        val pixel = File(avdHome, "Default.avd").also { it.mkdirs() }
+        File(pixel, "config.ini").writeText(
+            """
+            abi.type=x86_64
+            image.sysdir.1=system-images/android-34/google_apis/x86_64/
+            hw.device.name=pixel_7
+            """.trimIndent(),
+        )
+        File(avdHome, "Default.ini").writeText("path=${pixel.absolutePath}\ntarget=android-34\n")
+
+        val resolved = AvdHomeScanner.avdHome(env = emptyMap(), userHome = root)
+        val avds = AvdHomeScanner.listVirtualDevices(env = emptyMap(), userHome = root)
+
+        assertEquals(avdHome.absolutePath, resolved.absolutePath)
+        assertEquals("Default", avds.single().name)
+        assertEquals(34, avds.single().apiLevel)
+        assertEquals("x86_64", avds.single().abi)
+    }
+
+    private fun createTempDir(prefix: String): File {
+        return File.createTempFile(prefix, null).also {
+            it.delete()
+            it.mkdirs()
+        }
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopProxyServiceTest.kt
@@ -271,6 +271,69 @@ class DesktopProxyServiceTest {
     }
 
     @Test
+    fun addonHelloMismatchAndDroppedEventsPublishWarnings() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val service = DesktopProxyService(
+            env.runner,
+            env.devices,
+            mitmdumpExecutable = { "/usr/bin/mitmdump" },
+            processStarter = { _, _, _ ->
+                MockProxyProcess(
+                    stdoutText = """
+                        {"type":"addon_hello","sha256":"deadbeef","version":1,"startedAtMillis":1}
+                        {"type":"events_dropped","count":7}
+                        {"type":"addon_error","id":"err-1","startedAtMillis":2,"error":"response hook: boom"}
+                        {"type":"flow","id":"flow-1","startedAtMillis":2,"completedAtMillis":3,"durationMillis":1,"method":"GET","url":"https://example.test/","statusCode":200,"contentType":null,"sizeBytes":0,"requestHeaders":{},"responseHeaders":{},"requestBodyPreview":null,"responseBodyPreview":null,"error":null,"tlsStatus":"tls","matchedRuleId":null}
+                    """.trimIndent(),
+                )
+            },
+            hostOsName = { env.hostOsName },
+        )
+
+        assertTrue(service.start(8888, emptyList()).isSuccess)
+        val warnings = withTimeout(2_000) {
+            service.warnings.first { list ->
+                list.any { it.kind == ProxyWarningKind.AddonMismatch } &&
+                    list.any { it.kind == ProxyWarningKind.CaptureDropped } &&
+                    list.any { it.kind == ProxyWarningKind.AddonError }
+            }
+        }
+        assertTrue(warnings.any { it.message.contains("deadbeef") })
+        assertTrue(warnings.any { it.message.contains("7") })
+        assertTrue(warnings.any { it.message.contains("response hook: boom") })
+        withTimeout(2_000) {
+            service.exchanges.first { it.any { exchange -> exchange.id == "flow-1" } }
+        }
+        service.stop()
+        Unit
+    }
+
+    @Test
+    fun exchangePublicationIsThrottledToLatestSnapshot() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val lines = (1..40).joinToString("\n") { index ->
+            """{"type":"flow","id":"flow-$index","startedAtMillis":$index,"completedAtMillis":$index,"durationMillis":0,"method":"GET","url":"https://example.test/$index","statusCode":200,"contentType":null,"sizeBytes":0,"requestHeaders":{},"responseHeaders":{},"requestBodyPreview":null,"responseBodyPreview":null,"error":null,"tlsStatus":"tls","matchedRuleId":null}"""
+        }
+        val service = DesktopProxyService(
+            env.runner,
+            env.devices,
+            mitmdumpExecutable = { "/usr/bin/mitmdump" },
+            processStarter = { _, _, _ -> MockProxyProcess(stdoutText = lines) },
+            hostOsName = { env.hostOsName },
+        )
+
+        assertTrue(service.start(8888, emptyList()).isSuccess)
+        val exchanges = withTimeout(3_000) {
+            service.exchanges.first { it.size >= 40 }
+        }
+        assertEquals(40, exchanges.size)
+        assertEquals("flow-1", exchanges.first().id)
+        assertEquals("flow-40", exchanges.last().id)
+        service.stop()
+        Unit
+    }
+
+    @Test
     fun routeDiagnosticsFlagsDetectedMacCorporateProxy() = runBlocking {
         val env = MockAndroidDeviceEnvironment()
         val services = env.services()

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
@@ -295,6 +295,31 @@ class DesktopServicesMockDeviceTest {
         assertTrue(env.ran("avd", "snapshot", "delete", "manual"))
         assertTrue(env.ran("delete", "avd", "-n", "Pixel_8_API_36"))
         assertTrue(env.ran("-s", "emulator-5554", "emu", "kill"))
+        assertFalse(
+            env.commands.any { command ->
+                command.any { it.contains("avdmanager") } && command.takeLast(2) == listOf("list", "avd")
+            },
+            "listVirtualDevices should discover AVDs from disk without avdmanager",
+        )
+    }
+
+    @Test
+    fun listVirtualDevicesDoesNotInvokeAvdManager() = runBlocking {
+        val env = MockAndroidDeviceEnvironment()
+        val services = env.services()
+
+        val avds = services.avd.listVirtualDevices()
+
+        assertEquals("Pixel_8_API_36", avds.single().name)
+        assertEquals(36, avds.single().apiLevel)
+        assertEquals("arm64-v8a", avds.single().abi)
+        assertTrue(avds.single().running)
+        assertFalse(
+            env.commands.any { command ->
+                command.any { it.contains("avdmanager") } && command.takeLast(2) == listOf("list", "avd")
+            },
+        )
+        assertTrue(env.ran("devices", "-l"))
     }
 
     @Test
@@ -431,6 +456,9 @@ class DesktopServicesMockDeviceTest {
         val cleared = services.apps.clearData("emulator-5554", "com.example.app")
         val reset = services.apps.resetPermissions("emulator-5554", "com.example.app")
         val uninstalled = services.apps.uninstall("emulator-5554", "com.example.app")
+        val installed = services.apps.install("emulator-5554", "/tmp/app.apk")
+        val reinstallConflict = services.apps.install("emulator-5554", "/tmp/app.apk")
+        val reinstalled = services.apps.install("emulator-5554", "/tmp/app.apk", replace = true)
         val permissions = services.apps.listPermissions("emulator-5554", "com.example.app")
         val activities = services.apps.listActivities("emulator-5554", "com.example.app")
 
@@ -474,7 +502,9 @@ class DesktopServicesMockDeviceTest {
         assertEquals(false, apps.first { it.packageName == "com.example.app" }.system)
         assertEquals(false, apps.first { it.packageName == "com.disabled.app" }.enabled)
         assertTrue(apps.first { it.packageName == "com.android.settings" }.system)
-        assertTrue(listOf(launched, stopped, cleared, reset, uninstalled).all { it.isSuccess })
+        assertTrue(listOf(launched, stopped, cleared, reset, uninstalled, installed, reinstalled).all { it.isSuccess })
+        assertFalse(reinstallConflict.isSuccess)
+        assertTrue(reinstallConflict.stderr.contains("INSTALL_FAILED_ALREADY_EXISTS"))
         assertEquals(listOf(true, false), permissions.map { it.granted })
         assertEquals(listOf(".MainActivity", "com.example.app.SettingsActivity"), activities.map { it.name })
 

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MitmAddonSourceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MitmAddonSourceTest.kt
@@ -5,6 +5,7 @@ import java.security.MessageDigest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 /**
  * SHA-256 golden for the mitmproxy addon classpath resource.
@@ -16,19 +17,48 @@ class MitmAddonSourceTest {
     companion object {
         /** SHA-256 of `src/desktopMain/resources/proxy/andy_mitm_addon.py` (runtime source). */
         const val EXPECTED_RESOURCE_SHA256 =
-            "7972e62dc6ba215cd6dd4d4189dd2a5bfafdc5f598c560afc11ce6e5aecafe02"
+            "6b2b7f7b51d032768110169947c9fef8d7174618c0376f5bbba5dc7079e8317e"
     }
 
     @Test
     fun mitmAddonLoaderMatchesGoldenSha256() {
         val bytes = MitmAddon.getAddonSource()
         assertEquals(EXPECTED_RESOURCE_SHA256, sha256Hex(bytes))
+        assertEquals(EXPECTED_RESOURCE_SHA256, MitmAddon.getAddonSourceSha256())
         assertTrue(bytes.isNotEmpty())
         val source = String(bytes, Charsets.UTF_8)
         assertTrue(source.contains("def request("))
         assertTrue(source.contains("def tls_failed_client("))
         assertTrue(source.contains("tls_failed"))
         assertTrue(source.contains("def client_connected("))
+        assertTrue(source.contains("async def server_connect("))
+        assertTrue(source.contains("events_dropped"))
+        assertTrue(source.contains("addon_hello"))
+        assertTrue(source.contains("put_nowait"))
+    }
+
+    @Test
+    fun mitmAddonPassesPythonSyntaxCheckWhenPythonAvailable() {
+        val python = listOf("python3", "python").firstOrNull { candidate ->
+            runCatching {
+                ProcessBuilder(candidate, "--version").redirectErrorStream(true).start().waitFor() == 0
+            }.getOrDefault(false)
+        } ?: return
+        val source = MitmAddon.getAddonSource()
+        val temp = kotlin.io.path.createTempFile("andy-mitm-addon", ".py").toFile()
+        try {
+            temp.writeBytes(source)
+            val process = ProcessBuilder(python, "-m", "py_compile", temp.absolutePath)
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().readText()
+            val code = process.waitFor()
+            if (code != 0) {
+                fail("py_compile failed ($code): $output")
+            }
+        } finally {
+            temp.delete()
+        }
     }
 
     private fun sha256Hex(bytes: ByteArray): String {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/MockAndroidDeviceEnvironment.kt
@@ -59,6 +59,7 @@ internal class MockAndroidDeviceEnvironment {
     var hostIfconfigOutput: String = "lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST>\n"
     var hostOsName: String = "Mac OS X"
     var getpropOverrides: Map<String, String> = emptyMap()
+    val installedPackages: MutableSet<String> = mutableSetOf()
 
     init {
         File(avdHome, "Pixel_8_API_36.avd").apply {
@@ -67,6 +68,7 @@ internal class MockAndroidDeviceEnvironment {
                 """
                 AvdId=Pixel_8_API_36
                 avd.ini.displayname=Pixel_8_API_36
+                abi.type=arm64-v8a
                 image.sysdir.1=system-images/android-36/google_apis/arm64-v8a/
                 hw.device.name=Pixel 8
                 """.trimIndent(),
@@ -86,7 +88,14 @@ internal class MockAndroidDeviceEnvironment {
     fun services(): TestDesktopServices {
         return TestDesktopServices(
             devices = devices,
-            avd = DesktopAvdService(runner, locator) { store.load().selectedSdkPath },
+            avd = DesktopAvdService(
+                runner,
+                locator,
+                listAvdsFromDisk = {
+                    AvdHomeScanner.listVirtualDevices(env = mapOf("ANDROID_AVD_HOME" to avdHome.absolutePath))
+                },
+                resolveAvdHome = { avdHome },
+            ) { store.load().selectedSdkPath },
             mirror = DesktopMirrorEngine(runner, devices),
             logcat = DesktopLogcatService(runner, devices),
             intents = DesktopIntentService(runner, devices),
@@ -199,11 +208,25 @@ internal class MockAndroidDeviceEnvironment {
             command.getOrNull(1) == "-s" && command.getOrNull(3) == "remount" -> remountResult
             command.getOrNull(1) == "-s" && command.getOrNull(3) == "reboot" -> CommandResult.success()
             command.getOrNull(1) == "-s" && command.getOrNull(3) == "uninstall" -> CommandResult.success("Success")
+            command.getOrNull(1) == "-s" && command.getOrNull(3) == "install" -> runInstall(command.drop(4))
             command.getOrNull(1) == "-s" && command.getOrNull(3) == "pull" -> CommandResult.success("1 file pulled")
             command.getOrNull(1) == "-s" && command.getOrNull(3) == "push" -> CommandResult.success("1 file pushed")
             command.getOrNull(1) == "-s" && command.getOrNull(3) == "forward" -> CommandResult.success()
             else -> CommandResult.failure("Unexpected adb command: ${command.joinToString(" ")}")
         }
+    }
+
+    private fun runInstall(args: List<String>): CommandResult {
+        val replace = args.firstOrNull() == "-r"
+        val apkPath = if (replace) args.getOrNull(1) else args.firstOrNull()
+        if (apkPath.isNullOrBlank()) {
+            return CommandResult.failure("No APK path supplied")
+        }
+        if (!replace && installedPackages.contains(apkPath)) {
+            return CommandResult.failure("Failure [INSTALL_FAILED_ALREADY_EXISTS]")
+        }
+        installedPackages.add(apkPath)
+        return CommandResult.success("Success")
     }
 
     private fun runEmu(serial: String, args: List<String>): CommandResult {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/ProxyJsonGoldenTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/ProxyJsonGoldenTest.kt
@@ -129,6 +129,20 @@ class ProxyJsonGoldenTest {
     }
 
     @Test
+    fun parseAddonHelloAndEventsDropped() {
+        val hello = parseMitmproxyEvent(
+            """{"type":"addon_hello","sha256":"abc","version":1,"startedAtMillis":3}""",
+        )
+        assertIs<MitmproxyEvent.AddonHello>(hello)
+        assertEquals("abc", hello.sha256)
+        assertEquals(1, hello.version)
+
+        val dropped = parseMitmproxyEvent("""{"type":"events_dropped","count":12}""")
+        assertIs<MitmproxyEvent.EventsDropped>(dropped)
+        assertEquals(12L, dropped.count)
+    }
+
+    @Test
     fun nonFlowLinesAreIgnored() {
         assertNull(parseMitmproxyFlowLine("""{"type":"status","ok":true}"""))
         assertNull(parseMitmproxyFlowLine("not json"))


### PR DESCRIPTION
## Summary
- Add drag-and-drop and file-picker flows for pushing files to the device, pulling to Downloads, and installing APKs (with replace prompts via `DeviceTransferCoordinator`).
- Surface mitm addon operational issues in network diagnostics (capture drops, version mismatch, addon errors) and harden the Python addon.
- Scan common emulator home paths for AVD discovery when `JAVA_HOME` is unset.

## Test plan
- [x] `./gradlew desktopTest assemble` (macOS)
- [ ] Drag APKs onto Files screen and confirm install/replace flow
- [ ] Push/pull files between host and device
- [ ] Verify network diagnostics show addon warnings under load or version mismatch
- [ ] Confirm AVD list works without `JAVA_HOME` set


Made with [Cursor](https://cursor.com)