### PR TITLE
Fix macOS update installer stdin redirect

### DIFF
--- a/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
@@ -275,11 +275,7 @@ class DesktopAppUpdateService(
                 // Keep the helper fully detached from Andy. In particular, it
                 // must only hand the archive to macOS and never share the
                 // app's streams or run a follow-up relaunch command.
-                ProcessBuilder("/bin/sh", helper.absolutePath)
-                    .redirectInput(ProcessBuilder.Redirect.DISCARD)
-                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-                    .redirectError(ProcessBuilder.Redirect.DISCARD)
-                    .start()
+                macInstallerProcessBuilder(helper.absolutePath).start()
                 exitProcess(0)
             }
             UpdatePlatform.LinuxDeb -> {
@@ -458,6 +454,13 @@ internal fun macPkgInstallerHelperScript(pkgPath: String): String {
         exec /usr/bin/open -W ${pkgPath.shellQuote()}
     """.trimIndent() + "\n"
 }
+
+internal fun macInstallerProcessBuilder(helperPath: String): ProcessBuilder =
+    // Redirect.DISCARD is WRITE-typed and cannot be used for stdin.
+    ProcessBuilder("/bin/sh", helperPath)
+        .redirectInput(File("/dev/null"))
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
 
 internal fun linuxInstallerHelperScript(
     filePath: String,

--- a/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
@@ -41,4 +41,13 @@ class DesktopAppUpdateServiceTest {
         assertTrue(script.contains("exec /usr/bin/open -W '/tmp/Andy-1.2.3.pkg'"))
         assertTrue(!script.contains("open -a Andy"))
     }
+
+    @Test
+    fun macInstallerDetachesWithoutUsingDiscardForStdin() {
+        val builder = macInstallerProcessBuilder("/tmp/andy-update.sh")
+
+        assertEquals(java.io.File("/dev/null"), builder.redirectInput().file())
+        assertEquals(ProcessBuilder.Redirect.DISCARD, builder.redirectOutput())
+        assertEquals(ProcessBuilder.Redirect.DISCARD, builder.redirectError())
+    }
 }


### PR DESCRIPTION
## Summary
- macOS in-app update failed at installer handoff with `Redirect invalid for reading: WRITE` because `ProcessBuilder.redirectInput(Redirect.DISCARD)` is invalid (`DISCARD` is WRITE-typed).
- Redirect stdin from `/dev/null` instead, keep `DISCARD` for stdout/stderr, and add a regression test.

## Test plan
- [x] `./gradlew :desktopTest --tests "app.andy.desktop.updates.DesktopAppUpdateServiceTest"`
- [ ] On macOS, check for updates and install an available build; confirm it gets past “Starting installer…” without the redirect error


Made with [Cursor](https://cursor.com)