### PR TITLE
Add a reference image overlay to Design

### DIFF
--- a/src/commonMain/kotlin/app/andy/MirrorVideoSurface.kt
+++ b/src/commonMain/kotlin/app/andy/MirrorVideoSurface.kt
@@ -49,4 +49,6 @@ data class MirrorOverlay(
     val rulerY: Float = 0.5f,
     val pickerColor: Color? = null,
     val pickerHex: String? = null,
+    val referenceImagePath: String? = null,
+    val referenceImageOpacity: Float = 0.5f,
 )

--- a/src/commonMain/kotlin/app/andy/MirrorVideoSurface.kt
+++ b/src/commonMain/kotlin/app/andy/MirrorVideoSurface.kt
@@ -50,5 +50,6 @@ data class MirrorOverlay(
     val pickerColor: Color? = null,
     val pickerHex: String? = null,
     val referenceImagePath: String? = null,
+    val referenceImageKey: Long = 0L,
     val referenceImageOpacity: Float = 0.5f,
 )

--- a/src/commonMain/kotlin/app/andy/ui/design/DesignScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/design/DesignScreen.kt
@@ -189,7 +189,7 @@ internal fun DesignScreen(
                 OutlinedButton(onClick = {
                     scope.launch {
                         val path = pickFiles(allowMultiple = false).firstOrNull() ?: return@launch
-                        val canLoad = withContext(Dispatchers.Default) { loadImageBitmap(path) != null }
+                        val canLoad = withContext(Dispatchers.IO) { loadImageBitmap(path) != null }
                         if (canLoad) {
                             referenceImagePath = path
                             status = "Image overlay: ${path.fileName()}"

--- a/src/commonMain/kotlin/app/andy/ui/design/DesignScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/design/DesignScreen.kt
@@ -18,10 +18,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -36,6 +38,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.andy.model.AndroidDevice
+import app.andy.loadImageBitmap
+import app.andy.pickFiles
 import app.andy.service.AndyServices
 import app.andy.ui.components.FilterPill
 import app.andy.ui.components.FormRow
@@ -57,8 +61,10 @@ import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
 import app.andy.ui.theme.Yellow
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 internal fun DesignScreen(
@@ -81,6 +87,8 @@ internal fun DesignScreen(
     var pickerEnabled by remember { mutableStateOf(false) }
     var pickedColor by remember { mutableStateOf("#------") }
     var pickerToast by remember { mutableStateOf<String?>(null) }
+    var referenceImagePath by remember { mutableStateOf<String?>(null) }
+    var referenceImageOpacity by remember { mutableFloatStateOf(0.5f) }
     var zoom by remember { mutableStateOf("1.0") }
     var localDevicePaneWidth by remember(devicePaneWidth) { mutableStateOf(devicePaneWidth.coerceAtLeast(760f)) }
     val sendMirrorInput = rememberMirrorInputSender(services, serial)
@@ -117,6 +125,8 @@ internal fun DesignScreen(
                 gridColor = color.copy(alpha = 0.38f),
                 pickerColor = color.takeIf { pickerEnabled },
                 pickerHex = pickedColor,
+                referenceImagePath = referenceImagePath,
+                referenceImageOpacity = referenceImageOpacity,
                 zoom = zoom.toFloatOrNull()?.coerceIn(0.5f, 4f) ?: 1f,
                 onHoverColor = { hex ->
                     if (pickerEnabled) pickedColor = hex
@@ -174,6 +184,48 @@ internal fun DesignScreen(
                     }) { Text("+") }
                 }
             }
+            Text("Reference image", color = TextPrimary, fontWeight = FontWeight.Bold)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                OutlinedButton(onClick = {
+                    scope.launch {
+                        val path = pickFiles(allowMultiple = false).firstOrNull() ?: return@launch
+                        val canLoad = withContext(Dispatchers.Default) { loadImageBitmap(path) != null }
+                        if (canLoad) {
+                            referenceImagePath = path
+                            status = "Image overlay: ${path.fileName()}"
+                        } else {
+                            status = "Couldn't load ${path.fileName()} as an image"
+                        }
+                    }
+                }) {
+                    Text(if (referenceImagePath == null) "Upload image" else "Replace image")
+                }
+                if (referenceImagePath != null) {
+                    OutlinedButton(onClick = {
+                        referenceImagePath = null
+                        status = "Image overlay removed"
+                    }) { Text("Remove image") }
+                }
+            }
+            if (referenceImagePath != null) {
+                Text(referenceImagePath.orEmpty().fileName(), color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Opacity", color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp, modifier = Modifier.width(62.dp))
+                    Slider(
+                        value = referenceImageOpacity,
+                        onValueChange = { referenceImageOpacity = it },
+                        valueRange = 0f..1f,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        "${(referenceImageOpacity * 100).toInt()}%",
+                        color = TextSecondary,
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 12.sp,
+                        modifier = Modifier.width(46.dp),
+                    )
+                }
+            }
             Text("Grid color", color = TextPrimary, fontWeight = FontWeight.Bold)
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
                 listOf(Cyan, Rust, Green, Yellow, Red, Color.White).forEach { swatch ->
@@ -228,3 +280,5 @@ private fun Color.toHex(): String {
     val b = (blue * 255).toInt().coerceIn(0, 255)
     return "#%02X%02X%02X".format(r, g, b)
 }
+
+private fun String.fileName(): String = substringAfterLast('/').substringAfterLast('\\')

--- a/src/commonMain/kotlin/app/andy/ui/design/DesignScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/design/DesignScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -88,6 +89,7 @@ internal fun DesignScreen(
     var pickedColor by remember { mutableStateOf("#------") }
     var pickerToast by remember { mutableStateOf<String?>(null) }
     var referenceImagePath by remember { mutableStateOf<String?>(null) }
+    var referenceImageKey by remember { mutableLongStateOf(0L) }
     var referenceImageOpacity by remember { mutableFloatStateOf(0.5f) }
     var zoom by remember { mutableStateOf("1.0") }
     var localDevicePaneWidth by remember(devicePaneWidth) { mutableStateOf(devicePaneWidth.coerceAtLeast(760f)) }
@@ -126,6 +128,7 @@ internal fun DesignScreen(
                 pickerColor = color.takeIf { pickerEnabled },
                 pickerHex = pickedColor,
                 referenceImagePath = referenceImagePath,
+                referenceImageKey = referenceImageKey,
                 referenceImageOpacity = referenceImageOpacity,
                 zoom = zoom.toFloatOrNull()?.coerceIn(0.5f, 4f) ?: 1f,
                 onHoverColor = { hex ->
@@ -192,6 +195,7 @@ internal fun DesignScreen(
                         val canLoad = withContext(Dispatchers.IO) { loadImageBitmap(path) != null }
                         if (canLoad) {
                             referenceImagePath = path
+                            referenceImageKey++
                             status = "Image overlay: ${path.fileName()}"
                         } else {
                             status = "Couldn't load ${path.fileName()} as an image"

--- a/src/commonMain/kotlin/app/andy/ui/live/LiveDevicePane.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/LiveDevicePane.kt
@@ -92,6 +92,8 @@ internal fun LiveDevicePane(
     gridColor: Color = Color.White.copy(alpha = 0.14f),
     pickerColor: Color? = null,
     pickerHex: String? = null,
+    referenceImagePath: String? = null,
+    referenceImageOpacity: Float = 0.5f,
     zoom: Float = 1f,
     showDeviceHeader: Boolean = true,
     showChromeControls: Boolean = true,
@@ -213,6 +215,8 @@ internal fun LiveDevicePane(
                                     rulerY = rulerY,
                                     pickerColor = pickerColor,
                                     pickerHex = pickerHex,
+                                    referenceImagePath = referenceImagePath,
+                                    referenceImageOpacity = referenceImageOpacity,
                                 )
                                 if (frameFlow != null) {
                                     MirrorVideoSurface(

--- a/src/commonMain/kotlin/app/andy/ui/live/LiveDevicePane.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/LiveDevicePane.kt
@@ -93,6 +93,7 @@ internal fun LiveDevicePane(
     pickerColor: Color? = null,
     pickerHex: String? = null,
     referenceImagePath: String? = null,
+    referenceImageKey: Long = 0L,
     referenceImageOpacity: Float = 0.5f,
     zoom: Float = 1f,
     showDeviceHeader: Boolean = true,
@@ -216,6 +217,7 @@ internal fun LiveDevicePane(
                                     pickerColor = pickerColor,
                                     pickerHex = pickerHex,
                                     referenceImagePath = referenceImagePath,
+                                    referenceImageKey = referenceImageKey,
                                     referenceImageOpacity = referenceImageOpacity,
                                 )
                                 if (frameFlow != null) {

--- a/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import app.andy.service.MirrorFrame
 import app.andy.service.MirrorInput
 import app.andy.service.MirrorTouchAction
+import java.awt.AlphaComposite
 import java.awt.Point
 import java.awt.BasicStroke
 import java.awt.Cursor
@@ -24,6 +25,8 @@ import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferInt
 import java.awt.geom.Ellipse2D
+import java.io.File
+import javax.imageio.ImageIO
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import kotlin.math.roundToInt
@@ -100,6 +103,8 @@ private class MirrorPanel : JPanel() {
     private var image: BufferedImage? = null
     private var frameNumber: Long = -1
     private var overlay: MirrorOverlay = MirrorOverlay()
+    private var referenceImagePath: String? = null
+    private var referenceImage: BufferedImage? = null
     var onInput: (MirrorInput) -> Unit = {}
     var onHoverColor: (String) -> Unit = {}
     var onPickerClick: (String) -> Unit = {}
@@ -262,6 +267,12 @@ private class MirrorPanel : JPanel() {
 
     fun setOverlay(next: MirrorOverlay) {
         if (overlay == next) return
+        if (referenceImagePath != next.referenceImagePath) {
+            referenceImagePath = next.referenceImagePath
+            referenceImage = next.referenceImagePath?.let { path ->
+                runCatching { ImageIO.read(File(path)) }.getOrNull()
+            }
+        }
         overlay = next
         repaint()
     }
@@ -300,6 +311,19 @@ private class MirrorPanel : JPanel() {
     }
 
     private fun paintOverlay(g2: Graphics2D, frameImage: BufferedImage, rect: DrawRect) {
+        referenceImage?.let { image ->
+            val imageGraphics = g2.create() as Graphics2D
+            try {
+                imageGraphics.clipRect(rect.x, rect.y, rect.width, rect.height)
+                imageGraphics.composite = AlphaComposite.getInstance(
+                    AlphaComposite.SRC_OVER,
+                    overlay.referenceImageOpacity.coerceIn(0f, 1f),
+                )
+                imageGraphics.drawImage(image, rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0, 0, image.width, image.height, null)
+            } finally {
+                imageGraphics.dispose()
+            }
+        }
         if (overlay.showGrid && overlay.gridSize >= 2f) {
             val color = overlay.gridColor.toAwtColor(alphaOverride = 0.28f)
             g2.color = color

--- a/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
@@ -269,7 +269,7 @@ private class MirrorPanel : JPanel() {
 
     fun setOverlay(next: MirrorOverlay) {
         if (overlay == next) return
-        if (referenceImagePath != next.referenceImagePath) {
+        if (referenceImagePath != next.referenceImagePath || overlay.referenceImageKey != next.referenceImageKey) {
             referenceImagePath = next.referenceImagePath
             val requestId = ++referenceImageRequestId
             val path = next.referenceImagePath

--- a/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
@@ -29,6 +29,7 @@ import java.io.File
 import javax.imageio.ImageIO
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
+import java.util.concurrent.CompletableFuture
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
@@ -105,6 +106,7 @@ private class MirrorPanel : JPanel() {
     private var overlay: MirrorOverlay = MirrorOverlay()
     private var referenceImagePath: String? = null
     private var referenceImage: BufferedImage? = null
+    private var referenceImageRequestId = 0L
     var onInput: (MirrorInput) -> Unit = {}
     var onHoverColor: (String) -> Unit = {}
     var onPickerClick: (String) -> Unit = {}
@@ -269,8 +271,20 @@ private class MirrorPanel : JPanel() {
         if (overlay == next) return
         if (referenceImagePath != next.referenceImagePath) {
             referenceImagePath = next.referenceImagePath
-            referenceImage = next.referenceImagePath?.let { path ->
-                runCatching { ImageIO.read(File(path)) }.getOrNull()
+            val requestId = ++referenceImageRequestId
+            val path = next.referenceImagePath
+            referenceImage = null
+            if (path != null) {
+                CompletableFuture.supplyAsync {
+                    runCatching { ImageIO.read(File(path)) }.getOrNull()
+                }.thenAccept { loadedImage ->
+                    SwingUtilities.invokeLater {
+                        if (referenceImageRequestId == requestId && referenceImagePath == path) {
+                            referenceImage = loadedImage
+                            repaint()
+                        }
+                    }
+                }
             }
         }
         overlay = next


### PR DESCRIPTION
## Summary
- add an image picker, opacity control, and remove action to the Design tab
- render the selected reference image over the live device mirror
- keep grid, ruler, and picker guides above the reference image

## Validation
- `./gradlew desktopTest`

The image overlay is session-only and is scoped to the Design tab.