### PR TITLE
Paginate project sessions and harden workspace cleanup

### DIFF
--- a/.andy/actions.toml
+++ b/.andy/actions.toml
@@ -1,5 +1,7 @@
-# Starter actions for running Andy from this checkout. Andy loads this only when
-# ~/.andy/actions.toml does not exist, so it never overwrites personal projects.
+# Starter actions for running Andy from this checkout.
+# Andy seeds these projects only when ~/.andy/actions.toml does not exist.
+# If that file already exists, deleted projects stay deleted; matching projects
+# still pick up any new starter actions in memory without rewriting the file.
 version = 1
 
 [[projects]]

--- a/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -412,14 +412,16 @@ private fun ProjectCockpit(
                         val sessions = agentTasks.filter { it.projectId == project.id }
                         scope.launch {
                             sessions.forEach { task ->
-                                services.agentRuns.delete(task.id, task.worktreePath != null)
+                                runCatching {
+                                    services.agentRuns.delete(task.id, task.worktreePath != null)
+                                }
                             }
+                            if (selectedProjectId == project.id) {
+                                selectedProjectId = null
+                                selectedTaskId = null
+                            }
+                            onConfigChange(config.copy(projects = config.projects.filterNot { it.id == project.id }))
                         }
-                        if (selectedProjectId == project.id) {
-                            selectedProjectId = null
-                            selectedTaskId = null
-                        }
-                        onConfigChange(config.copy(projects = config.projects.filterNot { it.id == project.id }))
                     }
                 }
             },

--- a/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -122,6 +122,9 @@ private data class EditingNote(val projectId: String, val note: ProjectNote?)
 private enum class ProjectRightPane { Chat, ActionOutput }
 private enum class ProjectCanvas { Actions, Notes, Sessions }
 
