### PR TITLE
Add View menu Pop Out Mirror and icon attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,6 @@ The images below are approved macOS visual-test baselines. The full [screenshot 
 - mitmproxy for Network capture and rewrite rules: `brew install mitmproxy`.
 - scrcpy does not need to be installed separately for embedded mirroring; Andy bundles `scrcpy-server`.
 - Optional agent CLIs for Projects and Agents: Claude Code (`claude`), Codex (`codex`), Cursor Agent (`cursor-agent`), or Antigravity (`agy`).
+
+### Icon Attribution
+<a href="https://www.flaticon.com/free-icons/robot" title="robot icons">Robot icons created by Smashicons - Flaticon</a>

--- a/src/commonMain/kotlin/app/andy/AndyApp.kt
+++ b/src/commonMain/kotlin/app/andy/AndyApp.kt
@@ -50,11 +50,21 @@ fun AndyApp(
     services: AndyServices,
     requestedDestination: AndyDestination? = null,
     onDestinationConsumed: () -> Unit = {},
+    requestPopOutMirror: Boolean = false,
+    onPopOutMirrorRequestConsumed: () -> Unit = {},
     onPopOutMirror: (String?, String?) -> Unit = { _, _ -> },
     contentTopPadding: androidx.compose.ui.unit.Dp = 18.dp,
 ) {
     AndyTheme {
-        AndyShell(services, requestedDestination, onDestinationConsumed, onPopOutMirror, contentTopPadding)
+        AndyShell(
+            services = services,
+            requestedDestination = requestedDestination,
+            onDestinationConsumed = onDestinationConsumed,
+            requestPopOutMirror = requestPopOutMirror,
+            onPopOutMirrorRequestConsumed = onPopOutMirrorRequestConsumed,
+            onPopOutMirror = onPopOutMirror,
+            contentTopPadding = contentTopPadding,
+        )
     }
 }
 

--- a/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -88,8 +88,11 @@ internal fun AndyShell(
 
     LaunchedEffect(requestPopOutMirror) {
         if (!requestPopOutMirror) return@LaunchedEffect
-        val selectedDevice = state.devices.firstOrNull { it.serial == state.selectedSerial }
-        onPopOutMirror(state.selectedSerial, selectedDevice?.displayName ?: state.selectedSerial)
+        val serial = state.selectedSerial
+        if (serial != null) {
+            val selectedDevice = state.devices.firstOrNull { it.serial == serial }
+            onPopOutMirror(serial, selectedDevice?.displayName ?: serial)
+        }
         onPopOutMirrorRequestConsumed()
     }
 

--- a/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -60,6 +60,8 @@ internal fun AndyShell(
     services: AndyServices,
     requestedDestination: AndyDestination?,
     onDestinationConsumed: () -> Unit,
+    requestPopOutMirror: Boolean,
+    onPopOutMirrorRequestConsumed: () -> Unit,
     onPopOutMirror: (String?, String?) -> Unit,
     contentTopPadding: androidx.compose.ui.unit.Dp,
 ) {
@@ -82,6 +84,13 @@ internal fun AndyShell(
             state.setDestination(it)
             onDestinationConsumed()
         }
+    }
+
+    LaunchedEffect(requestPopOutMirror) {
+        if (!requestPopOutMirror) return@LaunchedEffect
+        val selectedDevice = state.devices.firstOrNull { it.serial == state.selectedSerial }
+        onPopOutMirror(state.selectedSerial, selectedDevice?.displayName ?: state.selectedSerial)
+        onPopOutMirrorRequestConsumed()
     }
 
     LaunchedEffect(state.workspaceState.mcpServerEnabled, state.workspaceState.mcpServerPort) {

--- a/src/desktopMain/kotlin/app/andy/desktop/Main.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/Main.kt
@@ -43,14 +43,19 @@ fun main() {
         val windowState = rememberWindowState(width = 1800.dp, height = 1040.dp)
         var visible by remember { mutableStateOf(true) }
         var requestedDestination by remember { mutableStateOf<AndyDestination?>(null) }
+        var requestPopOutMirror by remember { mutableStateOf(false) }
         var popOutSerial by remember { mutableStateOf<String?>(null) }
         var popOutDeviceName by remember { mutableStateOf<String?>(null) }
         var popOutControlsVisible by remember { mutableStateOf(false) }
-        val popOutToggleShortcut = KeyShortcut(Key.D, ctrl = !isMacOs(), meta = isMacOs(), shift = true)
+        val popOutMirrorShortcut = KeyShortcut(Key.D, ctrl = !isMacOs(), meta = isMacOs(), shift = true)
         val appIcon = painterResource(Res.drawable.andy_robot)
         fun open(destination: AndyDestination) {
             requestedDestination = destination
             visible = true
+        }
+        fun openPopOutMirror() {
+            visible = true
+            requestPopOutMirror = true
         }
         fun quitApp() {
             runBlocking { services.mirror.disconnect() }
@@ -104,11 +109,20 @@ fun main() {
                         )
                     }
                 }
+                Menu("View") {
+                    Item(
+                        "Pop Out Mirror",
+                        shortcut = popOutMirrorShortcut,
+                        onClick = { openPopOutMirror() },
+                    )
+                }
             }
             AndyApp(
                 services = services,
                 requestedDestination = requestedDestination,
                 onDestinationConsumed = { requestedDestination = null },
+                requestPopOutMirror = requestPopOutMirror,
+                onPopOutMirrorRequestConsumed = { requestPopOutMirror = false },
                 onPopOutMirror = { serial, name ->
                     popOutSerial = serial
                     popOutDeviceName = name
@@ -130,7 +144,7 @@ fun main() {
                             text = "Show controls",
                             checked = popOutControlsVisible,
                             onCheckedChange = { popOutControlsVisible = it },
-                            shortcut = popOutToggleShortcut,
+                            shortcut = popOutMirrorShortcut,
                         )
                     }
                 }
@@ -218,7 +232,7 @@ private fun AndyDestination.menuShortcut(): KeyShortcut {
         AndyDestination.Snapshots -> KeyShortcut(Key.S, meta = meta, ctrl = ctrl, shift = true)
         AndyDestination.Controls -> KeyShortcut(Key.C, meta = meta, ctrl = ctrl, shift = true)
         AndyDestination.Performance -> KeyShortcut(Key.P, meta = meta, ctrl = ctrl, shift = true)
-        // Shift+D is already used by the mirror pop-out "Show controls" toggle.
+        // Shift+D is already used by View → Pop Out Mirror / Show controls.
         AndyDestination.Design -> KeyShortcut(Key.E, meta = meta, ctrl = ctrl, shift = true)
         AndyDestination.Accessibility -> KeyShortcut(Key.A, meta = meta, ctrl = ctrl, shift = true)
         AndyDestination.Bugs -> KeyShortcut(Key.B, meta = meta, ctrl = ctrl, shift = true)


### PR DESCRIPTION
## Summary
- Add a View → Pop Out Mirror menu item (Cmd/Ctrl+Shift+D) that requests a pop-out through `AndyApp`/`AndyShell` using the currently selected device
- Keep the same shortcut on the floating window “Show controls” toggle, with an updated Design-destination comment
- Credit the Flaticon robot icon used for Andy in the README

## Test plan
- [ ] `./gradlew compileKotlinDesktop`
- [ ] Launch desktop app, select a device, use View → Pop Out Mirror and confirm the mirror window opens
- [ ] Confirm Cmd/Ctrl+Shift+D still toggles Show controls when the pop-out window is focused
- [ ] Confirm README Icon Attribution link renders correctly


Made with [Cursor](https://cursor.com)