### PR TITLE
Use Cursor CLI kebab-case model slugs

### DIFF
--- a/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -96,7 +96,11 @@ data class AgentModelOption(
     val label: String,
     val efforts: List<AgentReasoningEffort>,
     val supportsFastMode: Boolean = false,
-)
+) {
+    /** Preferred effort when the CLI requires a suffix and the user left effort unset. */
+    fun preferredEffort(): AgentReasoningEffort? =
+        efforts.firstOrNull { it == AgentReasoningEffort.High } ?: efforts.firstOrNull()
+}
 
 /**
  * A small public catalog for the four CLIs, plus an exact custom-model escape hatch
@@ -117,12 +121,12 @@ object AgentModelCatalog {
             AgentModelOption("fable", "Fable", AgentReasoningEffort.entries.toList()),
         )
         AgentKind.Cursor -> listOf(
-            AgentModelOption("Auto", "Auto", emptyList()),
-            AgentModelOption("Composer 2.5", "Composer 2.5", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High, AgentReasoningEffort.ExtraHigh), supportsFastMode = true),
-            AgentModelOption("Opus 4.8", "Opus 4.8", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High, AgentReasoningEffort.ExtraHigh), supportsFastMode = true),
-            AgentModelOption("GPT-5.6 Sol", "GPT-5.6 Sol", listOf(AgentReasoningEffort.Medium, AgentReasoningEffort.High, AgentReasoningEffort.ExtraHigh), supportsFastMode = true),
-            AgentModelOption("Gemini 3.1 Pro", "Gemini 3.1 Pro", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High), supportsFastMode = true),
-            AgentModelOption("Grok 4.5", "Grok 4.5", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High), supportsFastMode = true),
+            AgentModelOption("auto", "Auto", emptyList()),
+            AgentModelOption("composer-2.5", "Composer 2.5", emptyList(), supportsFastMode = true),
+            AgentModelOption("claude-opus-4-8", "Opus 4.8", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High, AgentReasoningEffort.ExtraHigh), supportsFastMode = true),
+            AgentModelOption("gpt-5.6-sol", "GPT-5.6 Sol", listOf(AgentReasoningEffort.Medium, AgentReasoningEffort.High, AgentReasoningEffort.ExtraHigh), supportsFastMode = true),
+            AgentModelOption("gemini-3.1-pro", "Gemini 3.1 Pro", emptyList()),
+            AgentModelOption("cursor-grok-4.5", "Grok 4.5", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High), supportsFastMode = true),
         )
         AgentKind.Antigravity -> listOf(
             AgentModelOption("Gemini 3.5 Flash", "Gemini 3.5 Flash", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High)),
@@ -134,7 +138,24 @@ object AgentModelCatalog {
     }
 
     fun option(agent: AgentKind, id: String?): AgentModelOption? =
-        id?.let { modelId -> options(agent).firstOrNull { it.id == modelId } }
+        id?.let { modelId ->
+            val normalized = if (agent == AgentKind.Cursor) cursorModelBaseId(modelId) else modelId
+            options(agent).firstOrNull { it.id == normalized }
+        }
+}
+
+/**
+ * Cursor CLI model IDs are kebab-case slugs (`cursor-grok-4.5-high-fast`), not display names.
+ * Map legacy catalog labels so persisted tasks/defaults still resolve.
+ */
+internal fun cursorModelBaseId(selected: String): String = when (selected) {
+    "Auto", "auto" -> "auto"
+    "Composer 2.5", "composer-2.5" -> "composer-2.5"
+    "Opus 4.8", "claude-opus-4-8" -> "claude-opus-4-8"
+    "GPT-5.6 Sol", "gpt-5.6-sol" -> "gpt-5.6-sol"
+    "Gemini 3.1 Pro", "gemini-3.1-pro" -> "gemini-3.1-pro"
+    "Grok 4.5", "cursor-grok-4.5" -> "cursor-grok-4.5"
+    else -> selected
 }
 
 enum class AgentTaskStatus {
@@ -455,10 +476,18 @@ fun AgentTask.providerDefaults(): AgentProviderDefaults = AgentProviderDefaults(
 /** Provider-specific model string passed by the adapter. */
 fun AgentTask.modelForCli(): String? = model?.let { selected ->
     when (agent) {
-        AgentKind.Cursor -> buildString {
-            append(selected)
-            reasoningEffort?.let { append(' ').append(it.label.split(' ').joinToString(" ") { word -> word.replaceFirstChar(Char::uppercase) }) }
-            if (fastMode) append(" Fast")
+        AgentKind.Cursor -> {
+            val base = cursorModelBaseId(selected)
+            val catalog = AgentModelCatalog.option(AgentKind.Cursor, base)
+            buildString {
+                append(base)
+                // Cursor variants bake effort into the model id; bare bases like cursor-grok-4.5 are rejected.
+                val effort = reasoningEffort ?: catalog?.preferredEffort()
+                if (effort != null && catalog?.efforts?.isNotEmpty() == true) {
+                    append('-').append(effort.cliValue)
+                }
+                if (fastMode) append("-fast")
+            }
         }
         AgentKind.Antigravity -> reasoningEffort?.let { "$selected (${it.label.split(' ').joinToString(" ") { word -> word.replaceFirstChar(Char::uppercase) }})" } ?: selected
         else -> selected
@@ -531,9 +560,10 @@ fun AgentTask.estimatedTokenCostUsd(inputTokens: Long?, outputTokens: Long?): Do
     val price = when (agent) {
         AgentKind.Codex -> TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 10.0)
         AgentKind.Cursor -> when {
-            model == "Auto" -> TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 6.0)
-            model?.contains("Opus", ignoreCase = true) == true -> TokenPrice(inputUsdPerMillion = 5.0, outputUsdPerMillion = 25.0)
-            model?.contains("GPT", ignoreCase = true) == true -> TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 10.0)
+            model.equals("auto", ignoreCase = true) -> TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 6.0)
+            model?.contains("opus", ignoreCase = true) == true -> TokenPrice(inputUsdPerMillion = 5.0, outputUsdPerMillion = 25.0)
+            model?.contains("gpt", ignoreCase = true) == true || model?.contains("sol", ignoreCase = true) == true ->
+                TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 10.0)
             else -> null
         }
         // Claude Code reports its billed total; Antigravity currently reports no token usage.

--- a/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -486,7 +486,8 @@ fun AgentTask.modelForCli(): String? = model?.let { selected ->
                 if (effort != null && catalog?.efforts?.isNotEmpty() == true) {
                     append('-').append(effort.cliValue)
                 }
-                if (fastMode) append("-fast")
+                // Catalog options gate -fast; custom exact slugs stay unadorned.
+                if (fastMode && catalog?.supportsFastMode == true) append("-fast")
             }
         }
         AgentKind.Antigravity -> reasoningEffort?.let { "$selected (${it.label.split(' ').joinToString(" ") { word -> word.replaceFirstChar(Char::uppercase) }})" } ?: selected
