### PR TITLE
Add Linux Flatpak distribution and in-app update support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,9 @@ jobs:
       - name: Install packaging tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y fakeroot xvfb libgtk-3-0 libxtst6 libxrender1 libxi6 libxrandr2
+          sudo apt-get install -y fakeroot flatpak flatpak-builder xvfb libgtk-3-0 libxtst6 libxrender1 libxi6 libxrandr2
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          sudo flatpak install --noninteractive flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -126,8 +128,33 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build Linux DEB
-        run: xvfb-run -a ./gradlew packageReleaseDeb -Pandy.versionName=${{ needs.version.outputs.version }}
+      - name: Build Linux packages
+        run: >
+          xvfb-run -a ./gradlew
+          packageReleaseDeb
+          createReleaseDistributable
+          -Pandy.versionName=${{ needs.version.outputs.version }}
+
+      - name: Build Linux Flatpak bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-artifacts
+          (
+            cd flatpak
+            flatpak-builder \
+              --force-clean \
+              --repo="${GITHUB_WORKSPACE}/flatpak-repo" \
+              "${GITHUB_WORKSPACE}/flatpak-build" \
+              com.joetr.andy.yml
+          )
+          flatpak build-bundle \
+            flatpak-repo \
+            "release-artifacts/Andy-${VERSION}.flatpak" \
+            com.joetr.andy \
+            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
 
       - name: Collect Linux release artifacts
         shell: bash
@@ -137,6 +164,11 @@ jobs:
           deb="$(find build -name '*.deb' -print -quit)"
           if [[ -z "${deb}" ]]; then
             echo "::error::Could not find Linux DEB release artifact"
+            exit 1
+          fi
+          flatpak_bundle="release-artifacts/Andy-${VERSION}.flatpak"
+          if [[ ! -f "${flatpak_bundle}" ]]; then
+            echo "::error::Could not find Linux Flatpak release artifact"
             exit 1
           fi
           cp "${deb}" "release-artifacts/Andy-${VERSION}.deb"
@@ -466,5 +498,6 @@ jobs:
           generate_release_notes: true
           files: |
             release-artifacts/**/*.deb
+            release-artifacts/**/*.flatpak
             release-artifacts/**/*.msi
             release-artifacts/**/*.dmg

--- a/flatpak/com.joetr.andy.desktop
+++ b/flatpak/com.joetr.andy.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Andy
+Comment=Android emulator and device companion
+Exec=Andy
+Icon=com.joetr.andy
+Terminal=false
+Categories=Development;Utility;
+StartupWMClass=Andy

--- a/flatpak/com.joetr.andy.metainfo.xml
+++ b/flatpak/com.joetr.andy.metainfo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.joetr.andy</id>
+  <name>Andy</name>
+  <summary>Android emulator and device companion</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>Andy is a desktop companion for Android developers that manages devices and emulators, provides live mirroring, and helps inspect and control Android apps.</p>
+  </description>
+  <launchable type="desktop-id">com.joetr.andy.desktop</launchable>
+  <categories>
+    <category>Development</category>
+    <category>Utility</category>
+  </categories>
+  <developer_name>j-roskopf</developer_name>
+</component>

--- a/flatpak/com.joetr.andy.yml
+++ b/flatpak/com.joetr.andy.yml
@@ -1,0 +1,43 @@
+app-id: com.joetr.andy
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: Andy
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  # Compose Desktop uses AWT on Linux. X11 remains necessary on Wayland sessions.
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  # Android devices are connected through USB via adb.
+  - --device=all
+  # Andy reads and writes SDK, AVD, project, and user-selected host files. It also
+  # runs the user's Android SDK tools from their installed location.
+  - --filesystem=host
+  - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.freedesktop.secrets
+
+modules:
+  - name: andy
+    buildsystem: simple
+    build-commands:
+      - install -d /app/bin /app/lib/andy
+      - cp -a andy/. /app/lib/andy/
+      - ln -s /app/lib/andy/bin/Andy /app/bin/Andy
+      - install -Dm644 com.joetr.andy.desktop /app/share/applications/com.joetr.andy.desktop
+      - install -Dm644 com.joetr.andy.metainfo.xml /app/share/metainfo/com.joetr.andy.metainfo.xml
+      - install -Dm644 com.joetr.andy.png /app/share/icons/hicolor/512x512/apps/com.joetr.andy.png
+    sources:
+      - type: dir
+        path: ../build/compose/binaries/main-release/app/Andy
+        dest: andy
+      - type: file
+        path: com.joetr.andy.desktop
+      - type: file
+        path: com.joetr.andy.metainfo.xml
+      - type: file
+        path: ../src/desktopMain/resources/icons/andy.png
+        dest-filename: com.joetr.andy.png

