### PR TITLE
Fix macOS DMG update restart-and-install handoff

### DIFF
--- a/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
@@ -468,14 +468,24 @@ internal fun macDmgInstallerHelperScript(
         mount_point="${'$'}work_dir/mount"
         staging_app="${'$'}{target_app}.update"
         backup_app="${'$'}{target_app}.previous"
+        # Andy has already quit by the time install work starts; reopen it unless we
+        # successfully hand off to the replacement bundle.
+        should_reopen=1
 
         shell_quote() {
           printf "'%s'" "${'$'}(printf '%s' "${'$'}1" | /usr/bin/sed "s/'/'\\\"'\\\"'/g")"
         }
 
+        reopen_current_app() {
+          [ ! -d "${'$'}target_app" ] || /usr/bin/open "${'$'}target_app"
+        }
+
         cleanup() {
           /usr/bin/hdiutil detach "${'$'}mount_point" -quiet >/dev/null 2>&1 || true
           /bin/rm -rf "${'$'}work_dir"
+          if [ "${'$'}should_reopen" -eq 1 ]; then
+            reopen_current_app
+          fi
         }
         trap cleanup EXIT HUP INT TERM
 
@@ -484,7 +494,8 @@ internal fun macDmgInstallerHelperScript(
           /bin/sleep 0.1
         done
 
-        /usr/bin/mkdir -p "${'$'}mount_point"
+        # mkdir lives in /bin on macOS (not under /usr/bin).
+        /bin/mkdir -p "${'$'}mount_point"
         /usr/bin/hdiutil attach "${'$'}dmg_path" -nobrowse -readonly -mountpoint "${'$'}mount_point" >/dev/null
         source_app=""
         for candidate in "${'$'}mount_point"/*.app; do
@@ -513,13 +524,8 @@ internal fun macDmgInstallerHelperScript(
           fi
         }
 
-        reopen_current_app() {
-          [ ! -d "${'$'}target_app" ] || /usr/bin/open "${'$'}target_app"
-        }
-
         if [ -w "${'$'}(/usr/bin/dirname "${'$'}target_app")" ]; then
           if ! install_app; then
-            reopen_current_app
             exit 1
           fi
         else
@@ -527,11 +533,11 @@ internal fun macDmgInstallerHelperScript(
           admin_command="/bin/rm -rf ${'$'}(shell_quote "${'$'}staging_app") ${'$'}(shell_quote "${'$'}backup_app"); /usr/bin/ditto ${'$'}(shell_quote "${'$'}source_app") ${'$'}(shell_quote "${'$'}staging_app"); if [ -e ${'$'}(shell_quote "${'$'}target_app") ]; then /bin/mv ${'$'}(shell_quote "${'$'}target_app") ${'$'}(shell_quote "${'$'}backup_app"); fi; if /bin/mv ${'$'}(shell_quote "${'$'}staging_app") ${'$'}(shell_quote "${'$'}target_app"); then /bin/rm -rf ${'$'}(shell_quote "${'$'}backup_app"); else if [ -e ${'$'}(shell_quote "${'$'}backup_app") ]; then /bin/mv ${'$'}(shell_quote "${'$'}backup_app") ${'$'}(shell_quote "${'$'}target_app"); fi; exit 1; fi"
           escaped_command="${'$'}(printf '%s' "${'$'}admin_command" | /usr/bin/sed 's/\\\\/\\\\\\\\/g; s/\"/\\\\\"/g')"
           if ! /usr/bin/osascript -e "do shell script \"${'$'}escaped_command\" with administrator privileges"; then
-            reopen_current_app
             exit 1
           fi
         fi
 
+        should_reopen=0
         /usr/bin/open "${'$'}target_app"
     """.trimIndent() + "\n"
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/updates/DesktopAppUpdateService.kt
@@ -487,7 +487,8 @@ internal fun macDmgInstallerHelperScript(
             reopen_current_app
           fi
         }
-        trap cleanup EXIT HUP INT TERM
+        trap 'exit 1' HUP INT TERM
+        trap cleanup EXIT
 
         # Wait for Andy itself rather than relying on a fixed delay before changing its bundle.
         while /bin/kill -0 "${'$'}parent_pid" 2>/dev/null; do

--- a/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
@@ -43,10 +43,14 @@ class DesktopAppUpdateServiceTest {
             parentProcessId = 1234,
         )
 
+        // macOS ships mkdir under /bin, not /usr/bin.
+        assertTrue(script.contains("/bin/mkdir -p \"${'$'}mount_point\""))
+        assertTrue(script.lineSequence().none { it.trimStart().startsWith("/usr/bin/mkdir") })
         assertTrue(script.contains("/usr/bin/hdiutil attach \"${'$'}dmg_path\""))
         assertTrue(script.contains("/usr/bin/codesign --verify --deep --strict \"${'$'}source_app\""))
         assertTrue(script.contains("/usr/bin/ditto \"${'$'}source_app\" \"${'$'}staging_app\""))
         assertTrue(script.contains("with administrator privileges"))
+        assertTrue(script.contains("should_reopen=1"))
         assertTrue(script.contains("reopen_current_app"))
         assertTrue(script.contains("/usr/bin/open \"${'$'}target_app\""))
     }

--- a/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/updates/DesktopAppUpdateServiceTest.kt
@@ -52,6 +52,8 @@ class DesktopAppUpdateServiceTest {
         assertTrue(script.contains("with administrator privileges"))
         assertTrue(script.contains("should_reopen=1"))
         assertTrue(script.contains("reopen_current_app"))
+        assertTrue(script.contains("trap 'exit 1' HUP INT TERM"))
+        assertTrue(script.contains("trap cleanup EXIT"))
         assertTrue(script.contains("/usr/bin/open \"${'$'}target_app\""))
     }
 


### PR DESCRIPTION
## Summary
- The macOS in-place DMG updater called `/usr/bin/mkdir`, which does not exist on macOS (`mkdir` lives at `/bin/mkdir`), so restart-and-install quit Andy and never replaced or relaunched the app.
- Reopen Andy from the helper EXIT trap on any install failure after quit, and clear that flag only after a successful handoff to the updated bundle.
- Extend unit coverage for the `/bin/mkdir` path and `should_reopen` behavior.

## Test plan
- [x] `./gradlew :desktopTest --tests 'app.andy.desktop.updates.DesktopAppUpdateServiceTest'`
- [x] Reproduced the failure against the leftover helper (`/usr/bin/mkdir: No such file or directory`)
- [x] Verified the corrected helper installs and relaunches from the downloaded DMG
- [ ] After merge/release, confirm Restart and install closes Andy, replaces `/Applications/Andy.app`, and relaunches automatically


Made with [Cursor](https://cursor.com)