@@ -560,7 +561,7 @@ fun AgentTask.estimatedTokenCostUsd(inputTokens: Long?, outputTokens: Long?): Do
     val price = when (agent) {
         AgentKind.Codex -> TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 10.0)
         AgentKind.Cursor -> when {
-            model.equals("auto", ignoreCase = true) -> TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 6.0)
+            model?.equals("auto", ignoreCase = true) == true -> TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 6.0)
             model?.contains("opus", ignoreCase = true) == true -> TokenPrice(inputUsdPerMillion = 5.0, outputUsdPerMillion = 25.0)
             model?.contains("gpt", ignoreCase = true) == true || model?.contains("sol", ignoreCase = true) == true ->
                 TokenPrice(inputUsdPerMillion = 1.25, outputUsdPerMillion = 10.0)

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
@@ -239,7 +239,7 @@ private class AgentTaskComposerFormState(
         val catalogModel = AgentModelCatalog.option(agent, savedModel)
         modelId = when {
             savedModel == null -> null
-            catalogModel != null -> savedModel
+            catalogModel != null -> catalogModel.id
             else -> CUSTOM_MODEL_ID
         }
         customModel = if (catalogModel == null) savedModel.orEmpty() else ""
@@ -330,10 +330,15 @@ private fun rememberAgentTaskComposerForm(
         if (!state.directoryIsGitRepo) state.useWorktree = false
     }
     LaunchedEffect(state.agent, state.modelId) {
-        if (state.usesCustomModel || selectedModel?.efforts?.contains(state.reasoningEffort) != true) {
-            state.reasoningEffort = null
+        val model = selectedModel
+        when {
+            state.usesCustomModel || model == null || model.efforts.isEmpty() -> state.reasoningEffort = null
+            state.reasoningEffort !in model.efforts -> {
+                // Cursor encodes effort in the model slug; leaving it unset yields invalid ids like cursor-grok-4.5.
+                state.reasoningEffort = if (state.agent == AgentKind.Cursor) model.preferredEffort() else null
+            }
         }
-        if (selectedModel?.supportsFastMode != true) state.fastMode = false
+        if (model?.supportsFastMode != true) state.fastMode = false
     }
 
     return AgentTaskComposerForm(
@@ -618,7 +623,9 @@ private fun AgentChatComposer(
                     Box {
                         FilterPill(state.reasoningEffort?.label ?: "effort", state.reasoningEffort != null, Rust) { effortMenuExpanded = true }
                         DropdownMenu(expanded = effortMenuExpanded, onDismissRequest = { effortMenuExpanded = false }) {
-                            DropdownMenuItem(text = { Text("provider default", color = TextPrimary) }, onClick = { state.reasoningEffort = null; effortMenuExpanded = false })
+                            if (state.agent != AgentKind.Cursor) {
+                                DropdownMenuItem(text = { Text("provider default", color = TextPrimary) }, onClick = { state.reasoningEffort = null; effortMenuExpanded = false })
+                            }
                             selectedModel.efforts.forEach { effort -> DropdownMenuItem(text = { Text(effort.label, color = TextPrimary) }, onClick = { state.reasoningEffort = effort; effortMenuExpanded = false }) }
                         }
                     }
@@ -728,11 +735,15 @@ private fun AgentTaskComposerFields(
                     )
                     Text("Custom variants are passed as-is, so Andy does not add a reasoning or speed suffix.", color = TextSecondary, fontFamily = MonoFont, fontSize = 10.sp)
                 } else if (form.selectedModel != null) {
-                    Text("Reasoning", color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 11.sp)
-                    Row(Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        FilterPill("provider default", state.reasoningEffort == null, Cyan) { state.reasoningEffort = null }
-                        form.selectedModel.efforts.forEach { effort ->
-                            FilterPill(effort.label, state.reasoningEffort == effort, Rust) { state.reasoningEffort = effort }
+                    if (form.selectedModel.efforts.isNotEmpty()) {
+                        Text("Reasoning", color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 11.sp)
+                        Row(Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            if (state.agent != AgentKind.Cursor) {
+                                FilterPill("provider default", state.reasoningEffort == null, Cyan) { state.reasoningEffort = null }
+                            }
+                            form.selectedModel.efforts.forEach { effort ->
+                                FilterPill(effort.label, state.reasoningEffort == effort, Rust) { state.reasoningEffort = effort }
+                            }
                         }
                     }
                     if (form.selectedModel.supportsFastMode) {
@@ -740,7 +751,7 @@ private fun AgentTaskComposerFields(
                     }
                     Text(
                         when (state.agent) {
-                            AgentKind.Cursor -> "Cursor receives the selected provider variant, e.g. Grok 4.5 High Fast. Availability follows your Cursor account."
+                            AgentKind.Cursor -> "Cursor receives the selected provider variant, e.g. cursor-grok-4.5-high-fast. Availability follows your Cursor account."
                             AgentKind.Antigravity -> "Antigravity receives its model plus level as one variant; its installed CLI/account remains authoritative."
                             else -> "The selected model and reasoning level are passed directly to the ${state.agent.label} CLI."
                         },

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
@@ -397,12 +397,46 @@ class CursorAdapterTest {
     @Test
     fun sendsTheSelectedFastReasoningVariant() {
         val configured = task(AgentKind.Cursor).copy(
-            model = "Grok 4.5",
+            model = "cursor-grok-4.5",
             reasoningEffort = AgentReasoningEffort.High,
             fastMode = true,
         )
         val argv = adapter.buildCommand("/bin/cursor-agent", configured, mcpUrl = null)
-        assertTrue("--model" in argv && "Grok 4.5 High Fast" in argv)
+        assertTrue("--model" in argv && "cursor-grok-4.5-high-fast" in argv)
+    }
+
+    @Test
+    fun migratesLegacyCursorDisplayNameToCliSlug() {
+        val configured = task(AgentKind.Cursor).copy(
+            model = "Grok 4.5",
+            reasoningEffort = AgentReasoningEffort.Medium,
+            fastMode = false,
+        )
+        val argv = adapter.buildCommand("/bin/cursor-agent", configured, mcpUrl = null)
+        assertTrue("--model" in argv && "cursor-grok-4.5-medium" in argv)
+    }
+
+    @Test
+    fun defaultsGrokEffortWhenUnset() {
+        val configured = task(AgentKind.Cursor).copy(
+            model = "cursor-grok-4.5",
+            reasoningEffort = null,
+            fastMode = false,
+        )
+        val argv = adapter.buildCommand("/bin/cursor-agent", configured, mcpUrl = null)
+        assertTrue("--model" in argv && "cursor-grok-4.5-high" in argv)
+        assertTrue("cursor-grok-4.5" !in argv.filter { it.startsWith("cursor-grok") })
+    }
+
+    @Test
+    fun composerWithoutEffortDoesNotAppendSuffix() {
+        val configured = task(AgentKind.Cursor).copy(
+            model = "composer-2.5",
+            reasoningEffort = null,
+            fastMode = true,
+        )
+        val argv = adapter.buildCommand("/bin/cursor-agent", configured, mcpUrl = null)
+        assertTrue("--model" in argv && "composer-2.5-fast" in argv)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
@@ -440,6 +440,30 @@ class CursorAdapterTest {
     }
 
     @Test
+    fun dropsPersistedFastModeWhenCatalogNoLongerSupportsIt() {
+        val configured = task(AgentKind.Cursor).copy(
+            model = "Gemini 3.1 Pro",
+            reasoningEffort = null,
+            fastMode = true,
+        )
+        val argv = adapter.buildCommand("/bin/cursor-agent", configured, mcpUrl = null)
+        assertTrue("--model" in argv && "gemini-3.1-pro" in argv)
+        assertTrue("gemini-3.1-pro-fast" !in argv)
+    }
+
+    @Test
+    fun customCursorSlugDoesNotAppendFastSuffix() {
+        val configured = task(AgentKind.Cursor).copy(
+            model = "my-custom-model",
+            reasoningEffort = null,
+            fastMode = true,
+        )
+        val argv = adapter.buildCommand("/bin/cursor-agent", configured, mcpUrl = null)
+        assertTrue("--model" in argv && "my-custom-model" in argv)
+        assertTrue("my-custom-model-fast" !in argv)
+    }
+
+    @Test
     fun explicitSandboxModeUsesCursorSandboxFlags() {
         val disabled = adapter.buildCommand(
             "/bin/cursor-agent",


### PR DESCRIPTION
## Summary
- Switch Cursor catalog model ids to kebab-case CLI slugs (`cursor-grok-4.5`, `composer-2.5`, etc.) and append `-effort` / `-fast` instead of spaced display variants.
- Migrate legacy persisted display names, default Cursor effort when the CLI requires a suffix, and hide the non-functional "provider default" effort choice for Cursor.
- Update adapter parsing tests for slug construction and legacy migration.

## Test plan
- [x] `./gradlew desktopTest --tests 'app.andy.desktop.service.agents.CursorAdapterTest' --rerun-tasks`
- [ ] Launch a Cursor agent task with Grok / Opus / Composer and confirm `--model` receives a valid slug
- [ ] Confirm older saved tasks with display-name models still resolve in the composer


Made with [Cursor](https://cursor.com)