--- a/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
@@ -276,10 +276,11 @@ class DesktopAppUpdateService(
                 exitProcess(0)
             }
             UpdatePlatform.LinuxDeb -> {
-                val helper = helperFile("andy-update.sh")
-                helper.writeText(linuxInstallerHelperScript(file.absolutePath, relaunchCommand))
-                helper.setExecutable(true)
-                ProcessBuilder("/bin/sh", helper.absolutePath).start()
+                launchLinuxInstaller(file, flatpak = false, relaunchCommand = relaunchCommand)
+                exitProcess(0)
+            }
+            UpdatePlatform.LinuxFlatpak -> {
+                launchLinuxInstaller(file, flatpak = true, relaunchCommand = "flatpak run com.joetr.andy")
                 exitProcess(0)
             }
             else -> {
@@ -295,6 +296,56 @@ class DesktopAppUpdateService(
     private fun helperFile(name: String): File =
         File(File(System.getProperty("java.io.tmpdir"), "andy-updates").apply { mkdirs() }, name)
 
+    private fun launchLinuxInstaller(file: File, flatpak: Boolean, relaunchCommand: String?) {
+        val insideFlatpak = !System.getenv("FLATPAK_ID").isNullOrBlank()
+        val installFile = if (insideFlatpak && flatpak) copyFlatpakBundleToHostDownloads(file) else file.absolutePath
+        val helper = helperFile("andy-update.sh")
+        helper.writeText(
+            linuxInstallerHelperScript(
+                filePath = installFile,
+                flatpak = flatpak,
+                insideFlatpak = insideFlatpak,
+                relaunchCommand = relaunchCommand,
+            ),
+        )
+        helper.setExecutable(true)
+        ProcessBuilder("/bin/sh", helper.absolutePath).start()
+    }
+
+    private fun copyFlatpakBundleToHostDownloads(sandboxFile: File): String {
+        val hostFileName = sandboxFile.name.replace(Regex("""[^A-Za-z0-9._-]"""), "_")
+        val hostPath = resolveHostDownloadsPath(hostFileName)
+        val copy = ProcessBuilder(
+            "flatpak-spawn",
+            "--host",
+            "sh",
+            "-c",
+            "cat > ${hostPath.shellQuote()}",
+        )
+            .redirectInput(sandboxFile)
+            .redirectErrorStream(true)
+            .start()
+        check(copy.waitFor() == 0) { "Couldn't copy the Flatpak update to the host Downloads folder." }
+        return hostPath
+    }
+
+    private fun resolveHostDownloadsPath(fileName: String): String {
+        val query = ProcessBuilder(
+            "flatpak-spawn",
+            "--host",
+            "sh",
+            "-c",
+            "printf '%s' \"${'$'}HOME/Downloads/$fileName\"",
+        )
+            .redirectErrorStream(true)
+            .start()
+        val hostPath = query.inputStream.bufferedReader().readText().trim()
+        check(query.waitFor() == 0 && hostPath.isNotBlank()) {
+            "Couldn't resolve the host Downloads path for the Flatpak update."
+        }
+        return hostPath
+    }
+
     private fun progressFraction(downloadedBytes: Long, totalBytes: Long?): Float? =
         totalBytes
             ?.takeIf { it > 0L }
@@ -308,6 +359,7 @@ private fun currentDesktopUpdatePlatform(): UpdatePlatform {
     return when {
         "win" in os -> UpdatePlatform.Windows
         "mac" in os -> UpdatePlatform.MacOs
+        System.getenv("FLATPAK_ID") == "com.joetr.andy" -> UpdatePlatform.LinuxFlatpak
         "linux" in os -> UpdatePlatform.LinuxDeb
         else -> UpdatePlatform.Other
     }
@@ -368,6 +420,7 @@ internal fun selectUpdateAsset(
     return when (platform) {
         UpdatePlatform.MacOs -> firstWithExtension(".dmg", ".pkg")
         UpdatePlatform.Windows -> firstWithExtension(".msi")
+        UpdatePlatform.LinuxFlatpak -> firstWithExtension(".flatpak")
         UpdatePlatform.LinuxDeb -> firstWithExtension(".deb")
         else -> null
     }
@@ -400,16 +453,23 @@ internal fun macPkgInstallerHelperScript(pkgPath: String): String {
 
 internal fun linuxInstallerHelperScript(
     filePath: String,
+    flatpak: Boolean,
+    insideFlatpak: Boolean,
     relaunchCommand: String?,
 ): String {
-    val installCommand = "pkexec sh -c ${(("dpkg -i " + filePath.shellQuote()) + " || apt-get install -f -y").shellQuote()}"
+    val installCommand = if (flatpak) {
+        "flatpak install --user -y ${filePath.shellQuote()} || flatpak install -y ${filePath.shellQuote()}"
+    } else {
+        "pkexec sh -c ${(("dpkg -i " + filePath.shellQuote()) + " || apt-get install -f -y").shellQuote()}"
+    }
     val relaunchBackground = relaunchCommand?.let { command ->
         "(sh -c ${command.shellQuote()} >/dev/null 2>&1 &)"
     } ?: "(sh -c 'andy' >/dev/null 2>&1 &)"
+    val hostPrefix = if (insideFlatpak) "flatpak-spawn --host " else ""
     return """
         #!/bin/sh
         sleep 1
-        sh -c ${(installCommand + " && " + relaunchBackground).shellQuote()}
+        ${hostPrefix}sh -c ${(installCommand + " && " + relaunchBackground).shellQuote()}
     """.trimIndent() + "\n"
 }
 

--- a/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
@@ -1,0 +1,36 @@
+package app.andy.desktop.updates
+
+import app.andy.service.UpdatePlatform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesktopAppUpdateServiceTest {
+    @Test
+    fun selectsFlatpakAssetForFlatpakInstalls() {
+        val asset = selectUpdateAsset(
+            UpdatePlatform.LinuxFlatpak,
+            listOf(
+                GitHubAssetDto("Andy-1.2.3.deb", "https://example.test/andy.deb", state = "uploaded"),
+                GitHubAssetDto("Andy-1.2.3.flatpak", "https://example.test/andy.flatpak", state = "uploaded"),
+            ),
+        )
+
+        assertEquals("Andy-1.2.3.flatpak", asset?.name)
+    }
+
+    @Test
+    fun flatpakInstallerEscapesToHostAndRelaunchesFlatpak() {
+        val script = linuxInstallerHelperScript(
+            filePath = "/home/ada/Downloads/Andy-1.2.3.flatpak",
+            flatpak = true,
+            insideFlatpak = true,
+            relaunchCommand = "flatpak run com.joetr.andy",
+        )
+
+        assertTrue(script.contains("flatpak-spawn --host sh -c"))
+        assertTrue(script.contains("flatpak install --user -y"))
+        assertTrue(script.contains("flatpak install -y"))
+        assertTrue(script.contains("flatpak run com.joetr.andy"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add Flatpak manifest, desktop entry, and metainfo for `com.joetr.andy`
- Extend release CI to build and publish `.flatpak` bundles alongside `.deb` packages
- Teach the desktop updater to detect Flatpak installs, select `.flatpak` release assets, and install updates via `flatpak-spawn` on the host

## Test plan
- [x] `./gradlew desktopTest --tests "app.andy.desktop.updates.DesktopAppUpdateServiceTest"`
- [ ] Verify release workflow builds DEB + Flatpak artifacts on next tag
- [ ] Smoke-test Flatpak install and in-app update on a Linux host


Made with [Cursor](https://cursor.com)