### PR TITLE
Address PR #16 review feedback

### DIFF
--- a/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
@@ -102,10 +102,23 @@ internal fun FilesScreen(
 
     fun selectRow(index: Int, file: DeviceFile, meta: Boolean, shift: Boolean) {
         when {
-            shift && anchorIndex != null && anchorIndex!! in rows.indices -> {
-                val from = minOf(anchorIndex!!, index)
-                val to = maxOf(anchorIndex!!, index)
-                selectedPaths = rows.slice(from..to).map { it.path }.toSet()
+            shift -> {
+                val anchor = anchorIndex
+                when {
+                    anchor != null && anchor in rows.indices -> {
+                        val from = minOf(anchor, index)
+                        val to = maxOf(anchor, index)
+                        selectedPaths = rows.slice(from..to).map { it.path }.toSet()
+                    }
+                    meta -> {
+                        selectedPaths = if (file.path in selectedPaths) selectedPaths - file.path else selectedPaths + file.path
+                        anchorIndex = index
+                    }
+                    else -> {
+                        selectedPaths = setOf(file.path)
+                        anchorIndex = index
+                    }
+                }
             }
             meta -> {
                 selectedPaths = if (file.path in selectedPaths) selectedPaths - file.path else selectedPaths + file.path

--- a/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
@@ -102,7 +102,7 @@ internal fun FilesScreen(
 
     fun selectRow(index: Int, file: DeviceFile, meta: Boolean, shift: Boolean) {
         when {
-            shift && anchorIndex != null -> {
+            shift && anchorIndex != null && anchorIndex!! in rows.indices -> {
                 val from = minOf(anchorIndex!!, index)
                 val to = maxOf(anchorIndex!!, index)
                 selectedPaths = rows.slice(from..to).map { it.path }.toSet()

--- a/src/desktopMain/kotlin/app/andy/ExternalFileDrop.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ExternalFileDrop.desktop.kt
@@ -51,7 +51,7 @@ internal fun parseDroppedFilePath(uriString: String): String? {
             uriString
         }
     }.getOrElse {
-        val clean = uriString.removePrefix("file:").removePrefix("///").removePrefix("//")
+        val clean = uriString.removePrefix("file://").removePrefix("file:")
         if (File(clean).exists()) {
             File(clean).absolutePath
         } else {

--- a/src/desktopMain/kotlin/app/andy/ExternalFileDrop.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ExternalFileDrop.desktop.kt
@@ -39,14 +39,23 @@ actual fun Modifier.onExternalFileDrop(
 @OptIn(ExperimentalComposeUiApi::class)
 private fun DragAndDropEvent.filePaths(): List<String> {
     val data = dragData() as? DragData.FilesList ?: return emptyList()
-    return data.readFiles().mapNotNull { uriString ->
-        runCatching {
-            val uri = URI(uriString)
-            if (uri.scheme.equals("file", ignoreCase = true)) {
-                File(uri).absolutePath
-            } else {
-                uriString
-            }
-        }.getOrNull()
+    return data.readFiles().mapNotNull(::parseDroppedFilePath)
+}
+
+internal fun parseDroppedFilePath(uriString: String): String? {
+    return runCatching {
+        val uri = URI(uriString)
+        if (uri.scheme != null && uri.scheme.equals("file", ignoreCase = true)) {
+            File(uri).absolutePath
+        } else {
+            uriString
+        }
+    }.getOrElse {
+        val clean = uriString.removePrefix("file:").removePrefix("///").removePrefix("//")
+        if (File(clean).exists()) {
+            File(clean).absolutePath
+        } else {
+            null
+        }
     }
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/AvdHomeScanner.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/AvdHomeScanner.kt
@@ -73,7 +73,7 @@ object AvdHomeScanner {
             .mapNotNull { line ->
                 val trimmed = line.trim()
                 if (trimmed.isBlank() || trimmed.startsWith("#") || "=" !in trimmed) null
-                else trimmed.substringBefore("=") to trimmed.substringAfter("=")
+                else trimmed.substringBefore("=").trim() to trimmed.substringAfter("=").trim()
             }
             .toMap()
     }

--- a/src/desktopTest/kotlin/app/andy/HostPathHelpersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/HostPathHelpersTest.kt
@@ -30,8 +30,8 @@ class HostPathHelpersTest {
     @Test
     fun parseDroppedFilePathFallsBackForUnescapedSpaces() {
         val file = File.createTempFile("andy drop", ".apk").also { it.deleteOnExit() }
-        val raw = "file:${file.absolutePath}"
-        assertEquals(file.absolutePath, parseDroppedFilePath(raw))
+        assertEquals(file.absolutePath, parseDroppedFilePath("file:${file.absolutePath}"))
+        assertEquals(file.absolutePath, parseDroppedFilePath("file://${file.absolutePath}"))
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/HostPathHelpersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/HostPathHelpersTest.kt
@@ -28,6 +28,13 @@ class HostPathHelpersTest {
     }
 
     @Test
+    fun parseDroppedFilePathFallsBackForUnescapedSpaces() {
+        val file = File.createTempFile("andy drop", ".apk").also { it.deleteOnExit() }
+        val raw = "file:${file.absolutePath}"
+        assertEquals(file.absolutePath, parseDroppedFilePath(raw))
+    }
+
+    @Test
     fun downloadsDirectoryIsWritable() {
         val path = downloadsDirectory()
         val dir = File(path)

--- a/src/desktopTest/kotlin/app/andy/desktop/service/AvdHomeScannerTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/AvdHomeScannerTest.kt
@@ -98,6 +98,20 @@ class AvdHomeScannerTest {
     }
 
     @Test
+    fun parsesIniKeysAndValuesWithSpacesAroundEquals() {
+        val root = createTempDir("andy-avd-spaced-ini")
+        val avdHome = File(root, "avd").also { it.mkdirs() }
+        val pixel = File(avdHome, "Pixel_6.avd").also { it.mkdirs() }
+        File(pixel, "config.ini").writeText("hw.device.name = pixel_6\n")
+        File(avdHome, "Pixel_6.ini").writeText("path = ${pixel.absolutePath}\n")
+
+        val avds = AvdHomeScanner.listVirtualDevices(env = mapOf("ANDROID_AVD_HOME" to avdHome.absolutePath))
+
+        assertEquals(1, avds.size)
+        assertEquals(pixel.absolutePath, avds.single().path)
+    }
+
+    @Test
     fun returnsEmptyWhenAvdHomeMissing() {
         val root = createTempDir("andy-missing-avd")
         val avds = AvdHomeScanner.listVirtualDevices(


### PR DESCRIPTION
## Summary
Follow-up for #16 — addresses gemini-code-assist review that arrived after merge:
- Guard shift-click range selection when `anchorIndex` is stale/out of bounds
- Trim INI keys and values around `=` in `AvdHomeScanner.readIni`
- Fall back to raw `file:` paths when dropped URIs are unescaped (spaces/special chars)

## Test plan
- [x] `./gradlew desktopTest assemble` (macOS)
- [x] `AvdHomeScannerTest.parsesIniKeysAndValuesWithSpacesAroundEquals`
- [x] `HostPathHelpersTest.parseDroppedFilePathFallsBackForUnescapedSpaces`


Made with [Cursor](https://cursor.com)