### PR TITLE
Keep mirror warm across tabs and persist recent intents

### DIFF
--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -64,8 +64,9 @@ interface MirrorEngine {
     suspend fun connect(serial: String, config: MirrorVideoConfig = MirrorVideoConfig()): CommandResult
     /**
      * Release the live session. By default implementations may keep the stream warm briefly so
-     * navigating between Live/Design/Accessibility can reuse scrcpy instead of black-screening.
-     * Pass [immediate] for shutdown, device changes, or other cases that must tear down now.
+     * navigating between Live/Design/Accessibility (and back) can reuse scrcpy instead of
+     * black-screening. Live and embedded panels no longer disconnect on leave; pass [immediate]
+     * for shutdown, device changes, or other cases that must tear down now.
      */
     suspend fun disconnect(immediate: Boolean = false)
     suspend fun sendInput(input: MirrorInput): CommandResult

--- a/src/commonMain/kotlin/app/andy/ui/intents/IntentsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/intents/IntentsScreen.kt
@@ -1,11 +1,12 @@
 package app.andy.ui.intents
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.LocalTextStyle
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,8 +18,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import app.andy.model.IntentDraft
 import app.andy.model.IntentMode
+import app.andy.model.WorkspaceState
 import app.andy.service.AndyServices
 import app.andy.ui.components.Button
 import app.andy.ui.components.FilterPill
@@ -30,11 +35,18 @@ import app.andy.ui.theme.Green
 import app.andy.ui.theme.Rust
 import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
-import androidx.compose.ui.unit.dp
+import androidx.compose.material3.LocalTextStyle
 import kotlinx.coroutines.launch
 
+private const val MaxRecentIntents = 10
+
 @Composable
-internal fun IntentsScreen(services: AndyServices, serial: String?) {
+internal fun IntentsScreen(
+    services: AndyServices,
+    serial: String?,
+    workspaceState: WorkspaceState,
+    onUpdateWorkspace: ((WorkspaceState) -> WorkspaceState) -> Unit,
+) {
     val intentService = services.intents
     val scope = rememberCoroutineScope()
     var mode by remember { mutableStateOf(IntentMode.DeepLink) }
@@ -44,6 +56,12 @@ internal fun IntentsScreen(services: AndyServices, serial: String?) {
     var result by remember { mutableStateOf("") }
     val draft = IntentDraft(mode = mode, action = action, component = component, dataUri = dataUri)
     val command = intentService.buildCommand(draft).joinToString(" ")
+    fun applyDraft(item: IntentDraft) {
+        mode = item.mode
+        action = item.action
+        component = item.component
+        dataUri = item.dataUri
+    }
     Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         PanelCard {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -57,9 +75,49 @@ internal fun IntentsScreen(services: AndyServices, serial: String?) {
                 Button(onClick = {
                     if (serial != null) scope.launch {
                         services.bugs.recordAction("intent", "Send ${mode.name}", command)
-                        result = intentService.send(serial, draft).let { if (it.isSuccess) it.stdout.ifBlank { "Sent" } else it.stderr }
+                        val sendResult = intentService.send(serial, draft)
+                        result = if (sendResult.isSuccess) sendResult.stdout.ifBlank { "Sent" } else sendResult.stderr
+                        if (sendResult.isSuccess) {
+                            onUpdateWorkspace { state ->
+                                state.copy(
+                                    savedIntents = (listOf(draft) + state.savedIntents.filterNot { it == draft })
+                                        .take(MaxRecentIntents),
+                                )
+                            }
+                        }
                     }
                 }) { Text("Send") }
+            }
+        }
+        if (workspaceState.savedIntents.isNotEmpty()) {
+            PanelCard {
+                Text("Recent", color = TextPrimary, fontWeight = FontWeight.Bold)
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    workspaceState.savedIntents.forEach { item ->
+                        Column(
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { applyDraft(item) }
+                                .padding(vertical = 6.dp),
+                        ) {
+                            Text(
+                                item.mode.name.lowercase(),
+                                color = Rust,
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                intentSummary(item),
+                                color = TextSecondary,
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 12.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
             }
         }
         PanelCard {
@@ -67,4 +125,11 @@ internal fun IntentsScreen(services: AndyServices, serial: String?) {
             Text(result.ifBlank { "No intent sent yet." }, color = TextSecondary, fontFamily = FontFamily.Monospace)
         }
     }
+}
+
+internal fun intentSummary(draft: IntentDraft): String = when {
+    draft.dataUri.isNotBlank() -> draft.dataUri
+    draft.component.isNotBlank() -> draft.component
+    draft.action.isNotBlank() -> draft.action
+    else -> draft.mode.name.lowercase()
 }

--- a/src/commonMain/kotlin/app/andy/ui/live/DeviceLivePanel.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/DeviceLivePanel.kt
@@ -10,11 +10,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import app.andy.model.AndroidDevice
 import app.andy.service.AndyServices
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @Composable
 internal fun DeviceLivePanel(
@@ -40,18 +37,13 @@ internal fun DeviceLivePanel(
             }
         }
     }
+    // Connect on enter; leave the session warm when the panel leaves composition so Live /
+    // Design / Performance handoffs stay instant (same pattern as DesignScreen).
     LaunchedEffect(serial) {
         connectResult = ""
         if (serial != null) {
             val result = services.mirror.connect(serial, LiveMirrorSettings.config.value)
             connectResult = if (result.isSuccess) result.stdout.ifBlank { "Connected" } else result.stderr
-            if (result.isSuccess) {
-                try {
-                    awaitCancellation()
-                } finally {
-                    withContext(NonCancellable) { services.mirror.disconnect() }
-                }
-            }
         }
     }
     MirrorFrameContent(services.mirror, serial) { frameFlow, frame ->

--- a/src/commonMain/kotlin/app/andy/ui/live/DeviceLivePanel.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/DeviceLivePanel.kt
@@ -10,8 +10,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import app.andy.model.AndroidDevice
 import app.andy.service.AndyServices
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 internal fun DeviceLivePanel(
@@ -44,6 +46,10 @@ internal fun DeviceLivePanel(
         if (serial != null) {
             val result = services.mirror.connect(serial, LiveMirrorSettings.config.value)
             connectResult = if (result.isSuccess) result.stdout.ifBlank { "Connected" } else result.stderr
+        } else {
+            withContext(NonCancellable) {
+                services.mirror.disconnect()
+            }
         }
     }
     MirrorFrameContent(services.mirror, serial) { frameFlow, frame ->

--- a/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
@@ -349,10 +349,17 @@ internal fun LiveScreen(
                     awaitCancellation()
                 } finally {
                     withContext(NonCancellable) {
+                        // Keep the scrcpy session warm when leaving Live so returning is instant.
+                        // Device stop / serial change still tear down via ShellState / reconnect.
                         services.bugs.stopCapture()
-                        services.mirror.disconnect()
                     }
                 }
+            }
+        } else {
+            // Still on Live but no online device — release the stream.
+            withContext(NonCancellable) {
+                services.bugs.stopCapture()
+                services.mirror.disconnect()
             }
         }
     }

--- a/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import app.andy.AndyDestination
+import app.andy.model.DeviceConnectionState
 import app.andy.service.AndyServices
 import app.andy.service.OpenAgentTaskRequest
 import app.andy.ui.accessibility.AccessibilityScreen
@@ -61,7 +62,9 @@ import app.andy.ui.theme.Border
 import app.andy.ui.theme.Cyan
 import app.andy.ui.theme.Ink
 import app.andy.ui.theme.Rust
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 
 @Composable
@@ -94,6 +97,19 @@ internal fun AndyShell(
         services.updates.pendingInstallConfirmation.collectAsState()
     } else {
         remember { mutableStateOf<AvailableUpdate?>(null) }
+    }
+    val mirrorSession by services.mirror.session.collectAsState()
+
+    LaunchedEffect(state.selectedSerial, state.devices, mirrorSession?.serial) {
+        val serial = state.selectedSerial
+        val device = state.devices.firstOrNull { it.serial == serial }
+        val selectedOnline = serial != null && device?.state == DeviceConnectionState.Online
+        val activeSerial = mirrorSession?.serial
+        if (!selectedOnline || (activeSerial != null && activeSerial != serial)) {
+            withContext(NonCancellable) {
+                services.mirror.disconnect()
+            }
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -376,7 +376,12 @@ internal fun AndyShell(
                             selectedPackage = state.workspaceState.selectedPackage,
                             onSelectedPackageChange = { pkg -> state.updateWorkspace { it.copy(selectedPackage = pkg) } }
                         )
-                        AndyDestination.Intents -> IntentsScreen(services, state.selectedSerial)
+                        AndyDestination.Intents -> IntentsScreen(
+                            services = services,
+                            serial = state.selectedSerial,
+                            workspaceState = state.workspaceState,
+                            onUpdateWorkspace = { state.updateWorkspace(it) },
+                        )
                         AndyDestination.Files -> FilesScreen(
                             files = services.files,
                             apps = services.apps,

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
@@ -1,5 +1,6 @@
 package app.andy.desktop.service
 
+import app.andy.model.IntentDraft
 import app.andy.model.PairedWifiDevice
 import app.andy.model.ProxyRule
 import app.andy.model.WorkspaceState
@@ -15,6 +16,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.io.File
 import java.util.Properties
 
@@ -30,6 +34,7 @@ class DesktopWorkspaceStore(
         WorkspaceState(
             selectedSdkPath = props.getProperty("selectedSdkPath")?.takeIf { it.isNotBlank() },
             selectedDeviceSerial = props.getProperty("selectedDeviceSerial")?.takeIf { it.isNotBlank() },
+            savedIntents = decodeSavedIntents(props.getProperty("savedIntents").orEmpty()),
             logSearch = props.getProperty("logSearch").orEmpty(),
             proxyPort = props.getProperty("proxyPort")?.toIntOrNull() ?: 9099,
             proxyStartOnLaunch = props.getProperty("proxyStartOnLaunch")?.toBooleanStrictOrNull() ?: false,
@@ -84,6 +89,7 @@ class DesktopWorkspaceStore(
         val props = Properties().apply {
             setProperty("selectedSdkPath", state.selectedSdkPath.orEmpty())
             setProperty("selectedDeviceSerial", state.selectedDeviceSerial.orEmpty())
+            setProperty("savedIntents", encodeSavedIntents(state.savedIntents))
             setProperty("logSearch", state.logSearch)
             setProperty("proxyPort", state.proxyPort.toString())
             setProperty("proxyStartOnLaunch", state.proxyStartOnLaunch.toString())
@@ -151,6 +157,18 @@ class DesktopWorkspaceStore(
         mutableState.value = state
     }
 
+    private fun encodeSavedIntents(intents: List<IntentDraft>): String {
+        if (intents.isEmpty()) return ""
+        return WorkspaceJson.encodeToString(intents)
+    }
+
+    private fun decodeSavedIntents(value: String): List<IntentDraft> {
+        if (value.isBlank()) return emptyList()
+        return runCatching {
+            WorkspaceJson.decodeFromString(ListSerializer(IntentDraft.serializer()), value)
+        }.getOrDefault(emptyList())
+    }
+
     private fun loadProxyRules(props: Properties): List<ProxyRule> {
         val count = props.getProperty("proxyRuleCount")?.toIntOrNull() ?: return emptyList()
         return (0 until count).mapNotNull { index ->
@@ -194,5 +212,9 @@ class DesktopWorkspaceStore(
             .map { it.trim() }
             .filter { it.isNotBlank() && ":" in it }
             .associate { it.substringBefore(':').trim() to it.substringAfter(':').trim() }
+    }
+
+    private companion object {
+        val WorkspaceJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
     }
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopWorkspaceStoreTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopWorkspaceStoreTest.kt
@@ -1,6 +1,8 @@
 package app.andy.desktop.service
 
 import app.andy.model.AgentNotificationTiming
+import app.andy.model.IntentDraft
+import app.andy.model.IntentMode
 import app.andy.model.WorkspaceState
 import kotlinx.coroutines.runBlocking
 import kotlin.io.path.createTempDirectory
@@ -22,6 +24,23 @@ class DesktopWorkspaceStoreTest {
         )
         DesktopWorkspaceStore(file).save(saved)
         assertEquals(saved, DesktopWorkspaceStore(file).load())
+
+        val withIntents = saved.copy(
+            savedIntents = listOf(
+                IntentDraft(
+                    mode = IntentMode.DeepLink,
+                    action = "android.intent.action.VIEW",
+                    dataUri = "app://open?id=1",
+                ),
+                IntentDraft(
+                    mode = IntentMode.Activity,
+                    action = "android.intent.action.MAIN",
+                    component = "com.example/.MainActivity",
+                ),
+            ),
+        )
+        DesktopWorkspaceStore(file).save(withIntents)
+        assertEquals(withIntents.savedIntents, DesktopWorkspaceStore(file).load().savedIntents)
 
         file.writeText(file.readText().replace("agentNotificationSoundId=ping", "agentNotificationSoundId=unknown"))
         assertEquals("chime", DesktopWorkspaceStore(file).load().agentNotificationSoundId)

--- a/src/desktopTest/kotlin/app/andy/ui/live/MirrorLifecycleTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/live/MirrorLifecycleTest.kt
@@ -78,6 +78,23 @@ class MirrorLifecycleTest {
     }
 
     @Test
+    fun embeddedLivePanelDisconnectsMirrorWhenSerialBecomesNull() = withComposeMirrorRenderer {
+        runDesktopComposeUiTestDrainingPriorFailures {
+            val serial = mutableStateOf<String?>("device-1")
+            val mirror = TrackingMirror()
+            val services = ScreenshotServices.create().copy(mirror = mirror)
+
+            setContent {
+                DeviceLivePanel(services = services, serial = serial.value, device = null)
+            }
+
+            waitUntil(timeoutMillis = 5_000) { mirror.connectCalls == 1 }
+            runOnUiThread { serial.value = null }
+            waitUntil(timeoutMillis = 5_000) { mirror.disconnectCalls == 1 }
+        }
+    }
+
+    @Test
     fun embeddedLivePanelKeepsMirrorConnectedWhenRemovedFromComposition() = withComposeMirrorRenderer {
         runDesktopComposeUiTestDrainingPriorFailures {
             val visible = mutableStateOf(true)

--- a/src/desktopTest/kotlin/app/andy/ui/live/MirrorLifecycleTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/live/MirrorLifecycleTest.kt
@@ -17,16 +17,18 @@ import app.andy.service.MirrorSession
 import app.andy.service.MirrorVideoConfig
 import app.andy.transfer.DeviceTransferCoordinator
 import app.andy.ui.logcat.LogcatState
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalTestApi::class)
 class MirrorLifecycleTest {
     @Test
-    fun liveScreenDisconnectsMirrorWhenRemovedFromComposition() = withComposeMirrorRenderer {
+    fun liveScreenKeepsMirrorConnectedWhenRemovedFromComposition() = withComposeMirrorRenderer {
         // Prior Compose desktop tests can leave uncaught Job failures that poison the next
         // runTest scope. Consume that once, then assert the lifecycle behavior.
         runDesktopComposeUiTestDrainingPriorFailures {
@@ -67,14 +69,16 @@ class MirrorLifecycleTest {
 
             waitUntil(timeoutMillis = 5_000) { mirror.connectCalls == 1 }
             runOnUiThread { visible.value = false }
-            waitUntil(timeoutMillis = 5_000) { mirror.disconnectCalls == 1 }
+            // Give composition teardown a moment; disconnect must not fire on leave.
+            runBlocking { delay(250) }
 
-            assertEquals(1, mirror.disconnectCalls)
+            assertEquals(1, mirror.connectCalls)
+            assertEquals(0, mirror.disconnectCalls)
         }
     }
 
     @Test
-    fun embeddedLivePanelDisconnectsMirrorWhenRemovedFromComposition() = withComposeMirrorRenderer {
+    fun embeddedLivePanelKeepsMirrorConnectedWhenRemovedFromComposition() = withComposeMirrorRenderer {
         runDesktopComposeUiTestDrainingPriorFailures {
             val visible = mutableStateOf(true)
             val mirror = TrackingMirror()
@@ -88,9 +92,10 @@ class MirrorLifecycleTest {
 
             waitUntil(timeoutMillis = 5_000) { mirror.connectCalls == 1 }
             runOnUiThread { visible.value = false }
-            waitUntil(timeoutMillis = 5_000) { mirror.disconnectCalls == 1 }
+            runBlocking { delay(250) }
 
-            assertEquals(1, mirror.disconnectCalls)
+            assertEquals(1, mirror.connectCalls)
+            assertEquals(0, mirror.disconnectCalls)
         }
     }
 


### PR DESCRIPTION
## Summary
- Stop disconnecting scrcpy when leaving Live or embedded mirror panels so tab switches back to Live stay instant; still disconnect when no online device is selected.
- Save successful intents to workspace state (up to 10 recent) with a clickable list on the Intents screen, persisted via `DesktopWorkspaceStore`.

## Test plan
- [x] `./gradlew desktopTest --tests "app.andy.desktop.service.DesktopWorkspaceStoreTest" --tests "app.andy.ui.live.MirrorLifecycleTest"`
- [ ] Manual: switch Live → Design → Live and confirm mirror reconnects without black screen
- [ ] Manual: send an intent, restart app, confirm recent intents appear and populate the form on click


Made with [Cursor](https://cursor.com)