### PR TITLE
Fix macOS notarization for Pty4J helper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -239,74 +239,6 @@ val stripMacReleaseFfmpegExecutables by tasks.registering {
     }
 }
 
-val resignMacReleaseApp by tasks.registering {
-    dependsOn("hardenMacReleasePty4jSpawnHelper")
-
-    val signingIdentity = providers.gradleProperty("compose.desktop.mac.signing.identity")
-    val signingKeychain = providers.gradleProperty("compose.desktop.mac.signing.keychain")
-
-    onlyIf {
-        System.getProperty("os.name").contains("mac", ignoreCase = true) &&
-            !signingIdentity.orNull.isNullOrBlank()
-    }
-
-    doLast {
-        val releaseAppDir = layout.buildDirectory.dir("compose/binaries/main-release/app").get().asFile
-        val apps = releaseAppDir.listFiles { file -> file.isDirectory && file.extension == "app" }.orEmpty()
-        val identity = signingIdentity.get()
-        val keychainArgs = signingKeychain.orNull
-            ?.takeIf { it.isNotBlank() }
-            ?.let { listOf("--keychain", it) }
-            .orEmpty()
-
-        val entitlementsFile = temporaryDir.resolve("entitlements.plist")
-        entitlementsFile.writeText(
-            """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-                <key>com.apple.security.cs.allow-jit</key>
-                <true/>
-                <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-                <true/>
-                <key>com.apple.security.cs.disable-library-validation</key>
-                <true/>
-            </dict>
-            </plist>
-            """.trimIndent()
-        )
-
-        fun runCommand(command: List<String>) {
-            val exitCode = ProcessBuilder(command)
-                .inheritIO()
-                .start()
-                .waitFor()
-            if (exitCode != 0) {
-                error("Command failed with exit code $exitCode: ${command.joinToString(" ")}")
-            }
-        }
-
-        apps.forEach { app ->
-            runCommand(
-                listOf(
-                    "codesign",
-                    "--force",
-                    "--deep",
-                    "--options",
-                    "runtime",
-                    "--entitlements",
-                    entitlementsFile.absolutePath,
-                    "--timestamp",
-                    "--sign",
-                    identity,
-                ) + keychainArgs + app.absolutePath
-            )
-            runCommand(listOf("codesign", "--verify", "--deep", "--strict", "--verbose=2", app.absolutePath))
-        }
-    }
-}
-
 val hardenMacReleasePty4jSpawnHelper by tasks.registering {
     dependsOn(stripMacReleaseFfmpegExecutables)
 
@@ -370,6 +302,74 @@ val hardenMacReleasePty4jSpawnHelper by tasks.registering {
             runCommand(listOf("zip", "-qry", replacement.absolutePath, "."), extractionDir)
             replacement.copyTo(jarFile, overwrite = true)
             logger.lifecycle("Signed the hardened-runtime Pty4J spawn helper in ${jarFile.name}")
+        }
+    }
+}
+
+val resignMacReleaseApp by tasks.registering {
+    dependsOn(hardenMacReleasePty4jSpawnHelper)
+
+    val signingIdentity = providers.gradleProperty("compose.desktop.mac.signing.identity")
+    val signingKeychain = providers.gradleProperty("compose.desktop.mac.signing.keychain")
+
+    onlyIf {
+        System.getProperty("os.name").contains("mac", ignoreCase = true) &&
+            !signingIdentity.orNull.isNullOrBlank()
+    }
+
+    doLast {
+        val releaseAppDir = layout.buildDirectory.dir("compose/binaries/main-release/app").get().asFile
+        val apps = releaseAppDir.listFiles { file -> file.isDirectory && file.extension == "app" }.orEmpty()
+        val identity = signingIdentity.get()
+        val keychainArgs = signingKeychain.orNull
+            ?.takeIf { it.isNotBlank() }
+            ?.let { listOf("--keychain", it) }
+            .orEmpty()
+
+        val entitlementsFile = temporaryDir.resolve("entitlements.plist")
+        entitlementsFile.writeText(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>com.apple.security.cs.allow-jit</key>
+                <true/>
+                <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+                <true/>
+                <key>com.apple.security.cs.disable-library-validation</key>
+                <true/>
+            </dict>
+            </plist>
+            """.trimIndent()
+        )
+
+        fun runCommand(command: List<String>) {
+            val exitCode = ProcessBuilder(command)
+                .inheritIO()
+                .start()
+                .waitFor()
+            if (exitCode != 0) {
+                error("Command failed with exit code $exitCode: ${command.joinToString(" ")}")
+            }
+        }
+
+        apps.forEach { app ->
+            runCommand(
+                listOf(
+                    "codesign",
+                    "--force",
+                    "--deep",
+                    "--options",
+                    "runtime",
+                    "--entitlements",
+                    entitlementsFile.absolutePath,
+                    "--timestamp",
+                    "--sign",
+                    identity,
+                ) + keychainArgs + app.absolutePath
+            )
+            runCommand(listOf("codesign", "--verify", "--deep", "--strict", "--verbose=2", app.absolutePath))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -240,7 +240,7 @@ val stripMacReleaseFfmpegExecutables by tasks.registering {
 }
 
 val resignMacReleaseApp by tasks.registering {
-    dependsOn(stripMacReleaseFfmpegExecutables)
+    dependsOn("hardenMacReleasePty4jSpawnHelper")
 
     val signingIdentity = providers.gradleProperty("compose.desktop.mac.signing.identity")
     val signingKeychain = providers.gradleProperty("compose.desktop.mac.signing.keychain")
@@ -303,6 +303,73 @@ val resignMacReleaseApp by tasks.registering {
                 ) + keychainArgs + app.absolutePath
             )
             runCommand(listOf("codesign", "--verify", "--deep", "--strict", "--verbose=2", app.absolutePath))
+        }
+    }
+}
+
+val hardenMacReleasePty4jSpawnHelper by tasks.registering {
+    dependsOn(stripMacReleaseFfmpegExecutables)
+
+    val signingIdentity = providers.gradleProperty("compose.desktop.mac.signing.identity")
+    val signingKeychain = providers.gradleProperty("compose.desktop.mac.signing.keychain")
+
+    onlyIf {
+        System.getProperty("os.name").contains("mac", ignoreCase = true) &&
+            !signingIdentity.orNull.isNullOrBlank()
+    }
+
+    doLast {
+        val releaseAppDir = layout.buildDirectory.dir("compose/binaries/main-release/app").get().asFile
+        val pty4jJars = fileTree(releaseAppDir) {
+            include("**/Contents/app/pty4j-*.jar")
+        }.files
+        val identity = signingIdentity.get()
+        val keychainArgs = signingKeychain.orNull
+            ?.takeIf { it.isNotBlank() }
+            ?.let { listOf("--keychain", it) }
+            .orEmpty()
+        val helperEntry = "resources/com/pty4j/native/darwin/pty4j-unix-spawn-helper"
+
+        fun runCommand(command: List<String>, workingDirectory: File? = null) {
+            val builder = ProcessBuilder(command).inheritIO()
+            workingDirectory?.let(builder::directory)
+            val exitCode = builder.start().waitFor()
+            if (exitCode != 0) {
+                error("Command failed with exit code $exitCode: ${command.joinToString(" ")}")
+            }
+        }
+
+        pty4jJars.forEach { jarFile ->
+            ZipFile(jarFile).use { source ->
+                if (source.getEntry(helperEntry) == null) return@forEach
+            }
+
+            val extractionDir = temporaryDir.resolve(jarFile.nameWithoutExtension).apply {
+                deleteRecursively()
+                mkdirs()
+            }
+            val replacement = temporaryDir.resolve("${jarFile.name}.signed")
+            replacement.delete()
+
+            runCommand(listOf("unzip", "-q", jarFile.absolutePath, "-d", extractionDir.absolutePath))
+            val helper = extractionDir.resolve(helperEntry)
+            check(helper.isFile) { "Could not extract $helperEntry from ${jarFile.name}" }
+            helper.setExecutable(true)
+            runCommand(
+                listOf(
+                    "codesign",
+                    "--force",
+                    "--options",
+                    "runtime",
+                    "--timestamp",
+                    "--sign",
+                    identity,
+                ) + keychainArgs + helper.absolutePath
+            )
+            runCommand(listOf("codesign", "--verify", "--strict", "--verbose=2", helper.absolutePath))
+            runCommand(listOf("zip", "-qry", replacement.absolutePath, "."), extractionDir)
+            replacement.copyTo(jarFile, overwrite = true)
+            logger.lifecycle("Signed the hardened-runtime Pty4J spawn helper in ${jarFile.name}")
         }
     }
 }


### PR DESCRIPTION
## Summary
- sign the embedded Pty4J Unix spawn helper with hardened runtime before rebuilding its JAR
- preserve the existing FFmpeg cleanup and re-sign the enclosing app before DMG packaging

## Root cause
Apple rejected the macOS DMG because `pty4j-unix-spawn-helper` is an executable embedded in a JAR without hardened runtime.

## Verification
- `./gradlew clean packageReleaseDmg -Pandy.versionName=2026.0713.1324 -Pcompose.desktop.mac.signing.identity=...`
- strict `codesign` verification for the embedded helper and final app
- `git diff --check`