### PR TITLE
Enhance agent task workflows

### DIFF
--- a/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -15,6 +15,69 @@ enum class AgentAutonomy(val label: String) {
 }
 
 /**
+ * A provider-specific execution safety choice, kept separate from the cross-provider autonomy dial.
+ * Each adapter maps the value to the most precise sandbox or permission control its CLI offers.
+ */
+enum class AgentSandboxMode(val label: String) {
+    ReadOnly("read-only"),
+    WorkspaceWrite("workspace write"),
+    None("no sandbox"),
+}
+
+fun AgentAutonomy.defaultSandboxMode(): AgentSandboxMode = when (this) {
+    AgentAutonomy.ReadOnly -> AgentSandboxMode.ReadOnly
+    AgentAutonomy.Standard -> AgentSandboxMode.WorkspaceWrite
+    AgentAutonomy.Full -> AgentSandboxMode.None
+}
+
+fun AgentKind.sandboxControlLabel(): String = when (this) {
+    AgentKind.Codex, AgentKind.Cursor -> "sandbox"
+    AgentKind.ClaudeCode, AgentKind.Antigravity -> "permissions"
+}
+
+fun AgentSandboxMode.labelFor(agent: AgentKind): String = when (agent) {
+    AgentKind.Codex -> label
+    AgentKind.ClaudeCode -> when (this) {
+        AgentSandboxMode.ReadOnly -> "plan"
+        AgentSandboxMode.WorkspaceWrite -> "accept edits"
+        AgentSandboxMode.None -> "skip permissions"
+    }
+    AgentKind.Cursor -> when (this) {
+        AgentSandboxMode.ReadOnly -> "plan + sandbox"
+        AgentSandboxMode.WorkspaceWrite -> "sandbox enabled"
+        AgentSandboxMode.None -> "sandbox disabled"
+    }
+    AgentKind.Antigravity -> when (this) {
+        AgentSandboxMode.ReadOnly -> "plan + sandbox"
+        AgentSandboxMode.WorkspaceWrite -> "accept edits"
+        AgentSandboxMode.None -> "skip permissions"
+    }
+}
+
+fun AgentSandboxMode.descriptionFor(agent: AgentKind): String = when (agent) {
+    AgentKind.Codex -> when (this) {
+        AgentSandboxMode.ReadOnly -> "Codex can inspect files but cannot modify the workspace."
+        AgentSandboxMode.WorkspaceWrite -> "Codex can edit the workspace, but network access remains sandboxed."
+        AgentSandboxMode.None -> "No sandbox: Codex can use your host permissions, including network tools such as GitHub."
+    }
+    AgentKind.ClaudeCode -> when (this) {
+        AgentSandboxMode.ReadOnly -> "Claude Code runs in plan mode."
+        AgentSandboxMode.WorkspaceWrite -> "Claude Code accepts edits while retaining permission checks."
+        AgentSandboxMode.None -> "Claude Code has no filesystem sandbox flag; this skips its permission checks."
+    }
+    AgentKind.Cursor -> when (this) {
+        AgentSandboxMode.ReadOnly -> "Cursor runs in plan mode with its sandbox enabled."
+        AgentSandboxMode.WorkspaceWrite -> "Cursor's CLI sandbox is explicitly enabled."
+        AgentSandboxMode.None -> "Cursor's CLI sandbox is explicitly disabled."
+    }
+    AgentKind.Antigravity -> when (this) {
+        AgentSandboxMode.ReadOnly -> "Antigravity runs in plan mode with terminal sandboxing enabled."
+        AgentSandboxMode.WorkspaceWrite -> "Antigravity accepts edits without its plan-mode sandbox."
+        AgentSandboxMode.None -> "Antigravity skips its permission checks."
+    }
+}
+
+/**
  * The effort requested from a provider. Not every provider supports every value;
  * [AgentModelCatalog] exposes only the combinations documented for its CLI.
  */
@@ -85,6 +148,13 @@ enum class AgentTaskStatus {
     Unknown,
 }
 