+private const val InitialSessionVisibleCount = 7
+private const val SessionVisiblePageSize = 10
+
 @Composable
 private fun ProjectCockpit(
     services: AndyServices,
@@ -143,14 +146,19 @@ private fun ProjectCockpit(
     var editingProject by remember { mutableStateOf<EditingProject?>(null) }
     var editingAction by remember { mutableStateOf<EditingAction?>(null) }
     var editingNote by remember { mutableStateOf<EditingNote?>(null) }
+    var pendingConfirmation by remember { mutableStateOf<PendingConfirmation?>(null) }
     var nowMillis by remember { mutableStateOf(System.currentTimeMillis()) }
     var completedNotesExpanded by remember { mutableStateOf(false) }
+    var sessionsVisibleCount by remember { mutableStateOf(InitialSessionVisibleCount) }
     var dockWidth by remember { mutableStateOf(680f) }
     var expandedActionId by remember { mutableStateOf<String?>(null) }
     var handledTerminalRunId by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(config.projects) {
         if (selectedProjectId !in config.projects.map { it.id }) selectedProjectId = config.projects.firstOrNull()?.id
+    }
+    LaunchedEffect(selectedProjectId) {
+        sessionsVisibleCount = InitialSessionVisibleCount
     }
     LaunchedEffect(terminalRunId, running) {
         val runId = terminalRunId ?: return@LaunchedEffect
@@ -318,7 +326,52 @@ private fun ProjectCockpit(
                         }
                         ProjectCanvas.Sessions -> {
                             Text("Agent sessions", color = TextPrimary, fontFamily = DisplayFont, fontWeight = FontWeight.SemiBold, fontSize = 18.sp)
-                            if (projectTasks.isEmpty()) EmptyState("Start a chat from the work dock") else LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxSize()) { items(projectTasks, key = { it.id }) { task -> ProjectChatRow(task, task.id == selectedTaskId, nowMillis, onOpen = { selectedTaskId = task.id; workPane = ProjectRightPane.Chat; if (task.unread) services.agentRuns.markRead(task.id) }, onMarkUnread = { services.agentRuns.markUnread(task.id) }) } }
+                            if (projectTasks.isEmpty()) {
+                                EmptyState("Start a chat from the work dock")
+                            } else {
+                                val visibleSessions = projectTasks.take(sessionsVisibleCount)
+                                val remainingSessions = (projectTasks.size - sessionsVisibleCount).coerceAtLeast(0)
+                                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxSize()) {
+                                    items(visibleSessions, key = { it.id }) { task ->
+                                        ProjectChatRow(
+                                            task,
+                                            task.id == selectedTaskId,
+                                            nowMillis,
+                                            onOpen = {
+                                                selectedTaskId = task.id
+                                                workPane = ProjectRightPane.Chat
+                                                if (task.unread) services.agentRuns.markRead(task.id)
+                                            },
+                                            onMarkUnread = { services.agentRuns.markUnread(task.id) },
+                                        )
+                                    }
+                                    if (remainingSessions > 0) {
+                                        item(key = "view-more-sessions") {
+                                            val nextBatch = minOf(SessionVisiblePageSize, remainingSessions)
+                                            Row(
+                                                Modifier.fillMaxWidth()
+                                                    .background(AndyColors.Neutral900, RoundedCornerShape(AndyRadius.R3))
+                                                    .clickable { sessionsVisibleCount += SessionVisiblePageSize }
+                                                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                                            ) {
+                                                Box(Modifier.width(3.dp).height(28.dp).background(Cyan.copy(alpha = 0.72f), RoundedCornerShape(AndyRadius.R2)))
+                                                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                                                    Text("View more", color = TextPrimary, fontFamily = DisplayFont, fontWeight = FontWeight.SemiBold)
+                                                    Text(
+                                                        "Show $nextBatch of $remainingSessions older session${if (remainingSessions == 1) "" else "s"}",
+                                                        color = TextSecondary,
+                                                        fontFamily = MonoFont,
+                                                        fontSize = 10.sp,
+                                                    )
+                                                }
+                                                Text("+$nextBatch", color = Cyan, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 10.sp)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -343,9 +396,58 @@ private fun ProjectCockpit(
     }
         }
     }
-    editingProject?.let { edit -> ProjectDialog(edit.project, config.projects, { editingProject = null }) { updated -> editingProject = null; onConfigChange(config.copy(projects = if (edit.project == null) config.projects + updated else config.projects.map { if (it.id == updated.id) updated else it })) } }
+    editingProject?.let { edit ->
+        ProjectDialog(
+            project = edit.project,
+            existingProjects = config.projects,
+            onDismiss = { editingProject = null },
+            onDelete = edit.project?.let { project ->
+                {
+                    editingProject = null
+                    pendingConfirmation = PendingConfirmation(
+                        title = "Delete workspace?",
+                        message = "Removes \"${project.name}\" and its actions, notes, and agent sessions from Andy.",
+                        confirmLabel = "Delete",
+                    ) {
+                        val sessions = agentTasks.filter { it.projectId == project.id }
+                        scope.launch {
+                            sessions.forEach { task ->
+                                services.agentRuns.delete(task.id, task.worktreePath != null)
+                            }
+                        }
+                        if (selectedProjectId == project.id) {
+                            selectedProjectId = null
+                            selectedTaskId = null
+                        }
+                        onConfigChange(config.copy(projects = config.projects.filterNot { it.id == project.id }))
+                    }
+                }
+            },
+        ) { updated ->
+            editingProject = null
+            onConfigChange(
+                config.copy(
+                    projects = if (edit.project == null) {
+                        config.projects + updated
+                    } else {
+                        config.projects.map { if (it.id == updated.id) updated else it }
+                    },
+                ),
+            )
+        }
+    }
     editingAction?.let { edit -> ActionDialog(config.projects, edit.projectId, edit.action, { editingAction = null }) { projectId, action -> editingAction = null; onConfigChange(config.copy(projects = config.projects.map { project -> if (project.id == projectId) project.copy(actions = project.actions.filterNot { it.id == action.id } + action) else project })) } }
     editingNote?.let { edit -> NoteDialog(config.projects, edit.projectId, edit.note, { editingNote = null }) { note -> editingNote = null; onConfigChange(config.copy(projects = config.projects.map { project -> if (project.id == edit.projectId) project.copy(notes = project.notes.filterNot { it.id == note.id } + note) else project })) } }
+    pendingConfirmation?.let { confirmation ->
+        ConfirmationDialog(
+            confirmation = confirmation,
+            onDismiss = { pendingConfirmation = null },
+            onConfirm = {
+                pendingConfirmation = null
+                confirmation.onConfirm()
+            },
+        )
+    }
 }
 
 @Composable
@@ -510,7 +612,13 @@ private fun ProjectChatRow(
 }
 
 @Composable
-private fun ProjectDialog(project: ActionProject?, existingProjects: List<ActionProject>, onDismiss: () -> Unit, onSave: (ActionProject) -> Unit) {
+private fun ProjectDialog(
+    project: ActionProject?,
+    existingProjects: List<ActionProject>,
+    onDismiss: () -> Unit,
+    onDelete: (() -> Unit)? = null,
+    onSave: (ActionProject) -> Unit,
+) {
     val scope = rememberCoroutineScope()
     var name by remember(project?.id) { mutableStateOf(project?.name.orEmpty()) }
     var contextDir by remember(project?.id) { mutableStateOf(project?.contextDir.orEmpty()) }
@@ -551,7 +659,17 @@ private fun ProjectDialog(project: ActionProject?, existingProjects: List<Action
                 colors = primaryButtonColors(),
             ) { Text("Save") }
         },
-        dismissButton = { OutlinedButton(onClick = onDismiss) { Text("Cancel") } },
+        dismissButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (onDelete != null) {
+                    OutlinedButton(
+                        onClick = onDelete,
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = Red),
+                    ) { Text("Delete") }
+                }
+                OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+            }
+        },
     )
 }
 

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
@@ -24,7 +24,7 @@ class DesktopActionConfigStore(
                     .resolveRelativeProjectPaths(source.parentFile?.parentFile ?: File(System.getProperty("user.dir")))
             }
             ?: ActionsConfig()
-        val personalFileExists = file.exists()
+        val personalFileExists = file.isFile
         val personal = if (!personalFileExists) {
             ActionsConfig()
         } else {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
@@ -25,15 +25,18 @@ class DesktopActionConfigStore(
             }
             ?: ActionsConfig()
         val personalFileExists = file.isFile
+        var seedMissingProjects = !personalFileExists
         val personal = if (!personalFileExists) {
             ActionsConfig()
         } else {
             decode(file).getOrElse {
                 file.copyTo(File(file.absolutePath + ".corrupt"), overwrite = true)
+                // Unreadable personal config is not an intentional project deletion.
+                seedMissingProjects = true
                 ActionsConfig()
             }
         }
-        personal.mergeMissingStarterActions(starter, seedMissingProjects = !personalFileExists)
+        personal.mergeMissingStarterActions(starter, seedMissingProjects = seedMissingProjects)
     }
 
     override suspend fun save(config: ActionsConfig): Unit = withContext(Dispatchers.IO) {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
@@ -24,7 +24,8 @@ class DesktopActionConfigStore(
                     .resolveRelativeProjectPaths(source.parentFile?.parentFile ?: File(System.getProperty("user.dir")))
             }
             ?: ActionsConfig()
-        val personal = if (!file.exists()) {
+        val personalFileExists = file.exists()
+        val personal = if (!personalFileExists) {
             ActionsConfig()
         } else {
             decode(file).getOrElse {
@@ -32,7 +33,7 @@ class DesktopActionConfigStore(
                 ActionsConfig()
             }
         }
-        personal.mergeMissingStarterActions(starter)
+        personal.mergeMissingStarterActions(starter, seedMissingProjects = !personalFileExists)
     }
 
     override suspend fun save(config: ActionsConfig): Unit = withContext(Dispatchers.IO) {
@@ -162,15 +163,26 @@ private fun ActionsConfig.resolveRelativeProjectPaths(workspace: File): ActionsC
     },
 )
 
-/** Adds checkout-provided actions without changing or persisting personal configuration. */
-private fun ActionsConfig.mergeMissingStarterActions(starter: ActionsConfig): ActionsConfig {
+/**
+ * Merges checkout-provided starter data without persisting it.
+ *
+ * Missing starter *projects* are only seeded when the user has no personal
+ * actions.toml yet. Once that file exists, deleted projects stay deleted;
+ * matching projects still receive any new starter actions in memory.
+ */
+private fun ActionsConfig.mergeMissingStarterActions(
+    starter: ActionsConfig,
+    seedMissingProjects: Boolean,
+): ActionsConfig {
     val merged = projects.toMutableList()
     starter.projects.forEach { starterProject ->
         val existingIndex = merged.indexOfFirst { project ->
             project.contextDir == starterProject.contextDir || project.id == starterProject.id
         }
         if (existingIndex < 0) {
-            merged += starterProject
+            if (seedMissingProjects) {
+                merged += starterProject
+            }
         } else {
             val existing = merged[existingIndex]
             val additions = starterProject.actions.filter { starterAction ->

--- a/src/desktopTest/kotlin/app/andy/AndyDesktopScreenshotTest.kt
+++ b/src/desktopTest/kotlin/app/andy/AndyDesktopScreenshotTest.kt
@@ -12,10 +12,16 @@ import androidx.compose.ui.test.v2.runDesktopComposeUiTest
 import androidx.compose.ui.unit.dp
 import app.andy.ui.screenshots.AndyScreenshotApp
 import app.andy.ui.screenshots.AndyScreenshotScenario
+import com.github.takahirom.roborazzi.RoborazziOptions
 import io.github.takahirom.roborazzi.captureRoboImage
 import kotlin.test.Test
 
 class AndyDesktopScreenshotTest {
+    // Sub-pixel antialiasing on CI runners can flip a few pixels against freshly
+    // recorded baselines. Keep the threshold tight so real UI changes still fail.
+    private val screenshotOptions = RoborazziOptions(
+        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0.0002f),
+    )
     private val routeScenarios = listOf(
         AndyScreenshotScenario.DevicesPopulated,
         AndyScreenshotScenario.CatalogImages,
@@ -68,7 +74,10 @@ class AndyDesktopScreenshotTest {
                         onNodeWithText(tab).performClick()
                         waitForIdle()
                     }
-                    onRoot().captureRoboImage(filePath = "src/screenshotTest/roborazzi/${baselinePlatform()}/${scenario.fileName}")
+                    onRoot().captureRoboImage(
+                        filePath = "src/screenshotTest/roborazzi/${baselinePlatform()}/${scenario.fileName}",
+                        roborazziOptions = screenshotOptions,
+                    )
                 }
             }
         } finally {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
@@ -74,6 +74,51 @@ class DesktopActionConfigStoreTest {
     }
 
     @Test
+    fun doesNotReseedDeletedStarterProjectWhenPersonalConfigurationExists() = runBlocking {
+        val dir = createTempDirectory("andy-actions-no-reseed").toFile()
+        val workspace = dir.resolve("workspace").apply { mkdirs() }
+        val homeConfig = dir.resolve("home/actions.toml").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                version = 1
+                [[projects]]
+                id = "proj-other"
+                name = "Other"
+                contextDir = "/tmp/other"
+                env = { }
+                """.trimIndent() + "\n",
+            )
+        }
+        val starter = workspace.resolve(".andy/actions.toml").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                version = 1
+                [[projects]]
+                id = "andy"
+                name = "Andy"
+                contextDir = "."
+                env = { }
+                [[actions]]
+                id = "record"
+                projectId = "andy"
+                name = "Record screenshots"
+                icon = "test"
+                command = "./gradlew recordRoborazziDesktop"
+                cwd = ""
+                env = { }
+                """.trimIndent() + "\n",
+            )
+        }
+
+        val loaded = DesktopActionConfigStore(homeConfig, starter).load()
+
+        assertEquals(listOf("proj-other"), loaded.projects.map { it.id })
+        assertFalse(loaded.projects.any { it.name == "Andy" })
+    }
+
+    @Test
     fun mergesScreenshotStarterActionIntoExistingPersonalProject() = runBlocking {
         val dir = createTempDirectory("andy-actions-merge").toFile()
         val workspace = dir.resolve("workspace").apply { mkdirs() }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
@@ -119,6 +119,42 @@ class DesktopActionConfigStoreTest {
     }
 
     @Test
+    fun reseedsStarterProjectsWhenPersonalConfigurationIsCorrupt() = runBlocking {
+        val dir = createTempDirectory("andy-actions-corrupt-reseed").toFile()
+        val workspace = dir.resolve("workspace").apply { mkdirs() }
+        val homeConfig = dir.resolve("home/actions.toml").apply {
+            parentFile.mkdirs()
+            writeText("[[projects]\nid = \"unterminated\"")
+        }
+        val starter = workspace.resolve(".andy/actions.toml").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                version = 1
+                [[projects]]
+                id = "andy"
+                name = "Andy"
+                contextDir = "."
+                env = { }
+                [[actions]]
+                id = "record"
+                projectId = "andy"
+                name = "Record screenshots"
+                icon = "test"
+                command = "./gradlew recordRoborazziDesktop"
+                cwd = ""
+                env = { }
+                """.trimIndent() + "\n",
+            )
+        }
+
+        val loaded = DesktopActionConfigStore(homeConfig, starter).load()
+
+        assertEquals(listOf("andy"), loaded.projects.map { it.id })
+        assertTrue(File(homeConfig.absolutePath + ".corrupt").exists())
+    }
+
+    @Test
     fun mergesScreenshotStarterActionIntoExistingPersonalProject() = runBlocking {
         val dir = createTempDirectory("andy-actions-merge").toFile()
         val workspace = dir.resolve("workspace").apply { mkdirs() }


### PR DESCRIPTION
## Summary
- Show the 7 most recent agent sessions under a project, with View more loading 10 at a time
- Add confirmed workspace delete that also removes that project's agent sessions
- Once `~/.andy/actions.toml` exists, do not re-seed deleted starter projects; matching projects still pick up new starter actions in memory

## Test plan
- [x] `./gradlew :compileKotlinDesktop desktopTest --tests 'app.andy.desktop.service.DesktopActionConfigStoreTest'`
- [ ] Open a project with >7 sessions and confirm only 7 show until View more
- [ ] Click View more repeatedly and confirm batches of 10 until exhausted
- [ ] Switch workspaces and confirm the visible count resets to 7
- [ ] Delete a workspace and confirm sessions for that project are removed
- [ ] With an existing personal actions.toml, confirm a deleted starter project stays gone


Made with [Cursor](https://cursor.com)