+/** A follow-up held until the agent's current response completes. */
+data class AgentQueuedFollowUp(
+    val text: String,
+    val imagePaths: List<String> = emptyList(),
+    val skills: List<AgentSkill> = emptyList(),
+)
+
 data class AgentTask(
     val id: String,
     val title: String,
@@ -100,6 +170,8 @@ data class AgentTask(
     val branchName: String? = null,
     val attachAndyMcp: Boolean = false,
     val autonomy: AgentAutonomy = AgentAutonomy.Standard,
+    /** Explicit provider sandbox/permission choice. Null preserves the legacy mapping from [autonomy]. */
+    val sandboxMode: AgentSandboxMode? = null,
     /** Null keeps the provider's own default model. */
     val model: String? = null,
     /** Null keeps the provider's own default reasoning level. */
@@ -110,6 +182,10 @@ data class AgentTask(
     val imagePaths: List<String> = emptyList(),
     /** Local skills selected while composing the original prompt. */
     val skills: List<AgentSkill> = emptyList(),
+    /** A durable objective Andy keeps alongside the provider session. */
+    val goal: String? = null,
+    /** Follow-ups to send in order after this task's current successful run completes. */
+    val queuedFollowUps: List<AgentQueuedFollowUp> = emptyList(),
     val maxBudgetUsd: Double? = null,
     /** Files already changed when the task began; excluded from its change summary. */
     val changeBaselinePaths: List<String> = emptyList(),
@@ -231,11 +307,13 @@ data class AgentTaskDraft(
     val useWorktree: Boolean = false,
     val attachAndyMcp: Boolean = false,
     val autonomy: AgentAutonomy = AgentAutonomy.Standard,
+    val sandboxMode: AgentSandboxMode? = null,
     val model: String? = null,
     val reasoningEffort: AgentReasoningEffort? = null,
     val fastMode: Boolean = false,
     val imagePaths: List<String> = emptyList(),
     val skills: List<AgentSkill> = emptyList(),
+    val goal: String? = null,
     val maxBudgetUsd: Double? = null,
 )
 
@@ -245,6 +323,7 @@ data class AgentProviderDefaults(
     val reasoningEffort: AgentReasoningEffort? = null,
     val fastMode: Boolean = false,
     val autonomy: AgentAutonomy = AgentAutonomy.Standard,
+    val sandboxMode: AgentSandboxMode? = null,
     val useWorktree: Boolean = false,
     val attachAndyMcp: Boolean = false,
     val maxBudgetUsd: Double? = null,
@@ -257,6 +336,52 @@ data class AgentSkill(
     /** Absolute path to the skill's SKILL.md, so the agent and chat link use the same source. */
     val path: String,
 )
+
+/** A command implemented by Andy rather than forwarded as literal prompt text to a provider CLI. */
+data class AgentNativeSlashCommand(
+    val name: String,
+    val description: String,
+)
+
+/**
+ * Interactive CLI slash commands are not available to the non-interactive
+ * provider runners Andy uses. Keep this list deliberately limited to commands
+ * Andy implements with equivalent, persisted behavior.
+ */
+object AgentNativeSlashCommands {
+    fun forAgent(agent: AgentKind): List<AgentNativeSlashCommand> = when (agent) {
+        AgentKind.Codex, AgentKind.ClaudeCode -> listOf(
+            AgentNativeSlashCommand("goal", "set or clear this task's persistent goal"),
+        )
+        else -> emptyList()
+    }
+
+    fun supportsGoal(agent: AgentKind): Boolean = agent == AgentKind.Codex || agent == AgentKind.ClaudeCode
+}
+
+enum class AgentGoalCommandAction { Set, Clear }
+
+data class AgentGoalCommand(
+    val action: AgentGoalCommandAction,
+    val goal: String? = null,
+    /** Any prompt text after the first command line. */
+    val remainingPrompt: String = "",
+)
+
+/** Parses Andy's native `/goal <objective>` and `/goal clear` syntax. */
+fun String.parseAgentGoalCommand(): AgentGoalCommand? {
+    val lines = trim().lines()
+    val firstLine = lines.firstOrNull()?.trim().orEmpty()
+    if (!firstLine.startsWith("/goal") || (firstLine.length > 5 && !firstLine[5].isWhitespace())) return null
+    val argument = firstLine.removePrefix("/goal").trim()
+    return if (argument.equals("clear", ignoreCase = true)) {
+        AgentGoalCommand(AgentGoalCommandAction.Clear, remainingPrompt = lines.drop(1).joinToString("\n").trim())
+    } else {
+        argument.takeIf { it.isNotBlank() }?.let { goal ->
+            AgentGoalCommand(AgentGoalCommandAction.Set, goal, lines.drop(1).joinToString("\n").trim())
+        }
+    }
+}
 
 data class AgentFileChange(
     val path: String,
@@ -292,6 +417,7 @@ fun AgentTaskDraft.providerDefaults(): AgentProviderDefaults = AgentProviderDefa
     reasoningEffort = reasoningEffort,
     fastMode = fastMode,
     autonomy = autonomy,
+    sandboxMode = sandboxMode,
     useWorktree = useWorktree,
     attachAndyMcp = attachAndyMcp,
     maxBudgetUsd = maxBudgetUsd,
@@ -302,6 +428,7 @@ fun AgentTask.providerDefaults(): AgentProviderDefaults = AgentProviderDefaults(
     reasoningEffort = reasoningEffort,
     fastMode = fastMode,
     autonomy = autonomy,
+    sandboxMode = sandboxMode,
     useWorktree = useWorktree,
     attachAndyMcp = attachAndyMcp,
     maxBudgetUsd = maxBudgetUsd,
@@ -352,7 +479,12 @@ fun promptWithSkillHints(text: String, skills: List<AgentSkill>): String = if (s
     }.trimEnd()
 }
 
-fun AgentTask.promptForCli(): String = promptWithImageHints(promptWithSkillHints(prompt, skills), imagePaths)
+/** Keeps an Andy-native goal visible to each provider without relying on TUI-only slash parsing. */
+fun promptWithGoalHint(text: String, goal: String?): String = goal?.takeIf { it.isNotBlank() }?.let { activeGoal ->
+    "$text\n\nPersistent task goal: $activeGoal\nKeep this goal in mind throughout the task."
+} ?: text
+
+fun AgentTask.promptForCli(): String = promptWithImageHints(promptWithGoalHint(promptWithSkillHints(prompt, skills), goal), imagePaths)
 
 private data class TokenPrice(val inputUsdPerMillion: Double, val outputUsdPerMillion: Double)
 
@@ -436,6 +568,21 @@ data class AgentCliStatus(
     val kind: AgentKind,
     val binaryPath: String? = null,
     val version: String? = null,
+    /** A setup issue detected before starting a task, phrased for the Agents UI. */
+    val issue: AgentCliIssue? = null,
 ) {
     val available: Boolean get() = binaryPath != null
+    /** Whether Andy can safely start a task with this CLI. */
+    val ready: Boolean get() = available && issue?.blocksTasks != true
 }
+
+/**
+ * An actionable local-installation problem. This deliberately holds user-facing
+ * copy instead of leaking a provider process error into a task transcript.
+ */
+data class AgentCliIssue(
+    val title: String,
+    val detail: String,
+    val repairCommand: String? = null,
+    val blocksTasks: Boolean = false,
+)

--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -188,6 +188,17 @@ interface AgentRunService {
         imagePaths: List<String> = emptyList(),
         skills: List<AgentSkill> = emptyList(),
     )
+    /** Holds a follow-up until the active run completes successfully. */
+    fun queueFollowUp(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String> = emptyList(),
+        skills: List<AgentSkill> = emptyList(),
+    )
+    /** Removes an unsent follow-up at [queueIndex]. */
+    fun removeQueuedFollowUp(taskId: String, queueIndex: Int)
+    /** Updates Andy's persisted task goal; providers receive it with subsequent prompts. */
+    fun updateGoal(taskId: String, goal: String?)
     suspend fun delete(taskId: String, removeWorktree: Boolean)
     /** Clears the unread indicator for a finished chat (e.g. when opened). */
     fun markRead(taskId: String)

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
@@ -244,7 +244,9 @@ private class AgentTaskComposerFormState(
         reasoningEffort = defaults?.reasoningEffort
         fastMode = defaults?.fastMode == true
         autonomy = defaults?.autonomy ?: AgentAutonomy.Standard
-        sandboxMode = defaults?.sandboxMode ?: autonomy.defaultSandboxMode()
+        // Leave the sandbox unset unless it was explicitly saved. This lets the
+        // provider derive it from whichever autonomy level the user chooses.
+        sandboxMode = defaults?.sandboxMode
         useWorktree = defaults?.useWorktree == true
         attachMcp = defaults?.attachAndyMcp == true
         budgetText = defaults?.maxBudgetUsd?.toString().orEmpty()

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
@@ -56,12 +56,21 @@ import app.andy.model.AgentCliStatus
 import app.andy.model.AgentKind
 import app.andy.model.AgentModelCatalog
 import app.andy.model.AgentModelOption
+import app.andy.model.AgentNativeSlashCommand
+import app.andy.model.AgentNativeSlashCommands
 import app.andy.model.AgentProviderDefaults
 import app.andy.model.AgentReasoningEffort
+import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentSkill
 import app.andy.model.AgentTaskDraft
+import app.andy.model.defaultSandboxMode
+import app.andy.model.descriptionFor
+import app.andy.model.labelFor
+import app.andy.model.parseAgentGoalCommand
+import app.andy.model.sandboxControlLabel
 import app.andy.onImageFilesDropped
 import app.andy.pickDirectory
+import app.andy.rememberCopyText
 import app.andy.service.AndyServices
 import app.andy.ui.components.Button
 import app.andy.ui.components.FilterPill
@@ -94,6 +103,8 @@ internal fun AgentTaskComposerPane(
     modifier: Modifier = Modifier,
 ) {
     val form = rememberAgentTaskComposerForm(services, cliStatuses, projectContext)
+    val copyText = rememberCopyText()
+    val scope = rememberCoroutineScope()
     var showOptions by remember(projectContext?.id) { mutableStateOf(false) }
     Column(modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
         if (showOptions) {
@@ -133,6 +144,11 @@ internal fun AgentTaskComposerPane(
                 }
             }
         }
+        AgentCliIssueNotices(
+            statuses = cliStatuses,
+            onCopyRepairCommand = copyText,
+            onRefresh = { scope.launch { services.agentRuns.refreshCliStatuses() } },
+        )
         AgentChatComposer(
             form = form,
             showOptions = showOptions,
@@ -143,6 +159,43 @@ internal fun AgentTaskComposerPane(
                 form.clearPrompt()
             },
         )
+    }
+}
+
+@Composable
+private fun AgentCliIssueNotices(
+    statuses: List<AgentCliStatus>,
+    onCopyRepairCommand: (String) -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        statuses.mapNotNull { status -> status.issue?.let { status to it } }.forEach { (status, issue) ->
+            Column(
+                Modifier.fillMaxWidth()
+                    .background(AndyColors.OrangeSubtle, RoundedCornerShape(AndyRadius.R3))
+                    .border(1.dp, AndyColors.OrangeBorder.copy(alpha = 0.65f), RoundedCornerShape(AndyRadius.R3))
+                    .padding(10.dp),
+                verticalArrangement = Arrangement.spacedBy(5.dp),
+            ) {
+                Text(
+                    "${status.kind.label}: ${issue.title}",
+                    color = TextPrimary,
+                    fontFamily = DisplayFont,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 12.sp,
+                )
+                Text(issue.detail, color = TextSecondary, fontFamily = MonoFont, fontSize = 10.sp)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    issue.repairCommand?.let { command ->
+                        OutlinedButton(onClick = { onCopyRepairCommand(command) }) {
+                            Text("copy repair command", fontSize = 10.sp)
+                        }
+                    }
+                    OutlinedButton(onClick = onRefresh) { Text("refresh check", fontSize = 10.sp) }
+                }
+            }
+        }
     }
 }
 
@@ -160,6 +213,7 @@ private class AgentTaskComposerFormState(
     var useWorktree by mutableStateOf(false)
     var attachMcp by mutableStateOf(false)
     var autonomy by mutableStateOf(AgentAutonomy.Standard)
+    var sandboxMode by mutableStateOf<AgentSandboxMode?>(null)
     var modelId by mutableStateOf<String?>(null)
     var customModel by mutableStateOf("")
     var reasoningEffort by mutableStateOf<AgentReasoningEffort?>(null)
@@ -190,6 +244,7 @@ private class AgentTaskComposerFormState(
         reasoningEffort = defaults?.reasoningEffort
         fastMode = defaults?.fastMode == true
         autonomy = defaults?.autonomy ?: AgentAutonomy.Standard
+        sandboxMode = defaults?.sandboxMode ?: autonomy.defaultSandboxMode()
         useWorktree = defaults?.useWorktree == true
         attachMcp = defaults?.attachAndyMcp == true
         budgetText = defaults?.maxBudgetUsd?.toString().orEmpty()
@@ -216,10 +271,16 @@ private fun rememberAgentTaskComposerForm(
     val availableSkills by remember(state.agent, directory) {
         services.agentRuns.skills(state.agent, directory)
     }.collectAsState()
-    val selectedCliAvailable = cliStatuses.any { it.kind == state.agent && it.available }
+    val selectedCliAvailable = cliStatuses.any { it.kind == state.agent && it.ready }
     val showModelSection = state.providerChosenInComposer && selectedCliAvailable
     val selectedModel = AgentModelCatalog.option(state.agent, state.modelId)
     val slashCommand = findComposerSlashCommand(state.prompt)
+    val matchingCommands = slashCommand?.let { command ->
+        AgentNativeSlashCommands.forAgent(state.agent).filter { nativeCommand ->
+            nativeCommand.name.contains(command.query, ignoreCase = true) ||
+                nativeCommand.description.contains(command.query, ignoreCase = true)
+        }
+    }.orEmpty()
     val matchingSkills = slashCommand?.let { command ->
         availableSkills.filter { skill ->
             skill.name.contains(command.query, ignoreCase = true) ||
@@ -233,18 +294,18 @@ private fun rememberAgentTaskComposerForm(
     val canSubmit = state.prompt.isNotBlank() &&
         (!state.usesCustomModel || state.customModel.isNotBlank()) &&
         (state.budgetText.isBlank() || validBudget != null) &&
-        cliStatuses.any { it.kind == state.agent && it.available }
+        cliStatuses.any { it.kind == state.agent && it.ready }
 
     LaunchedEffect(lastUsedAgent, cliStatuses, projectKey) {
         if (!state.providerChosenInComposer) {
             val preferred = lastUsedAgent?.takeIf { preferred ->
-                cliStatuses.any { it.kind == preferred && it.available }
+                cliStatuses.any { it.kind == preferred && it.ready }
             }
             if (preferred != null) {
                 state.agent = preferred
                 state.providerChosenInComposer = true
             } else {
-                state.agent = cliStatuses.firstOrNull { it.available }?.kind ?: AgentKind.ClaudeCode
+                state.agent = cliStatuses.firstOrNull { it.ready }?.kind ?: AgentKind.ClaudeCode
             }
         }
     }
@@ -279,6 +340,7 @@ private fun rememberAgentTaskComposerForm(
         showModelSection = showModelSection,
         selectedModel = selectedModel,
         slashCommand = slashCommand,
+        matchingCommands = matchingCommands,
         matchingSkills = matchingSkills,
         selectedSkills = selectedSkills,
         canSubmit = canSubmit,
@@ -295,6 +357,7 @@ private class AgentTaskComposerForm(
     val showModelSection: Boolean,
     val selectedModel: AgentModelOption?,
     val slashCommand: ComposerSlashCommand?,
+    val matchingCommands: List<AgentNativeSlashCommand>,
     val matchingSkills: List<AgentSkill>,
     val selectedSkills: List<AgentSkill>,
     val canSubmit: Boolean,
@@ -302,22 +365,27 @@ private class AgentTaskComposerForm(
 ) {
     fun clearPrompt() = state.clearPrompt()
 
-    fun buildDraft(): AgentTaskDraft = AgentTaskDraft(
-        title = "",
-        prompt = state.prompt.trim(),
-        agent = state.agent,
-        projectId = projectContext?.id,
-        directory = directory?.trim()?.takeIf { it.isNotBlank() },
-        useWorktree = state.useWorktree,
-        attachAndyMcp = state.attachMcp,
-        autonomy = state.autonomy,
-        model = if (state.usesCustomModel) state.customModel.trim().ifBlank { null } else state.modelId,
-        reasoningEffort = if (state.usesCustomModel) null else state.reasoningEffort,
-        fastMode = if (state.usesCustomModel) false else state.fastMode,
-        imagePaths = state.imagePaths,
-        skills = selectedSkills,
-        maxBudgetUsd = state.budgetText.toMaxBudgetUsd(),
-    )
+    fun buildDraft(): AgentTaskDraft {
+        val goalCommand = state.prompt.takeIf { AgentNativeSlashCommands.supportsGoal(state.agent) }?.parseAgentGoalCommand()
+        return AgentTaskDraft(
+            title = "",
+            prompt = goalCommand?.remainingPrompt?.ifBlank { goalCommand.goal.orEmpty() } ?: state.prompt.trim(),
+            agent = state.agent,
+            projectId = projectContext?.id,
+            directory = directory?.trim()?.takeIf { it.isNotBlank() },
+            useWorktree = state.useWorktree,
+            attachAndyMcp = state.attachMcp,
+            autonomy = state.autonomy,
+            sandboxMode = state.sandboxMode,
+            model = if (state.usesCustomModel) state.customModel.trim().ifBlank { null } else state.modelId,
+            reasoningEffort = if (state.usesCustomModel) null else state.reasoningEffort,
+            fastMode = if (state.usesCustomModel) false else state.fastMode,
+            imagePaths = state.imagePaths,
+            skills = selectedSkills,
+            goal = goalCommand?.goal,
+            maxBudgetUsd = state.budgetText.toMaxBudgetUsd(),
+        )
+    }
 
     fun selectSkill(skill: AgentSkill) {
         val command = slashCommand ?: return
@@ -325,6 +393,16 @@ private class AgentTaskComposerForm(
         state.promptValue = TextFieldValue(
             text = state.prompt.replaceRange(command.start, command.end, insertion),
             selection = TextRange(command.start + insertion.length),
+        )
+        state.skillMenuDismissed = true
+    }
+
+    fun selectCommand(command: AgentNativeSlashCommand) {
+        val slash = slashCommand ?: return
+        val insertion = "/${command.name} "
+        state.promptValue = TextFieldValue(
+            text = state.prompt.replaceRange(slash.start, slash.end, insertion),
+            selection = TextRange(slash.start + insertion.length),
         )
         state.skillMenuDismissed = true
     }
@@ -342,9 +420,11 @@ private fun AgentChatComposer(
     var agentMenuExpanded by remember { mutableStateOf(false) }
     var modelMenuExpanded by remember { mutableStateOf(false) }
     var effortMenuExpanded by remember { mutableStateOf(false) }
+    var sandboxMenuExpanded by remember { mutableStateOf(false) }
     val canSubmit = form.canSubmit
 
     fun selectSkill(skill: AgentSkill) = form.selectSkill(skill)
+    fun selectCommand(command: AgentNativeSlashCommand) = form.selectCommand(command)
 
     Column(
         Modifier.fillMaxWidth()
@@ -367,8 +447,8 @@ private fun AgentChatComposer(
                     .heightIn(min = 94.dp, max = 180.dp)
                     .onPreviewKeyEvent { event ->
                         if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
-                        if (event.key == Key.Tab && form.matchingSkills.isNotEmpty()) {
-                            selectSkill(form.matchingSkills.first())
+                        if (event.key == Key.Tab && (form.matchingCommands.isNotEmpty() || form.matchingSkills.isNotEmpty())) {
+                            form.matchingCommands.firstOrNull()?.let(::selectCommand) ?: selectSkill(form.matchingSkills.first())
                             return@onPreviewKeyEvent true
                         }
                         if (event.key != Key.Enter && event.key != Key.NumPadEnter) return@onPreviewKeyEvent false
@@ -398,16 +478,27 @@ private fun AgentChatComposer(
                 properties = PopupProperties(focusable = false),
             ) {
                 Text(
-                    if (form.matchingSkills.isEmpty()) {
-                        "no ${state.agent.label} skills matching /${form.slashCommand?.query.orEmpty()}"
+                    if (form.matchingCommands.isEmpty() && form.matchingSkills.isEmpty()) {
+                        "no ${state.agent.label} commands or skills matching /${form.slashCommand?.query.orEmpty()}"
                     } else {
-                        "${state.agent.label} skills matching /${form.slashCommand?.query.orEmpty()}"
+                        "${state.agent.label} commands and skills matching /${form.slashCommand?.query.orEmpty()}"
                     },
                     color = TextSecondary,
                     fontFamily = MonoFont,
                     fontSize = 10.sp,
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
                 )
+                form.matchingCommands.forEach { command ->
+                    DropdownMenuItem(
+                        text = {
+                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                Text("/${command.name}", color = Green, fontFamily = MonoFont, fontSize = 12.sp)
+                                Text(command.description, color = TextSecondary, fontSize = 11.sp, maxLines = 2)
+                            }
+                        },
+                        onClick = { selectCommand(command) },
+                    )
+                }
                 form.matchingSkills.forEach { skill ->
                     DropdownMenuItem(
                         text = {
@@ -466,7 +557,7 @@ private fun AgentChatComposer(
                     agentMenuExpanded = true
                 }
                 DropdownMenu(expanded = agentMenuExpanded, onDismissRequest = { agentMenuExpanded = false }) {
-                    form.cliStatuses.filter { it.available }.forEach { status ->
+                    form.cliStatuses.filter { it.ready }.forEach { status ->
                         DropdownMenuItem(
                             text = {
                                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -543,6 +634,25 @@ private fun AgentChatComposer(
                     FilterPill("fast", state.fastMode, Green) { state.fastMode = !state.fastMode }
                 }
             }
+            Box {
+                val sandbox = state.sandboxMode ?: state.autonomy.defaultSandboxMode()
+                FilterPill(
+                    "${state.agent.sandboxControlLabel()}: ${sandbox.labelFor(state.agent)}",
+                    true,
+                    if (sandbox == AgentSandboxMode.None) Rust else Cyan,
+                ) { sandboxMenuExpanded = true }
+                DropdownMenu(expanded = sandboxMenuExpanded, onDismissRequest = { sandboxMenuExpanded = false }) {
+                    AgentSandboxMode.entries.forEach { mode ->
+                        DropdownMenuItem(
+                            text = { Text(mode.labelFor(state.agent), color = TextPrimary) },
+                            onClick = {
+                                state.sandboxMode = mode
+                                sandboxMenuExpanded = false
+                            },
+                        )
+                    }
+                }
+            }
             Spacer(Modifier.weight(1f))
             AgentQuotaMenu(services = form.services, agent = state.agent)
             OutlinedButton(onClick = { onShowOptionsChange(!showOptions) }) {
@@ -583,7 +693,7 @@ private fun AgentTaskComposerFields(
             Row(Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
                 AgentKind.entries.forEach { kind ->
                     val status = form.cliStatuses.firstOrNull { it.kind == kind }
-                    if (status?.available == true) {
+                    if (status?.ready == true) {
                         FilterPill(
                             kind.label,
                             state.providerChosenInComposer && state.agent == kind,
@@ -595,7 +705,7 @@ private fun AgentTaskComposerFields(
                         }
                     } else {
                         Text(
-                            "${kind.label} — not found",
+                            "${kind.label} — ${if (status?.issue != null) "needs repair" else "not found"}",
                             color = TextSecondary.copy(alpha = 0.6f),
                             fontFamily = MonoFont,
                             fontSize = 11.sp,
@@ -685,7 +795,7 @@ private fun AgentTaskComposerFields(
                     textStyle = LocalTextStyle.current.copy(color = TextPrimary, fontFamily = MonoFont),
                     colors = fieldColors(),
                     placeholder = {
-                        Text("type / for ${state.agent.label} skills — drop image files here to attach them", color = TextSecondary, fontFamily = MonoFont)
+                        Text("type / for ${state.agent.label} commands or skills — drop image files here to attach them", color = TextSecondary, fontFamily = MonoFont)
                     },
                 )
                 DropdownMenu(
@@ -695,16 +805,27 @@ private fun AgentTaskComposerFields(
                     properties = PopupProperties(focusable = false),
                 ) {
                     Text(
-                        if (form.matchingSkills.isEmpty()) {
-                            "no ${state.agent.label} skills matching /${form.slashCommand?.query.orEmpty()}"
+                        if (form.matchingCommands.isEmpty() && form.matchingSkills.isEmpty()) {
+                            "no ${state.agent.label} commands or skills matching /${form.slashCommand?.query.orEmpty()}"
                         } else {
-                            "${state.agent.label} skills matching /${form.slashCommand?.query.orEmpty()}"
+                            "${state.agent.label} commands and skills matching /${form.slashCommand?.query.orEmpty()}"
                         },
                         color = TextSecondary,
                         fontFamily = MonoFont,
                         fontSize = 10.sp,
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
                     )
+                    form.matchingCommands.forEach { command ->
+                        DropdownMenuItem(
+                            text = {
+                                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                    Text("/${command.name}", color = Green, fontFamily = MonoFont, fontSize = 12.sp)
+                                    Text(command.description, color = TextSecondary, fontSize = 11.sp, maxLines = 2)
+                                }
+                            },
+                            onClick = { form.selectCommand(command) },
+                        )
+                    }
                     form.matchingSkills.forEach { skill ->
                         DropdownMenuItem(
                             text = {
@@ -799,6 +920,26 @@ private fun AgentTaskComposerFields(
         }
         Text(
             "standard may stop when the agent needs approval; use full for unattended runs in trusted or worktree dirs",
+            color = TextSecondary,
+            fontFamily = MonoFont,
+            fontSize = 10.sp,
+        )
+        Text(
+            "${state.agent.label} ${state.agent.sandboxControlLabel()}",
+            color = TextSecondary,
+            fontFamily = MonoFont,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 11.sp,
+        )
+        Row(Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            AgentSandboxMode.entries.forEach { mode ->
+                FilterPill(mode.labelFor(state.agent), state.sandboxMode == mode, if (mode == AgentSandboxMode.None) Rust else Cyan) {
+                    state.sandboxMode = mode
+                }
+            }
+        }
+        Text(
+            (state.sandboxMode ?: state.autonomy.defaultSandboxMode()).descriptionFor(state.agent),
             color = TextSecondary,
             fontFamily = MonoFont,
             fontSize = 10.sp,

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -178,7 +178,7 @@ internal fun AgentTaskDetail(
                 followUpImagePaths = emptyList()
                 return
             }
-            sendOrQueue(remainder, emptyList())
+            sendOrQueue(remainder, selectedSkills.filter { remainder.referencesSkill(it) })
         } else {
             sendOrQueue(followUp.trim(), selectedSkills)
         }

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -65,12 +65,15 @@ import app.andy.model.AgentKind
 import app.andy.model.AgentChangeSummary
 import app.andy.model.AgentFileChange
 import app.andy.model.AgentFileDiff
+import app.andy.model.AgentNativeSlashCommand
+import app.andy.model.AgentNativeSlashCommands
 import app.andy.model.AgentSkill
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskStatus
 import app.andy.model.DiffLine
 import app.andy.model.DiffLineKind
 import app.andy.model.modelConfigurationLabel
+import app.andy.model.parseAgentGoalCommand
 import app.andy.onImageFilesDropped
 import app.andy.service.AndyServices
 import app.andy.ui.components.Button
@@ -123,10 +126,18 @@ internal fun AgentTaskDetail(
     var copiedHint by remember(task.id) { mutableStateOf(false) }
     var followUpImagePaths by remember(task.id) { mutableStateOf<List<String>>(emptyList()) }
     var followUpImageDragActive by remember(task.id) { mutableStateOf(false) }
+    var goalEditorOpen by remember(task.id) { mutableStateOf(false) }
+    var goalEditorText by remember(task.id) { mutableStateOf(task.goal.orEmpty()) }
 
     val supportsResume = task.vendorSessionId != null && task.agent != AgentKind.Antigravity
     val canSendFollowUp = followUp.isNotBlank() || followUpImagePaths.isNotEmpty()
     val slashCommand = findActiveSlashCommand(followUp)
+    val matchingCommands = slashCommand?.let { command ->
+        AgentNativeSlashCommands.forAgent(task.agent).filter { nativeCommand ->
+            nativeCommand.name.contains(command.query, ignoreCase = true) ||
+                nativeCommand.description.contains(command.query, ignoreCase = true)
+        }
+    }.orEmpty()
     val matchingSkills = slashCommand?.let { command ->
         availableSkills.filter { skill ->
             skill.name.contains(command.query, ignoreCase = true) ||
@@ -143,9 +154,34 @@ internal fun AgentTaskDetail(
         skillMenuDismissed = true
     }
 
+    fun selectCommand(command: AgentNativeSlashCommand) {
+        val slash = findActiveSlashCommand(followUp) ?: return
+        followUp = followUp.replaceRange(slash.start, slash.end, "/${command.name} ")
+        skillMenuDismissed = true
+    }
+
     fun submitFollowUp() {
         if (!supportsResume || !canSendFollowUp) return
-        services.agentRuns.resume(task.id, followUp.trim(), followUpImagePaths, selectedSkills)
+        fun sendOrQueue(message: String, skills: List<AgentSkill>) {
+            if (task.isActive) {
+                services.agentRuns.queueFollowUp(task.id, message, followUpImagePaths, skills)
+            } else {
+                services.agentRuns.resume(task.id, message, followUpImagePaths, skills)
+            }
+        }
+        val goalCommand = if (AgentNativeSlashCommands.supportsGoal(task.agent)) followUp.parseAgentGoalCommand() else null
+        if (goalCommand != null) {
+            services.agentRuns.updateGoal(task.id, goalCommand.goal)
+            val remainder = goalCommand.remainingPrompt
+            if (remainder.isBlank()) {
+                followUp = ""
+                followUpImagePaths = emptyList()
+                return
+            }
+            sendOrQueue(remainder, emptyList())
+        } else {
+            sendOrQueue(followUp.trim(), selectedSkills)
+        }
         followUp = ""
         followUpImagePaths = emptyList()
     }
@@ -158,6 +194,10 @@ internal fun AgentTaskDetail(
         expandedDiffPath = null
         loadedFileDiffs = emptyMap()
         loadingDiffPath = null
+    }
+    LaunchedEffect(task.goal) {
+        goalEditorText = task.goal.orEmpty()
+        if (task.goal == null) goalEditorOpen = false
     }
 
     fun toggleFileDiff(path: String) {
@@ -227,7 +267,48 @@ internal fun AgentTaskDetail(
             modifier = Modifier.weight(1f).fillMaxWidth(),
         )
 
-        if (!task.isActive) {
+        if (task.queuedFollowUps.isNotEmpty()) {
+            Column(
+                Modifier.fillMaxWidth()
+                    .background(AndyColors.Neutral850, RoundedCornerShape(AndyRadius.R4))
+                    .border(1.dp, Cyan.copy(alpha = 0.6f), RoundedCornerShape(AndyRadius.R4))
+                    .padding(10.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text("MESSAGE QUEUE · ${task.queuedFollowUps.size}", color = Cyan, fontFamily = MonoFont, fontWeight = FontWeight.Bold, fontSize = 10.sp)
+                }
+                task.queuedFollowUps.forEachIndexed { index, queuedFollowUp ->
+                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("${index + 1}.", color = Cyan, fontFamily = MonoFont, fontSize = 11.sp)
+                        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(
+                                queuedFollowUp.text.ifBlank { "images attached" },
+                                color = TextPrimary,
+                                fontSize = 12.sp,
+                                maxLines = 3,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            if (queuedFollowUp.skills.isNotEmpty()) {
+                                Text(
+                                    queuedFollowUp.skills.joinToString("  ") { "/${it.name}" },
+                                    color = Cyan,
+                                    fontFamily = MonoFont,
+                                    fontSize = 10.sp,
+                                )
+                            }
+                        }
+                        OutlinedButton(
+                            onClick = { services.agentRuns.removeQueuedFollowUp(task.id, index) },
+                            modifier = Modifier.height(26.dp),
+                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 1.dp),
+                        ) { Text("remove", fontSize = 10.sp) }
+                    }
+                }
+            }
+        }
+
+        if (!task.isActive || supportsResume) {
             Column(
                 Modifier.fillMaxWidth()
                     .background(AndyColors.Neutral850, RoundedCornerShape(AndyRadius.R4))
@@ -238,6 +319,55 @@ internal fun AgentTaskDetail(
                 Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     if (supportsResume) {
                         Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            task.goal?.let { goal ->
+                                OutlinedButton(
+                                    onClick = { goalEditorOpen = !goalEditorOpen },
+                                    modifier = Modifier.fillMaxWidth().heightIn(min = 34.dp),
+                                    contentPadding = PaddingValues(horizontal = 9.dp, vertical = 5.dp),
+                                ) {
+                                    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                                        Text("GOAL MODE ACTIVE", color = Green, fontFamily = MonoFont, fontWeight = FontWeight.Bold, fontSize = 9.sp)
+                                        Text(goal, color = TextPrimary, fontFamily = MonoFont, fontSize = 10.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                                    }
+                                }
+                            }
+                            if (goalEditorOpen) {
+                                Column(
+                                    Modifier.fillMaxWidth()
+                                        .background(AndyColors.Neutral900, RoundedCornerShape(AndyRadius.R3))
+                                        .border(1.dp, Green.copy(alpha = 0.4f), RoundedCornerShape(AndyRadius.R3))
+                                        .padding(8.dp),
+                                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                                ) {
+                                    Text("persistent task goal", color = Green, fontFamily = MonoFont, fontWeight = FontWeight.Bold, fontSize = 10.sp)
+                                    TextField(
+                                        goalEditorText,
+                                        { goalEditorText = it },
+                                        singleLine = false,
+                                        minLines = 2,
+                                        maxLines = 4,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        textStyle = LocalTextStyle.current.copy(color = TextPrimary, fontFamily = MonoFont, fontSize = 11.sp),
+                                        colors = fieldColors(),
+                                    )
+                                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                        Button(
+                                            onClick = {
+                                                services.agentRuns.updateGoal(task.id, goalEditorText)
+                                                goalEditorOpen = false
+                                            },
+                                            enabled = goalEditorText.isNotBlank(),
+                                            modifier = Modifier.height(28.dp),
+                                            contentPadding = PaddingValues(horizontal = 9.dp, vertical = 1.dp),
+                                        ) { Text("save goal", fontSize = 10.sp) }
+                                        OutlinedButton(
+                                            onClick = { services.agentRuns.updateGoal(task.id, null) },
+                                            modifier = Modifier.height(28.dp),
+                                            contentPadding = PaddingValues(horizontal = 9.dp, vertical = 1.dp),
+                                        ) { Text("clear goal", fontSize = 10.sp) }
+                                    }
+                                }
+                            }
                             Box(Modifier.fillMaxWidth()) {
                             TextField(
                                 followUp,
@@ -252,8 +382,8 @@ internal fun AgentTaskDetail(
                                     .heightIn(min = 54.dp, max = 160.dp)
                                     .onPreviewKeyEvent { event ->
                                         if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
-                                        if (event.key == Key.Tab && matchingSkills.isNotEmpty()) {
-                                            selectSkill(matchingSkills.first())
+                                        if (event.key == Key.Tab && (matchingCommands.isNotEmpty() || matchingSkills.isNotEmpty())) {
+                                            matchingCommands.firstOrNull()?.let(::selectCommand) ?: selectSkill(matchingSkills.first())
                                             return@onPreviewKeyEvent true
                                         }
                                         if (event.key != Key.Enter && event.key != Key.NumPadEnter) return@onPreviewKeyEvent false
@@ -276,8 +406,10 @@ internal fun AgentTaskDetail(
                                     Text(
                                         if (followUpImageDragActive) {
                                             "release to attach image"
+                                        } else if (task.isActive) {
+                                            "next message — type / for ${task.agent.label} commands or skills, enter to queue"
                                         } else {
-                                            "follow-up prompt — type / for ${task.agent.label} skills, enter to send"
+                                            "follow-up prompt — type / for ${task.agent.label} commands or skills, enter to send"
                                         },
                                         color = if (followUpImageDragActive) Cyan else TextSecondary,
                                         fontFamily = MonoFont,
@@ -292,16 +424,27 @@ internal fun AgentTaskDetail(
                                 properties = PopupProperties(focusable = false),
                             ) {
                                 Text(
-                                    if (matchingSkills.isEmpty()) {
-                                        "no ${task.agent.label} skills matching /${slashCommand?.query.orEmpty()}"
+                                    if (matchingCommands.isEmpty() && matchingSkills.isEmpty()) {
+                                        "no ${task.agent.label} commands or skills matching /${slashCommand?.query.orEmpty()}"
                                     } else {
-                                        "${task.agent.label} skills matching /${slashCommand?.query.orEmpty()}"
+                                        "${task.agent.label} commands and skills matching /${slashCommand?.query.orEmpty()}"
                                     },
                                     color = TextSecondary,
                                     fontFamily = MonoFont,
                                     fontSize = 10.sp,
                                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
                                 )
+                                matchingCommands.forEach { command ->
+                                    DropdownMenuItem(
+                                        text = {
+                                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                                Text("/${command.name}", color = Green, fontFamily = MonoFont, fontSize = 12.sp)
+                                                Text(command.description, color = TextSecondary, fontSize = 11.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                                            }
+                                        },
+                                        onClick = { selectCommand(command) },
+                                    )
+                                }
                                 matchingSkills.forEach { skill ->
                                     DropdownMenuItem(
                                         text = {
@@ -334,7 +477,7 @@ internal fun AgentTaskDetail(
                             colors = primaryButtonColors(),
                             modifier = Modifier.height(36.dp),
                             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 2.dp),
-                        ) { Text("send", fontSize = 11.sp) }
+                        ) { Text(if (task.isActive) "queue" else "send", fontSize = 11.sp) }
                     } else {
                         Spacer(Modifier.weight(1f))
                     }
@@ -481,6 +624,19 @@ private fun AgentTaskHeader(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+
+        task.goal?.let { goal ->
+            Column(
+                Modifier.fillMaxWidth()
+                    .background(Green.copy(alpha = 0.12f), RoundedCornerShape(AndyRadius.R3))
+                    .border(1.dp, Green.copy(alpha = 0.38f), RoundedCornerShape(AndyRadius.R3))
+                    .padding(horizontal = 10.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text("GOAL MODE ACTIVE", color = Green, fontFamily = MonoFont, fontWeight = FontWeight.Bold, fontSize = 10.sp)
+                Text(goal, color = TextPrimary, fontFamily = MonoFont, fontSize = 11.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            }
+        }
 
         AgentContextWindowIndicator(task)
 

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentsScreen.kt
@@ -70,14 +70,14 @@ internal fun AgentsScreen(
     val cliStatuses by services.agentRuns.cliStatuses.collectAsState()
     var projects by remember { mutableStateOf<List<ActionProject>>(emptyList()) }
     var selectedTaskId by remember { mutableStateOf<String?>(null) }
-    var showComposer by remember { mutableStateOf(false) }
+    var showComposer by remember { mutableStateOf(true) }
     var pendingConfirmation by remember { mutableStateOf<PendingConfirmation?>(null) }
     var listPaneWidth by remember { mutableStateOf(420f) }
     var nowMillis by remember { mutableStateOf(System.currentTimeMillis()) }
 
     LaunchedEffect(active) {
         if (!active) {
-            showComposer = false
+            showComposer = true
             pendingConfirmation = null
         }
     }
@@ -99,7 +99,7 @@ internal fun AgentsScreen(
     val activeTasks = remember(ordered) { ordered.filter { it.isActive } }
     val completedTasks = remember(ordered) { ordered.filterNot { it.isActive } }
     val runningCount = activeTasks.size
-    val availableAgents = cliStatuses.filter { it.available }
+    val availableAgents = cliStatuses.filter { it.ready }
 
     Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         Column(Modifier.width(listPaneWidth.dp).fillMaxHeight(), verticalArrangement = Arrangement.spacedBy(10.dp)) {

--- a/src/commonTest/kotlin/app/andy/model/AgentGoalCommandTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AgentGoalCommandTest.kt
@@ -1,0 +1,48 @@
+package app.andy.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AgentGoalCommandTest {
+    @Test
+    fun parsesGoalAndKeepsFollowingPrompt() {
+        assertEquals(
+            AgentGoalCommand(
+                action = AgentGoalCommandAction.Set,
+                goal = "Ship the regression fix",
+                remainingPrompt = "Start with the failing desktop test.",
+            ),
+            "/goal Ship the regression fix\nStart with the failing desktop test.".parseAgentGoalCommand(),
+        )
+    }
+
+    @Test
+    fun parsesClearGoal() {
+        assertEquals(
+            AgentGoalCommand(AgentGoalCommandAction.Clear),
+            "/goal clear".parseAgentGoalCommand(),
+        )
+    }
+
+    @Test
+    fun leavesOtherSlashCommandsAlone() {
+        assertNull("/goals keep working".parseAgentGoalCommand())
+        assertNull("please use /goal in the reply".parseAgentGoalCommand())
+    }
+
+    @Test
+    fun appendsGoalHintToProviderPrompt() {
+        assertEquals(
+            "Implement the fix\n\nPersistent task goal: Ship the regression fix\nKeep this goal in mind throughout the task.",
+            promptWithGoalHint("Implement the fix", "Ship the regression fix"),
+        )
+    }
+
+    @Test
+    fun goalIsOnlyOfferedByProvidersWithNativeAndySupport() {
+        assertEquals(listOf("goal"), AgentNativeSlashCommands.forAgent(AgentKind.Codex).map { it.name })
+        assertEquals(listOf("goal"), AgentNativeSlashCommands.forAgent(AgentKind.ClaudeCode).map { it.name })
+        assertEquals(emptyList(), AgentNativeSlashCommands.forAgent(AgentKind.Cursor))
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentCliLocator.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentCliLocator.kt
@@ -14,11 +14,50 @@ class AgentCliLocator {
     fun locateAll(overrides: Map<String, String>): List<AgentCliStatus> {
         val fromShell = lookupViaLoginShell()
         return AgentKind.entries.map { kind ->
-            val binary = overrides[kind.cliName]?.takeIf { File(it).canExecute() }
+            val discoveredBinary = overrides[kind.cliName]?.takeIf { File(it).canExecute() }
                 ?: fromShell[kind.cliName]
                 ?: probeKnownLocations(kind)
-            AgentCliStatus(kind = kind, binaryPath = binary, version = binary?.let(::probeVersion))
+            val binary = discoveredBinary?.let(::canonicalExecutable)
+            AgentCliStatus(
+                kind = kind,
+                binaryPath = binary,
+                version = binary?.let(::probeVersion),
+                issue = discoveredBinary?.let { source -> diagnoseInstallation(kind, source, binary) },
+            )
         }
+    }
+
+    /**
+     * App launchers commonly put a symlink in ~/.local/bin. Resolving it makes
+     * providers that look for sibling helper binaries run from their real bundle.
+     */
+    private fun canonicalExecutable(path: String): String = runCatching {
+        File(path).canonicalFile.path
+    }.getOrDefault(path)
+
+    private fun diagnoseInstallation(kind: AgentKind, sourcePath: String, binaryPath: String?): app.andy.model.AgentCliIssue? {
+        if (kind != AgentKind.Codex || binaryPath == null) return null
+        // A user may deliberately point Codex at a wrapper; only inspect the
+        // packaged Codex executable whose code-mode helper contract is known.
+        if (File(binaryPath).name != AgentKind.Codex.cliName) return null
+        val bundledHost = File(File(binaryPath).parentFile, "codex-code-mode-host")
+        if (!bundledHost.canExecute()) {
+            return app.andy.model.AgentCliIssue(
+                title = "Codex installation needs repair",
+                detail = "Codex's code-mode helper is missing. Update or reinstall Codex before starting a chat.",
+                blocksTasks = true,
+            )
+        }
+
+        val sourceHost = File(File(sourcePath).parentFile, "codex-code-mode-host")
+        if (sourcePath != binaryPath && !sourceHost.canExecute()) {
+            return app.andy.model.AgentCliIssue(
+                title = "Codex Terminal link needs repair",
+                detail = "Andy will use Codex's bundled executable, but running codex in Terminal can still fail because its code-mode helper is not linked beside it.",
+                repairCommand = "ln -sf ${shellQuote(bundledHost.path)} ${shellQuote(sourceHost.path)}",
+            )
+        }
+        return null
     }
 
     private fun lookupViaLoginShell(): Map<String, String> {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AntigravityAdapter.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AntigravityAdapter.kt
@@ -3,6 +3,7 @@ package app.andy.desktop.service.agents
 import app.andy.model.AgentAutonomy
 import app.andy.model.AgentEvent
 import app.andy.model.AgentKind
+import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentTask
 import app.andy.model.modelForCli
 import app.andy.model.promptForCli
@@ -26,11 +27,7 @@ class AntigravityAdapter : AgentCliAdapter {
         add("-p"); add(task.promptForCli())
         // Print mode defaults to a 5m ceiling; agentic tasks routinely run longer.
         add("--print-timeout"); add("60m")
-        when (task.autonomy) {
-            AgentAutonomy.ReadOnly -> { add("--mode"); add("plan"); add("--sandbox") }
-            AgentAutonomy.Standard -> { add("--mode"); add("accept-edits") }
-            AgentAutonomy.Full -> add("--dangerously-skip-permissions")
-        }
+        addAntigravityPermissionMode(task)
     }
 
     override fun buildResumeCommand(binary: String, task: AgentTask, followUp: String, imagePaths: List<String>, mcpUrl: String?): List<String>? = null
@@ -39,4 +36,17 @@ class AntigravityAdapter : AgentCliAdapter {
         "${shellQuote(binary)} --continue"
 
     override fun parseLine(line: String, nowMillis: Long): List<AgentEvent> = rawIfNotBlank(line, nowMillis)
+}
+
+private fun MutableList<String>.addAntigravityPermissionMode(task: AgentTask) {
+    when (task.sandboxMode) {
+        AgentSandboxMode.ReadOnly -> { add("--mode"); add("plan"); add("--sandbox") }
+        AgentSandboxMode.WorkspaceWrite -> { add("--mode"); add("accept-edits") }
+        AgentSandboxMode.None -> add("--dangerously-skip-permissions")
+        null -> when (task.autonomy) {
+            AgentAutonomy.ReadOnly -> { add("--mode"); add("plan"); add("--sandbox") }
+            AgentAutonomy.Standard -> { add("--mode"); add("accept-edits") }
+            AgentAutonomy.Full -> add("--dangerously-skip-permissions")
+        }
+    }
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/ClaudeCodeAdapter.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/ClaudeCodeAdapter.kt
@@ -3,6 +3,7 @@ package app.andy.desktop.service.agents
 import app.andy.model.AgentAutonomy
 import app.andy.model.AgentEvent
 import app.andy.model.AgentKind
+import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentTask
 import app.andy.model.modelForCli
 import app.andy.model.promptForCli
@@ -26,11 +27,7 @@ class ClaudeCodeAdapter : AgentCliAdapter {
         task.vendorSessionId?.let { add("--session-id"); add(it) }
         task.modelForCli()?.let { add("--model"); add(it) }
         task.reasoningEffort?.let { add("--effort"); add(it.cliValue) }
-        when (task.autonomy) {
-            AgentAutonomy.ReadOnly -> { add("--permission-mode"); add("plan") }
-            AgentAutonomy.Standard -> { add("--permission-mode"); add("acceptEdits") }
-            AgentAutonomy.Full -> add("--dangerously-skip-permissions")
-        }
+        addClaudePermissionMode(task)
         task.maxBudgetUsd?.let { add("--max-budget-usd"); add(it.toString()) }
         mcpUrl?.let {
             add("--mcp-config")
@@ -49,11 +46,7 @@ class ClaudeCodeAdapter : AgentCliAdapter {
             add("--resume"); add(sessionId)
             task.modelForCli()?.let { add("--model"); add(it) }
             task.reasoningEffort?.let { add("--effort"); add(it.cliValue) }
-            when (task.autonomy) {
-                AgentAutonomy.ReadOnly -> { add("--permission-mode"); add("plan") }
-                AgentAutonomy.Standard -> { add("--permission-mode"); add("acceptEdits") }
-                AgentAutonomy.Full -> add("--dangerously-skip-permissions")
-            }
+            addClaudePermissionMode(task)
             mcpUrl?.let {
                 add("--mcp-config")
                 add("""{"mcpServers":{"andy":{"type":"http","url":"$it"}}}""")
@@ -70,6 +63,19 @@ class ClaudeCodeAdapter : AgentCliAdapter {
     override fun parseLine(line: String, nowMillis: Long): List<AgentEvent> {
         val obj = parseJsonObject(line) ?: return rawIfNotBlank(line, nowMillis)
         return parseClaudeStyleObject(obj, nowMillis) ?: rawIfNotBlank(line, nowMillis)
+    }
+}
+
+private fun MutableList<String>.addClaudePermissionMode(task: AgentTask) {
+    when (task.sandboxMode) {
+        AgentSandboxMode.ReadOnly -> { add("--permission-mode"); add("plan") }
+        AgentSandboxMode.WorkspaceWrite -> { add("--permission-mode"); add("acceptEdits") }
+        AgentSandboxMode.None -> add("--dangerously-skip-permissions")
+        null -> when (task.autonomy) {
+            AgentAutonomy.ReadOnly -> { add("--permission-mode"); add("plan") }
+            AgentAutonomy.Standard -> { add("--permission-mode"); add("acceptEdits") }
+            AgentAutonomy.Full -> add("--dangerously-skip-permissions")
+        }
     }
 }
 

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/CodexAdapter.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/CodexAdapter.kt
@@ -1,9 +1,10 @@
 package app.andy.desktop.service.agents
 
-import app.andy.model.AgentAutonomy
 import app.andy.model.AgentEvent
 import app.andy.model.AgentKind
+import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentTask
+import app.andy.model.defaultSandboxMode
 import app.andy.model.modelForCli
 import app.andy.model.promptForCli
 import app.andy.model.promptWithImageHints
@@ -23,10 +24,10 @@ class CodexAdapter : AgentCliAdapter {
         add("--skip-git-repo-check")
         task.modelForCli()?.let { add("--model"); add(it) }
         task.reasoningEffort?.let { add("-c"); add("model_reasoning_effort=\"${it.cliValue}\"") }
-        when (task.autonomy) {
-            AgentAutonomy.ReadOnly -> { add("--sandbox"); add("read-only") }
-            AgentAutonomy.Standard -> { add("--sandbox"); add("workspace-write") }
-            AgentAutonomy.Full -> add("--dangerously-bypass-approvals-and-sandbox")
+        when (task.sandboxMode ?: task.autonomy.defaultSandboxMode()) {
+            AgentSandboxMode.ReadOnly -> { add("--sandbox"); add("read-only") }
+            AgentSandboxMode.WorkspaceWrite -> { add("--sandbox"); add("workspace-write") }
+            AgentSandboxMode.None -> add("--dangerously-bypass-approvals-and-sandbox")
         }
         mcpUrl?.let { add("-c"); add("mcp_servers.andy.url=\"$it\"") }
         add(task.promptForCli())

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/CursorAdapter.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/CursorAdapter.kt
@@ -3,6 +3,7 @@ package app.andy.desktop.service.agents
 import app.andy.model.AgentAutonomy
 import app.andy.model.AgentEvent
 import app.andy.model.AgentKind
+import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentTask
 import app.andy.model.modelForCli
 import app.andy.model.promptForCli
@@ -18,6 +19,7 @@ class CursorAdapter : AgentCliAdapter {
         add("-p")
         add("--output-format"); add("stream-json")
         task.modelForCli()?.let { add("--model"); add(it) }
+        addSandboxMode(task)
         if (task.autonomy == AgentAutonomy.Full) add("--force")
         add(task.promptForCli())
     }
@@ -30,6 +32,7 @@ class CursorAdapter : AgentCliAdapter {
             add("--output-format"); add("stream-json")
             add("--resume"); add(chatId)
             task.modelForCli()?.let { add("--model"); add(it) }
+            addSandboxMode(task)
             if (task.autonomy == AgentAutonomy.Full) add("--force")
             add(promptWithImageHints(followUp, imagePaths))
         }
@@ -44,5 +47,14 @@ class CursorAdapter : AgentCliAdapter {
         val obj = parseJsonObject(line) ?: return rawIfNotBlank(line, nowMillis)
         // cursor-agent's stream-json mimics Claude Code's schema.
         return parseClaudeStyleObject(obj, nowMillis) ?: rawIfNotBlank(line, nowMillis)
+    }
+}
+
+private fun MutableList<String>.addSandboxMode(task: AgentTask) {
+    when (task.sandboxMode) {
+        AgentSandboxMode.ReadOnly -> { add("--mode"); add("plan"); add("--sandbox"); add("enabled") }
+        AgentSandboxMode.WorkspaceWrite -> { add("--sandbox"); add("enabled") }
+        AgentSandboxMode.None -> { add("--sandbox"); add("disabled") }
+        null -> Unit // Preserve the CLI/config default for tasks created before explicit sandbox support.
     }
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -867,9 +867,7 @@ class DesktopAgentRunService(
         handles.remove(taskId)
         if (status == AgentTaskStatus.Completed && queuedFollowUp != null) {
             updateTask(taskId) { current -> current.copy(queuedFollowUps = current.queuedFollowUps.drop(1)) }
-            scope.launch {
-                resume(taskId, queuedFollowUp.text, queuedFollowUp.imagePaths, queuedFollowUp.skills)
-            }
+            resume(taskId, queuedFollowUp.text, queuedFollowUp.imagePaths, queuedFollowUp.skills)
         } else {
             scope.launch { persist() }
         }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -6,6 +6,7 @@ import app.andy.model.AgentEvent
 import app.andy.model.AgentFileDiff
 import app.andy.model.AgentKind
 import app.andy.model.AgentProviderDefaults
+import app.andy.model.AgentQueuedFollowUp
 import app.andy.model.AgentProviderQuota
 import app.andy.model.AgentQuotaSource
 import app.andy.model.AgentQuotaAccess
@@ -14,6 +15,7 @@ import app.andy.model.AgentTask
 import app.andy.model.AgentTaskDraft
 import app.andy.model.AgentTaskStatus
 import app.andy.model.estimatedTokenCostUsd
+import app.andy.model.promptWithGoalHint
 import app.andy.model.promptWithSkillHints
 import app.andy.model.providerDefaults
 import app.andy.service.ActionConfigStore
@@ -160,6 +162,7 @@ class DesktopAgentRunService(
             useWorktree = draft.useWorktree,
             attachAndyMcp = draft.attachAndyMcp,
             autonomy = draft.autonomy,
+            sandboxMode = draft.sandboxMode,
             model = draft.model,
             reasoningEffort = draft.reasoningEffort,
             fastMode = draft.fastMode,
@@ -167,6 +170,7 @@ class DesktopAgentRunService(
             skills = draft.skills.filter { skill ->
                 skills(draft.agent, draft.directory).value.any { it.path == skill.path }
             },
+            goal = draft.goal,
             maxBudgetUsd = draft.maxBudgetUsd,
             status = AgentTaskStatus.Queued,
             // Claude accepts a caller-assigned session id; pre-assigning means resume
@@ -179,7 +183,7 @@ class DesktopAgentRunService(
         if (binary == null) {
             task = task.copy(
                 status = AgentTaskStatus.Failed,
-                errorMessage = "${task.agent.cliName} CLI not found — install it or set a binary override in ~/.andy/agents.toml",
+                errorMessage = unavailableCliMessage(task.agent),
                 finishedAtMillis = now,
             )
             upsertTask(task)
@@ -244,7 +248,7 @@ class DesktopAgentRunService(
         val selectedSkills = skills.filter { skill ->
             this.skills(task.agent, skillDirectory).value.any { it.path == skill.path }
         }
-        val followUpForCli = promptWithSkillHints(followUp, selectedSkills)
+        val followUpForCli = promptWithGoalHint(promptWithSkillHints(followUp, selectedSkills), task.goal)
         appendEvents(taskId, listOf(AgentEvent.UserMessage(now, followUp, selectedSkills)))
         writeAndyTranscriptLine(taskId, followUp, selectedSkills, now)
         val queued = task.copy(
@@ -260,6 +264,42 @@ class DesktopAgentRunService(
             resumeAdapter.buildResumeCommand(binary, currentTask(taskId) ?: queued, followUpForCli, imagePaths, mcpUrl)
                 ?: error("resume not supported")
         }
+    }
+
+    override fun queueFollowUp(taskId: String, followUp: String, imagePaths: List<String>, skills: List<AgentSkill>) {
+        val task = currentTask(taskId) ?: return
+        val adapter = adapters[task.agent] ?: return
+        if (!task.isActive || !adapter.supportsHeadlessResume || task.vendorSessionId == null) return
+
+        val text = followUp.trim()
+        if (text.isBlank() && imagePaths.isEmpty()) return
+        val skillDirectory = task.worktreePath ?: task.cwd
+        val selectedSkills = skills.filter { skill ->
+            this.skills(task.agent, skillDirectory).value.any { it.path == skill.path }
+        }
+        updateTask(taskId) { current ->
+            if (!current.isActive) {
+                current
+            } else {
+                current.copy(
+                    queuedFollowUps = current.queuedFollowUps + AgentQueuedFollowUp(
+                        text = text,
+                        imagePaths = imagePaths,
+                        skills = selectedSkills,
+                    ),
+                )
+            }
+        }
+        scope.launch { persist() }
+    }
+
+    override fun removeQueuedFollowUp(taskId: String, queueIndex: Int) {
+        val task = currentTask(taskId) ?: return
+        if (queueIndex !in task.queuedFollowUps.indices) return
+        updateTask(taskId) { current ->
+            current.copy(queuedFollowUps = current.queuedFollowUps.filterIndexed { index, _ -> index != queueIndex })
+        }
+        scope.launch { persist() }
     }
 
     override suspend fun retry(taskId: String) {
@@ -296,6 +336,14 @@ class DesktopAgentRunService(
         }
     }
 
+    override fun updateGoal(taskId: String, goal: String?) {
+        val normalizedGoal = goal?.trim()?.takeIf { it.isNotBlank() }
+        val task = currentTask(taskId) ?: return
+        if (task.goal == normalizedGoal) return
+        updateTask(taskId) { it.copy(goal = normalizedGoal) }
+        scope.launch { persist() }
+    }
+
     private fun launchRun(task: AgentTask, argvBuilder: (AgentCliAdapter, String, String?) -> List<String>) {
         val handle = TaskHandle()
         handles[task.id] = handle
@@ -317,7 +365,7 @@ class DesktopAgentRunService(
         val adapter = adapters.getValue(task.agent)
         val binary = binaryFor(task.agent)
         if (binary == null) {
-            finishTask(taskId, AgentTaskStatus.Failed, exitCode = null, error = "${task.agent.cliName} CLI not found")
+            finishTask(taskId, AgentTaskStatus.Failed, exitCode = null, error = unavailableCliMessage(task.agent))
             return
         }
 
@@ -668,9 +716,20 @@ class DesktopAgentRunService(
         }
     }
 
-    private fun binaryFor(agent: AgentKind): String? =
-        _cliStatuses.value.firstOrNull { it.kind == agent }?.binaryPath
-            ?: binaryOverrides[agent.cliName]?.takeIf { File(it).canExecute() }
+    private fun binaryFor(agent: AgentKind): String? {
+        val status = _cliStatuses.value.firstOrNull { it.kind == agent }
+        return when {
+            status?.ready == true -> status.binaryPath
+            status != null -> null
+            else -> binaryOverrides[agent.cliName]?.takeIf { File(it).canExecute() }
+        }
+    }
+
+    private fun unavailableCliMessage(agent: AgentKind): String {
+        val issue = _cliStatuses.value.firstOrNull { it.kind == agent }?.issue
+        return issue?.let { "${it.title}: ${it.detail}" }
+            ?: "${agent.cliName} CLI not found — install it or set a binary override in ~/.andy/agents.toml"
+    }
 
     private fun currentTask(taskId: String): AgentTask? = _tasks.value.firstOrNull { it.id == taskId }
 
@@ -804,8 +863,16 @@ class DesktopAgentRunService(
                 task
             }
         }
+        val queuedFollowUp = currentTask(taskId)?.queuedFollowUps?.firstOrNull()
         handles.remove(taskId)
-        scope.launch { persist() }
+        if (status == AgentTaskStatus.Completed && queuedFollowUp != null) {
+            updateTask(taskId) { current -> current.copy(queuedFollowUps = current.queuedFollowUps.drop(1)) }
+            scope.launch {
+                resume(taskId, queuedFollowUp.text, queuedFollowUp.imagePaths, queuedFollowUp.skills)
+            }
+        } else {
+            scope.launch { persist() }
+        }
     }
 
     private suspend fun persist() {
@@ -863,6 +930,7 @@ class DesktopAgentRunService(
                 workspace?.let { File(it, ".cursor/skills") },
                 workspace?.let { File(it, ".agents/skills") },
                 File(home, ".cursor/skills"),
+                File(home, ".cursor/skills-cursor"),
                 File(home, ".agents/skills"),
             )
             // Antigravity CLI loads workspace Agent Skills and its own global root.

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStore.kt
@@ -5,6 +5,8 @@ import app.andy.model.AgentKind
 import app.andy.model.AgentQuotaAccess
 import app.andy.model.AgentReasoningEffort
 import app.andy.model.AgentProviderDefaults
+import app.andy.model.AgentQueuedFollowUp
+import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentSkill
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskStatus
@@ -80,6 +82,7 @@ private data class AgentProviderDefaultsDto(
     val reasoningEffort: String = "",
     val fastMode: Boolean = false,
     val autonomy: String = AgentAutonomy.Standard.name,
+    val sandboxMode: String = "",
     val useWorktree: Boolean = false,
     val attachAndyMcp: Boolean = false,
     val maxBudgetUsd: Double = 0.0,
@@ -99,12 +102,20 @@ private data class AgentTaskDto(
     val branchName: String = "",
     val attachAndyMcp: Boolean = false,
     val autonomy: String = AgentAutonomy.Standard.name,
+    val sandboxMode: String = "",
     val model: String = "",
     val reasoningEffort: String = "",
     val fastMode: Boolean = false,
     val imagePaths: List<String> = emptyList(),
     val skillNames: List<String> = emptyList(),
     val skillPaths: List<String> = emptyList(),
+    val goal: String = "",
+    val queuedFollowUps: List<AgentQueuedFollowUpDto> = emptyList(),
+    /** Kept while migrating the first queue implementation's single saved item. */
+    val queuedFollowUp: String = "",
+    val queuedFollowUpImagePaths: List<String> = emptyList(),
+    val queuedFollowUpSkillNames: List<String> = emptyList(),
+    val queuedFollowUpSkillPaths: List<String> = emptyList(),
     val maxBudgetUsd: Double = 0.0,
     val changeBaselinePaths: List<String> = emptyList(),
     val hasChangeBaseline: Boolean = false,
@@ -122,6 +133,14 @@ private data class AgentTaskDto(
     val contextTokens: Long = 0,
     val contextWindowTokens: Long = 0,
     val unread: Boolean = false,
+)
+
+@Serializable
+private data class AgentQueuedFollowUpDto(
+    val text: String = "",
+    val imagePaths: List<String> = emptyList(),
+    val skillNames: List<String> = emptyList(),
+    val skillPaths: List<String> = emptyList(),
 )
 
 private fun AgentsFileDto.toModel(): AgentStoreState = AgentStoreState(
@@ -144,6 +163,7 @@ private fun AgentProviderDefaultsDto.toModel(): Pair<AgentKind, AgentProviderDef
         reasoningEffort = AgentReasoningEffort.entries.firstOrNull { it.name == reasoningEffort },
         fastMode = fastMode,
         autonomy = AgentAutonomy.entries.firstOrNull { it.name == autonomy } ?: AgentAutonomy.Standard,
+        sandboxMode = AgentSandboxMode.entries.firstOrNull { it.name == sandboxMode },
         useWorktree = useWorktree,
         attachAndyMcp = attachAndyMcp,
         maxBudgetUsd = maxBudgetUsd.takeIf { it > 0 },
@@ -153,6 +173,15 @@ private fun AgentProviderDefaultsDto.toModel(): Pair<AgentKind, AgentProviderDef
 private fun AgentTaskDto.toModel(): AgentTask? {
     val agentKind = AgentKind.entries.firstOrNull { it.name == agent } ?: return null
     val persistedStatus = AgentTaskStatus.entries.firstOrNull { it.name == status } ?: AgentTaskStatus.Unknown
+    val legacyQueuedFollowUp = queuedFollowUp.takeIf { it.isNotBlank() || queuedFollowUpImagePaths.isNotEmpty() }?.let { text ->
+        AgentQueuedFollowUp(
+            text = text,
+            imagePaths = queuedFollowUpImagePaths,
+            skills = queuedFollowUpSkillNames.zip(queuedFollowUpSkillPaths)
+                .filter { (_, path) -> path.isNotBlank() }
+                .map { (name, path) -> AgentSkill(name = name, description = "", path = path) },
+        )
+    }
     return AgentTask(
         id = id,
         title = title,
@@ -166,6 +195,7 @@ private fun AgentTaskDto.toModel(): AgentTask? {
         branchName = branchName.takeIf { it.isNotBlank() },
         attachAndyMcp = attachAndyMcp,
         autonomy = AgentAutonomy.entries.firstOrNull { it.name == autonomy } ?: AgentAutonomy.Standard,
+        sandboxMode = AgentSandboxMode.entries.firstOrNull { it.name == sandboxMode },
         model = model.takeIf { it.isNotBlank() },
         reasoningEffort = AgentReasoningEffort.entries.firstOrNull { it.name == reasoningEffort },
         fastMode = fastMode,
@@ -173,6 +203,18 @@ private fun AgentTaskDto.toModel(): AgentTask? {
         skills = skillNames.zip(skillPaths).filter { (_, path) -> path.isNotBlank() }.map { (name, path) ->
             AgentSkill(name = name, description = "", path = path)
         },
+        goal = goal.takeIf { it.isNotBlank() },
+        queuedFollowUps = queuedFollowUps.mapNotNull { queued ->
+            queued.text.takeIf { it.isNotBlank() || queued.imagePaths.isNotEmpty() }?.let { text ->
+                AgentQueuedFollowUp(
+                    text = text,
+                    imagePaths = queued.imagePaths,
+                    skills = queued.skillNames.zip(queued.skillPaths)
+                    .filter { (_, path) -> path.isNotBlank() }
+                    .map { (name, path) -> AgentSkill(name = name, description = "", path = path) },
+                )
+            }
+        } + listOfNotNull(legacyQueuedFollowUp),
         maxBudgetUsd = maxBudgetUsd.takeIf { it > 0 },
         changeBaselinePaths = changeBaselinePaths,
         hasChangeBaseline = hasChangeBaseline,
@@ -209,6 +251,7 @@ private fun AgentStoreState.toFileDto(): AgentsFileDto = AgentsFileDto(
             reasoningEffort = defaults.reasoningEffort?.name.orEmpty(),
             fastMode = defaults.fastMode,
             autonomy = defaults.autonomy.name,
+            sandboxMode = defaults.sandboxMode?.name.orEmpty(),
             useWorktree = defaults.useWorktree,
             attachAndyMcp = defaults.attachAndyMcp,
             maxBudgetUsd = defaults.maxBudgetUsd ?: 0.0,
@@ -233,12 +276,22 @@ private fun AgentStoreState.toFileDto(): AgentsFileDto = AgentsFileDto(
             branchName = task.branchName.orEmpty(),
             attachAndyMcp = task.attachAndyMcp,
             autonomy = task.autonomy.name,
+            sandboxMode = task.sandboxMode?.name.orEmpty(),
             model = task.model.orEmpty(),
             reasoningEffort = task.reasoningEffort?.name.orEmpty(),
             fastMode = task.fastMode,
             imagePaths = task.imagePaths,
             skillNames = task.skills.map { it.name },
             skillPaths = task.skills.map { it.path },
+            goal = task.goal.orEmpty(),
+            queuedFollowUps = task.queuedFollowUps.map { queued ->
+                AgentQueuedFollowUpDto(
+                    text = queued.text,
+                    imagePaths = queued.imagePaths,
+                    skillNames = queued.skills.map { it.name },
+                    skillPaths = queued.skills.map { it.path },
+                )
+            },
             maxBudgetUsd = task.maxBudgetUsd ?: 0.0,
             changeBaselinePaths = task.changeBaselinePaths,
             hasChangeBaseline = task.hasChangeBaseline,

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
@@ -4,6 +4,7 @@ import app.andy.model.AgentAutonomy
 import app.andy.model.AgentEvent
 import app.andy.model.AgentKind
 import app.andy.model.AgentReasoningEffort
+import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentTask
 import app.andy.model.estimatedTokenCostUsd
 import kotlin.test.Test
@@ -38,6 +39,17 @@ class ClaudeCodeAdapterTest {
     @Test
     fun fullAutonomySkipsPermissions() {
         val argv = adapter.buildCommand("/bin/claude", task(AgentKind.ClaudeCode, autonomy = AgentAutonomy.Full), mcpUrl = null)
+        assertTrue("--dangerously-skip-permissions" in argv)
+        assertTrue("--permission-mode" !in argv)
+    }
+
+    @Test
+    fun explicitPermissionModeOverridesAutonomy() {
+        val argv = adapter.buildCommand(
+            "/bin/claude",
+            task(AgentKind.ClaudeCode).copy(sandboxMode = AgentSandboxMode.None),
+            mcpUrl = null,
+        )
         assertTrue("--dangerously-skip-permissions" in argv)
         assertTrue("--permission-mode" !in argv)
     }
@@ -129,6 +141,15 @@ class CodexAdapterTest {
     fun buildsExecCommandWithSandbox() {
         val argv = adapter.buildCommand("/bin/codex", task(AgentKind.Codex), mcpUrl = null)
         assertEquals(listOf("/bin/codex", "exec", "--json", "-C", "/tmp/repo", "--skip-git-repo-check", "--sandbox", "workspace-write", "do the thing"), argv)
+    }
+
+    @Test
+    fun explicitNoSandboxOverridesAutonomy() {
+        val configured = task(AgentKind.Codex).copy(sandboxMode = AgentSandboxMode.None)
+        val argv = adapter.buildCommand("/bin/codex", configured, mcpUrl = null)
+
+        assertTrue("--dangerously-bypass-approvals-and-sandbox" in argv)
+        assertTrue("--sandbox" !in argv)
     }
 
     @Test
@@ -269,6 +290,16 @@ class AntigravityAdapterTest {
     }
 
     @Test
+    fun explicitPermissionModeOverridesAutonomy() {
+        val argv = adapter.buildCommand(
+            "/bin/agy",
+            task(AgentKind.Antigravity).copy(sandboxMode = AgentSandboxMode.None),
+            mcpUrl = null,
+        )
+        assertTrue("--dangerously-skip-permissions" in argv)
+    }
+
+    @Test
     fun selectedModelAndLevelBecomeAntigravityVariant() {
         val configured = task(AgentKind.Antigravity).copy(model = "Gemini 3.5 Flash", reasoningEffort = AgentReasoningEffort.High)
         val argv = adapter.buildCommand("/bin/agy", configured, mcpUrl = null)
@@ -288,6 +319,24 @@ class CursorAdapterTest {
         )
         val argv = adapter.buildCommand("/bin/cursor-agent", configured, mcpUrl = null)
         assertTrue("--model" in argv && "Grok 4.5 High Fast" in argv)
+    }
+
+    @Test
+    fun explicitSandboxModeUsesCursorSandboxFlags() {
+        val disabled = adapter.buildCommand(
+            "/bin/cursor-agent",
+            task(AgentKind.Cursor).copy(sandboxMode = AgentSandboxMode.None),
+            mcpUrl = null,
+        )
+        assertTrue("--sandbox" in disabled && "disabled" in disabled)
+
+        val readOnly = adapter.buildCommand(
+            "/bin/cursor-agent",
+            task(AgentKind.Cursor).copy(sandboxMode = AgentSandboxMode.ReadOnly),
+            mcpUrl = null,
+        )
+        assertTrue("--mode" in readOnly && "plan" in readOnly)
+        assertTrue("--sandbox" in readOnly && "enabled" in readOnly)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentRunEndToEndTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentRunEndToEndTest.kt
@@ -199,6 +199,90 @@ class AgentRetryTest {
     }
 }
 
+class AgentQueuedFollowUpTest {
+    @Test
+    fun startsQueuedFollowUpAfterTheCurrentRunCompletes() = runBlocking {
+        val shell = File("/bin/sh")
+        if (!shell.canExecute()) return@runBlocking
+        val dir = File.createTempFile("andy-agent-queue", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val store = DesktopAgentTaskStore(File(dir, "agents.toml"))
+            store.save(AgentStoreState(binaryOverrides = mapOf(AgentKind.Codex.cliName to shell.absolutePath)))
+            val service = DesktopAgentRunService(
+                scope = scope,
+                store = store,
+                locator = AgentCliLocator(),
+                adapters = mapOf(AgentKind.Codex to QueueTestAdapter()),
+                worktrees = WorktreeManager(File(dir, "worktrees")),
+                mcp = FakeMcp(),
+                workspaceStore = FakeWorkspaceStore(),
+                actionConfig = FakeActionConfig(),
+            )
+            val task = service.createAndStart(
+                AgentTaskDraft(
+                    title = "queue test",
+                    prompt = "first message",
+                    agent = AgentKind.Codex,
+                    projectId = null,
+                    directory = dir.absolutePath,
+                ),
+            )
+            withTimeout(10_000) {
+                while (service.tasks.value.first { it.id == task.id }.vendorSessionId == null) delay(25)
+            }
+
+            service.queueFollowUp(task.id, "second message")
+            service.queueFollowUp(task.id, "third message")
+            assertEquals(
+                listOf("second message", "third message"),
+                service.tasks.value.first { it.id == task.id }.queuedFollowUps.map { it.text },
+            )
+
+            withTimeout(10_000) {
+                while (service.tasks.value.first { it.id == task.id }.isActive) delay(25)
+            }
+            val finished = service.tasks.value.first { it.id == task.id }
+            assertEquals(AgentTaskStatus.Completed, finished.status)
+            assertTrue(finished.queuedFollowUps.isEmpty())
+            assertTrue(
+                service.events(task.id).value.filterIsInstance<AgentEvent.UserMessage>().map { it.text } == listOf("second message", "third message"),
+            )
+        } finally {
+            scope.cancel()
+            dir.deleteRecursively()
+        }
+    }
+}
+
+private class QueueTestAdapter : AgentCliAdapter {
+    override val kind = AgentKind.Codex
+    override val supportsHeadlessResume = true
+    override val supportsStreamJson = false
+
+    override fun buildCommand(binary: String, task: AgentTask, mcpUrl: String?): List<String> =
+        listOf(binary, "-c", "printf 'session\\n'; sleep 1")
+
+    override fun buildResumeCommand(
+        binary: String,
+        task: AgentTask,
+        followUp: String,
+        imagePaths: List<String>,
+        mcpUrl: String?,
+    ): List<String> = listOf(binary, "-c", "printf 'resumed\\n'")
+
+    override fun interactiveResumeCommand(binary: String, task: AgentTask): String = binary
+
+    override fun parseLine(line: String, nowMillis: Long): List<AgentEvent> = when (line) {
+        "session" -> listOf(AgentEvent.SessionStarted(nowMillis, "queue-test-session", null))
+        "resumed" -> listOf(AgentEvent.AssistantText(nowMillis, "queued response"))
+        else -> emptyList()
+    }
+}
+
 private class FakeMcp : McpServerService {
     override val status = MutableStateFlow("stopped")
     override val running = MutableStateFlow(false)

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStoreTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStoreTest.kt
@@ -4,6 +4,9 @@ import app.andy.model.AgentAutonomy
 import app.andy.model.AgentKind
 import app.andy.model.AgentReasoningEffort
 import app.andy.model.AgentProviderDefaults
+import app.andy.model.AgentQueuedFollowUp
+import app.andy.model.AgentSandboxMode
+import app.andy.model.AgentSkill
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskStatus
 import java.io.File
@@ -39,9 +42,19 @@ class DesktopAgentTaskStoreTest {
             branchName = "andy/codex/fix-abc",
             attachAndyMcp = true,
             autonomy = AgentAutonomy.Full,
+            sandboxMode = AgentSandboxMode.None,
             model = "gpt-5.6-sol",
             reasoningEffort = AgentReasoningEffort.ExtraHigh,
             imagePaths = listOf("/tmp/reference.png"),
+            goal = "Ship the regression fix with coverage",
+            queuedFollowUps = listOf(
+                AgentQueuedFollowUp(
+                    text = "run the verification suite next",
+                    imagePaths = listOf("/tmp/next.png"),
+                    skills = listOf(AgentSkill("verify", "", "/tmp/verify/SKILL.md")),
+                ),
+                AgentQueuedFollowUp(text = "then summarize the results"),
+            ),
             maxBudgetUsd = 2.5,
             status = AgentTaskStatus.Completed,
             vendorSessionId = "t-99",
@@ -92,6 +105,7 @@ class DesktopAgentTaskStoreTest {
             model = "gpt-5.6-terra",
             reasoningEffort = AgentReasoningEffort.High,
             autonomy = AgentAutonomy.Full,
+            sandboxMode = AgentSandboxMode.None,
             useWorktree = true,
             attachAndyMcp = true,
             maxBudgetUsd = 4.0,


### PR DESCRIPTION
## Summary
- add explicit, provider-aware sandbox and permission controls to agent task creation and defaults
- add persistent `/goal` handling plus queued follow-ups that resume after a successful agent response
- improve CLI readiness diagnostics, provider invocation flags, skill discovery, persistence migration, and test coverage

## Validation
- `./gradlew desktopTest --rerun-tasks`
- `git diff --check`

## Impact
Agent runs can now retain an objective across turns, safely queue subsequent work, and expose provider-specific execution controls without conflating them with the autonomy preset.