### PR TITLE
Probe provider CLIs for live model lists and refresh agent transcript UI

### DIFF
--- a/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -119,6 +119,8 @@ data class AgentModelOption(
     val label: String,
     val efforts: List<AgentReasoningEffort>,
     val supportsFastMode: Boolean = false,
+    /** True when the provider CLI only advertises a `*-fast` slug for this base model. */
+    val fastRequired: Boolean = false,
     /**
      * Provider-specific effort suffix tokens when they differ from [AgentReasoningEffort.cliValue]
      * (for example Cursor's `extra-high` vs Codex's `xhigh`).
@@ -591,8 +593,8 @@ fun AgentTask.modelForCli(discovered: Map<AgentKind, List<AgentModelOption>> = A
                 if (effort != null && catalog?.efforts?.isNotEmpty() == true) {
                     append('-').append(catalog.effortToken(effort))
                 }
-                // Catalog options gate -fast; custom exact slugs stay unadorned.
-                if (fastMode && catalog?.supportsFastMode == true) append("-fast")
+                // Catalog options gate -fast; fast-only models always keep the suffix.
+                if (catalog?.supportsFastMode == true && (fastMode || catalog.fastRequired)) append("-fast")
             }
         }
         AgentKind.Antigravity -> {

--- a/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -93,6 +93,8 @@ fun AgentSandboxMode.descriptionFor(agent: AgentKind): String = when (agent) {
  * [AgentModelCatalog] exposes only the combinations documented for its CLI.
  */
 enum class AgentReasoningEffort(val label: String, val cliValue: String) {
+    None("none", "none"),
+    Minimal("minimal", "minimal"),
     Low("low", "low"),
     Medium("medium", "medium"),
     High("high", "high"),
@@ -101,23 +103,50 @@ enum class AgentReasoningEffort(val label: String, val cliValue: String) {
     Ultracode("ultracode", "ultracode"),
 }
 
+/** Claude Code aliases that accept the full effort dial Andy exposes. */
+private val ClaudeCodeEfforts = listOf(
+    AgentReasoningEffort.Low,
+    AgentReasoningEffort.Medium,
+    AgentReasoningEffort.High,
+    AgentReasoningEffort.ExtraHigh,
+    AgentReasoningEffort.Max,
+    AgentReasoningEffort.Ultracode,
+)
+
 data class AgentModelOption(
     /** Model identifier passed to the provider CLI, before any provider-specific variant syntax. */
     val id: String,
     val label: String,
     val efforts: List<AgentReasoningEffort>,
     val supportsFastMode: Boolean = false,
+    /**
+     * Provider-specific effort suffix tokens when they differ from [AgentReasoningEffort.cliValue]
+     * (for example Cursor's `extra-high` vs Codex's `xhigh`).
+     */
+    val effortTokens: Map<AgentReasoningEffort, String> = emptyMap(),
 ) {
     /** Preferred effort when the CLI requires a suffix and the user left effort unset. */
     fun preferredEffort(): AgentReasoningEffort? =
         efforts.firstOrNull { it == AgentReasoningEffort.High } ?: efforts.firstOrNull()
+
+    fun effortToken(effort: AgentReasoningEffort): String =
+        effortTokens[effort] ?: effort.cliValue
 }
 
 /**
- * A small public catalog for the four CLIs, plus an exact custom-model escape hatch
- * in the composer. Account/workspace entitlements remain the source of truth.
+ * Offline fallback catalog for providers that cannot list models, plus a safety net when a
+ * probe fails. Live lists from [AgentRunService.providerModels] take precedence in the UI.
  */
 object AgentModelCatalog {
+    private var liveDiscovered: Map<AgentKind, List<AgentModelOption>> = emptyMap()
+
+    /** Latest successful provider probes; used when composing CLI model ids. */
+    fun discovered(): Map<AgentKind, List<AgentModelOption>> = liveDiscovered
+
+    fun publishDiscovered(models: Map<AgentKind, List<AgentModelOption>>) {
+        liveDiscovered = models
+    }
+
     fun options(agent: AgentKind): List<AgentModelOption> = when (agent) {
         AgentKind.Codex -> listOf(
             AgentModelOption("gpt-5.6-sol", "GPT-5.6 Sol", listOf(AgentReasoningEffort.Medium, AgentReasoningEffort.High, AgentReasoningEffort.ExtraHigh, AgentReasoningEffort.Max)),
@@ -126,10 +155,10 @@ object AgentModelCatalog {
             AgentModelOption("gpt-5.2-codex", "GPT-5.2-Codex", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High, AgentReasoningEffort.ExtraHigh)),
         )
         AgentKind.ClaudeCode -> listOf(
-            AgentModelOption("opus", "Opus", AgentReasoningEffort.entries.toList()),
-            AgentModelOption("sonnet", "Sonnet", AgentReasoningEffort.entries.toList()),
+            AgentModelOption("opus", "Opus", ClaudeCodeEfforts),
+            AgentModelOption("sonnet", "Sonnet", ClaudeCodeEfforts),
             AgentModelOption("haiku", "Haiku", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High)),
-            AgentModelOption("fable", "Fable", AgentReasoningEffort.entries.toList()),
+            AgentModelOption("fable", "Fable", ClaudeCodeEfforts),
         )
         AgentKind.Cursor -> listOf(
             AgentModelOption("auto", "Auto", emptyList()),
@@ -140,19 +169,31 @@ object AgentModelCatalog {
             AgentModelOption("cursor-grok-4.5", "Grok 4.5", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High), supportsFastMode = true),
         )
         AgentKind.Antigravity -> listOf(
-            AgentModelOption("Gemini 3.5 Flash", "Gemini 3.5 Flash", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High)),
-            AgentModelOption("Gemini 3.1 Pro", "Gemini 3.1 Pro", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.High)),
-            AgentModelOption("Claude Sonnet 4.6", "Claude Sonnet 4.6", listOf(AgentReasoningEffort.High)),
-            AgentModelOption("Claude Opus 4.6", "Claude Opus 4.6", listOf(AgentReasoningEffort.High)),
-            AgentModelOption("GPT-OSS 120B", "GPT-OSS 120B", listOf(AgentReasoningEffort.Medium)),
+            AgentModelOption("gemini-3.6-flash", "Gemini 3.6 Flash", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High)),
+            AgentModelOption("gemini-3.5-flash", "Gemini 3.5 Flash", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High)),
+            AgentModelOption("gemini-3.1-pro", "Gemini 3.1 Pro", listOf(AgentReasoningEffort.Low, AgentReasoningEffort.High)),
+            AgentModelOption("claude-sonnet-4-6", "Claude Sonnet 4.6", emptyList()),
+            AgentModelOption("claude-opus-4-6-thinking", "Claude Opus 4.6", emptyList()),
+            AgentModelOption("gpt-oss-120b", "GPT-OSS 120B", listOf(AgentReasoningEffort.Medium)),
         )
     }
 
-    fun option(agent: AgentKind, id: String?): AgentModelOption? =
+    fun options(agent: AgentKind, discovered: Map<AgentKind, List<AgentModelOption>>): List<AgentModelOption> =
+        discovered[agent]?.takeIf { it.isNotEmpty() } ?: options(agent)
+
+    fun option(agent: AgentKind, id: String?, discovered: Map<AgentKind, List<AgentModelOption>> = emptyMap()): AgentModelOption? =
         id?.let { modelId ->
-            val normalized = if (agent == AgentKind.Cursor) cursorModelBaseId(modelId) else modelId
-            options(agent).firstOrNull { it.id == normalized }
+            val normalized = normalizeModelId(agent, modelId)
+            options(agent, discovered).firstOrNull { it.id == normalized }
+                ?: options(agent).firstOrNull { it.id == normalized }
         }
+}
+
+/** Normalize persisted catalog labels / full variants to the base model id Andy stores. */
+internal fun normalizeModelId(agent: AgentKind, selected: String): String = when (agent) {
+    AgentKind.Cursor -> cursorModelBaseId(selected)
+    AgentKind.Antigravity -> antigravityModelBaseId(selected)
+    else -> selected
 }
 
 /**
@@ -166,7 +207,18 @@ internal fun cursorModelBaseId(selected: String): String = when (selected) {
     "GPT-5.6 Sol", "gpt-5.6-sol" -> "gpt-5.6-sol"
     "Gemini 3.1 Pro", "gemini-3.1-pro" -> "gemini-3.1-pro"
     "Grok 4.5", "cursor-grok-4.5" -> "cursor-grok-4.5"
-    else -> selected
+    else -> stripProviderModelVariant(selected).baseId
+}
+
+/** Map legacy Antigravity display names and full effort slugs to the base id Andy stores. */
+internal fun antigravityModelBaseId(selected: String): String = when (selected) {
+    "Gemini 3.6 Flash", "gemini-3.6-flash" -> "gemini-3.6-flash"
+    "Gemini 3.5 Flash", "gemini-3.5-flash" -> "gemini-3.5-flash"
+    "Gemini 3.1 Pro", "gemini-3.1-pro" -> "gemini-3.1-pro"
+    "Claude Sonnet 4.6", "claude-sonnet-4-6" -> "claude-sonnet-4-6"
+    "Claude Opus 4.6", "claude-opus-4-6", "claude-opus-4-6-thinking" -> "claude-opus-4-6-thinking"
+    "GPT-OSS 120B", "gpt-oss-120b" -> "gpt-oss-120b"
+    else -> stripProviderModelVariant(selected).baseId
 }
 
 enum class AgentTaskStatus {
@@ -527,23 +579,36 @@ fun AgentTask.providerDefaults(): AgentProviderDefaults = AgentProviderDefaults(
 )
 
 /** Provider-specific model string passed by the adapter. */
-fun AgentTask.modelForCli(): String? = model?.let { selected ->
+fun AgentTask.modelForCli(discovered: Map<AgentKind, List<AgentModelOption>> = AgentModelCatalog.discovered()): String? = model?.let { selected ->
     when (agent) {
         AgentKind.Cursor -> {
             val base = cursorModelBaseId(selected)
-            val catalog = AgentModelCatalog.option(AgentKind.Cursor, base)
+            val catalog = AgentModelCatalog.option(AgentKind.Cursor, base, discovered)
             buildString {
                 append(base)
                 // Cursor variants bake effort into the model id; bare bases like cursor-grok-4.5 are rejected.
                 val effort = reasoningEffort ?: catalog?.preferredEffort()
                 if (effort != null && catalog?.efforts?.isNotEmpty() == true) {
-                    append('-').append(effort.cliValue)
+                    append('-').append(catalog.effortToken(effort))
                 }
                 // Catalog options gate -fast; custom exact slugs stay unadorned.
                 if (fastMode && catalog?.supportsFastMode == true) append("-fast")
             }
         }
-        AgentKind.Antigravity -> reasoningEffort?.let { "$selected (${it.label.split(' ').joinToString(" ") { word -> word.replaceFirstChar(Char::uppercase) }})" } ?: selected
+        AgentKind.Antigravity -> {
+            val base = antigravityModelBaseId(selected)
+            val catalog = AgentModelCatalog.option(AgentKind.Antigravity, base, discovered)
+            val effort = reasoningEffort
+            when {
+                effort == null -> if (selected.any { it.isWhitespace() }) selected else base
+                // Legacy display-name tasks keep the "(High)" variant syntax.
+                selected.any { it.isWhitespace() } -> {
+                    val level = effort.label.split(' ').joinToString(" ") { word -> word.replaceFirstChar(Char::uppercase) }
+                    "$selected ($level)"
+                }
+                else -> "$base-${catalog?.effortToken(effort) ?: effort.cliValue}"
+            }
+        }
         else -> selected
     }
 }

--- a/src/commonMain/kotlin/app/andy/model/ProviderModelParsing.kt
+++ b/src/commonMain/kotlin/app/andy/model/ProviderModelParsing.kt
@@ -1,0 +1,179 @@
+package app.andy.model
+
+/**
+ * Parses provider CLI `models` output into Andy's base-model + effort catalog shape.
+ * Cursor prints `id - Label`; Antigravity prints one slug per line.
+ */
+
+private val EffortTokenOrder = listOf(
+    "none" to AgentReasoningEffort.None,
+    "minimal" to AgentReasoningEffort.Minimal,
+    "low" to AgentReasoningEffort.Low,
+    "medium" to AgentReasoningEffort.Medium,
+    "high" to AgentReasoningEffort.High,
+    "xhigh" to AgentReasoningEffort.ExtraHigh,
+    "extra-high" to AgentReasoningEffort.ExtraHigh,
+    "max" to AgentReasoningEffort.Max,
+    "ultracode" to AgentReasoningEffort.Ultracode,
+)
+
+private val EffortTokenByLength = EffortTokenOrder.map { it.first }.sortedByDescending { it.length }
+
+internal data class ProviderModelVariant(
+    val baseId: String,
+    val effort: AgentReasoningEffort?,
+    val effortToken: String?,
+    val fast: Boolean,
+)
+
+/** Strip a trailing effort / fast suffix from a provider model slug. */
+internal fun stripProviderModelVariant(modelId: String): ProviderModelVariant {
+    var remaining = modelId.trim()
+    if (remaining.isEmpty()) return ProviderModelVariant(modelId, null, null, false)
+    var fast = false
+    if (remaining.endsWith("-fast")) {
+        fast = true
+        remaining = remaining.removeSuffix("-fast")
+    }
+    for (token in EffortTokenByLength) {
+        val suffix = "-$token"
+        if (remaining.endsWith(suffix) && remaining.length > suffix.length) {
+            val effort = EffortTokenOrder.first { it.first == token }.second
+            return ProviderModelVariant(remaining.removeSuffix(suffix), effort, token, fast)
+        }
+    }
+    return ProviderModelVariant(remaining, null, null, fast)
+}
+
+fun parseAntigravityModels(output: String): List<AgentModelOption> =
+    groupProviderModelVariants(
+        output.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("Available") && !it.startsWith("Tip:") }
+            .map { slug -> slug to humanizeModelSlug(stripProviderModelVariant(slug).baseId) }
+            .toList(),
+    )
+
+fun parseCursorModels(output: String): List<AgentModelOption> {
+    val rows = output.lineSequence().mapNotNull { line ->
+        val trimmed = line.trim()
+        if (trimmed.isEmpty() || trimmed.startsWith("Available") || trimmed.startsWith("Tip:")) return@mapNotNull null
+        val separator = trimmed.indexOf(" - ")
+        if (separator <= 0) {
+            val slug = trimmed.takeWhile { !it.isWhitespace() }
+            if (slug.isEmpty()) null else slug to humanizeModelSlug(stripProviderModelVariant(slug).baseId)
+        } else {
+            val slug = trimmed.take(separator).trim()
+            val label = trimmed.substring(separator + 3).trim()
+            if (slug.isEmpty()) null else slug to cursorBaseLabel(slug, label)
+        }
+    }.toList()
+    return groupProviderModelVariants(rows)
+}
+
+private fun cursorBaseLabel(slug: String, variantLabel: String): String {
+    val base = stripProviderModelVariant(slug).baseId
+    val cleaned = variantLabel
+        .removeSuffix(" Fast")
+        .replace(Regex("""\b(None|Minimal|Low|Medium|High|Extra High|Max|Ultracode)\b"""), "")
+        .replace(Regex("""\s+"""), " ")
+        .trim()
+        .trimEnd('-', ' ')
+    return cleaned.ifBlank { humanizeModelSlug(base) }
+}
+
+private fun groupProviderModelVariants(rows: List<Pair<String, String>>): List<AgentModelOption> {
+    data class Acc(
+        var label: String,
+        val efforts: LinkedHashMap<AgentReasoningEffort, String> = linkedMapOf(),
+        var supportsFastMode: Boolean = false,
+        var sawBareVariant: Boolean = false,
+    )
+    val grouped = linkedMapOf<String, Acc>()
+    for ((slug, label) in rows) {
+        val variant = stripProviderModelVariant(slug)
+        val acc = grouped.getOrPut(variant.baseId) { Acc(label = label) }
+        if (label.isNotBlank()) {
+            // Prefer a label from a bare / high variant when available.
+            if (variant.effort == null || variant.effort == AgentReasoningEffort.High || acc.label.isBlank()) {
+                acc.label = label
+            }
+        }
+        if (variant.fast) acc.supportsFastMode = true
+        if (variant.effort == null && !variant.fast) acc.sawBareVariant = true
+        val effort = variant.effort
+        val token = variant.effortToken
+        if (effort != null && token != null && effort !in acc.efforts) {
+            acc.efforts[effort] = token
+        }
+    }
+    return grouped.map { (baseId, acc) ->
+        val efforts = if (acc.efforts.isEmpty() && acc.sawBareVariant) {
+            emptyList()
+        } else {
+            AgentReasoningEffort.entries.filter { it in acc.efforts }
+        }
+        AgentModelOption(
+            id = baseId,
+            label = acc.label.ifBlank { humanizeModelSlug(baseId) },
+            efforts = efforts,
+            supportsFastMode = acc.supportsFastMode,
+            effortTokens = acc.efforts.toMap(),
+        )
+    }
+}
+
+internal fun humanizeModelSlug(slug: String): String {
+    if (slug.isBlank()) return slug
+    return slug.split('-').joinToString(" ") { part ->
+        when {
+            part.equals("gpt", ignoreCase = true) -> "GPT"
+            part.equals("oss", ignoreCase = true) -> "OSS"
+            part.equals("glm", ignoreCase = true) -> "GLM"
+            part.matches(Regex("""\d+(?:\.\d+)*""")) -> part
+            else -> part.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        }
+    }
+}
+
+/**
+ * Vendor family for Cursor's mixed model marketplace (and similar multi-vendor lists).
+ * Order is intentional: Cursor-native first, then the major labs.
+ */
+enum class AgentModelFamily(val label: String) {
+    Cursor("Cursor"),
+    OpenAI("OpenAI"),
+    Anthropic("Anthropic"),
+    Google("Google"),
+    XAI("xAI"),
+    Moonshot("Moonshot"),
+    Zhipu("Zhipu"),
+    Other("Other"),
+}
+
+fun AgentModelOption.modelFamily(): AgentModelFamily = modelFamilyForId(id)
+
+fun modelFamilyForId(modelId: String): AgentModelFamily {
+    val id = modelId.trim().lowercase()
+    return when {
+        id == "auto" || id.startsWith("composer-") || id.startsWith("cursor-") -> AgentModelFamily.Cursor
+        id.startsWith("gpt-") || id.startsWith("o1") || id.startsWith("o3") || id.startsWith("o4") -> AgentModelFamily.OpenAI
+        id.startsWith("claude-") || id.startsWith("anthropic-") -> AgentModelFamily.Anthropic
+        id.startsWith("gemini-") || id.startsWith("google-") -> AgentModelFamily.Google
+        id.startsWith("grok-") || id.startsWith("xai-") -> AgentModelFamily.XAI
+        id.startsWith("kimi-") || id.startsWith("moonshot-") -> AgentModelFamily.Moonshot
+        id.startsWith("glm-") || id.startsWith("zhipu-") -> AgentModelFamily.Zhipu
+        else -> AgentModelFamily.Other
+    }
+}
+
+/** Groups models by [AgentModelFamily], omitting empty families and preserving catalog order within each. */
+fun List<AgentModelOption>.groupedByModelFamily(): List<Pair<AgentModelFamily, List<AgentModelOption>>> {
+    if (isEmpty()) return emptyList()
+    val buckets = AgentModelFamily.entries.associateWith { mutableListOf<AgentModelOption>() }
+    forEach { option -> buckets.getValue(option.modelFamily()).add(option) }
+    return AgentModelFamily.entries.mapNotNull { family ->
+        buckets.getValue(family).takeIf { it.isNotEmpty() }?.let { family to it }
+    }
+}
+

--- a/src/commonMain/kotlin/app/andy/model/ProviderModelParsing.kt
+++ b/src/commonMain/kotlin/app/andy/model/ProviderModelParsing.kt
@@ -118,6 +118,7 @@ private fun groupProviderModelVariants(rows: List<Pair<String, String>>): List<A
             label = acc.label.ifBlank { humanizeModelSlug(baseId) },
             efforts = efforts,
             supportsFastMode = acc.supportsFastMode,
+            fastRequired = acc.supportsFastMode && !acc.sawBareVariant,
             effortTokens = acc.efforts.toMap(),
         )
     }

--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -277,6 +277,11 @@ interface ActionRunService {
 interface AgentRunService {
     val tasks: StateFlow<List<AgentTask>>
     val cliStatuses: StateFlow<List<AgentCliStatus>>
+    /**
+     * Models reported by installed provider CLIs (`agy models`, `cursor-agent models`, …).
+     * Missing providers fall back to [app.andy.model.AgentModelCatalog] in the UI.
+     */
+    val providerModels: StateFlow<Map<AgentKind, List<AgentModelOption>>>
     /** Most recent provider-reported account limits, keyed by provider. */
     val providerQuotas: StateFlow<Map<AgentKind, AgentProviderQuota>>
     /** Explicit consent for provider-local account sources; disabled by default. */

--- a/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
+++ b/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
@@ -239,6 +239,7 @@ object UnavailableActionRunService : ActionRunService {
 object UnavailableAgentRunService : AgentRunService {
     override val tasks = MutableStateFlow(emptyList<AgentTask>())
     override val cliStatuses = MutableStateFlow(emptyList<AgentCliStatus>())
+    override val providerModels = MutableStateFlow(emptyMap<AgentKind, List<AgentModelOption>>())
     override val providerQuotas = MutableStateFlow(emptyMap<AgentKind, AgentProviderQuota>())
     override val quotaAccess = MutableStateFlow(AgentQuotaAccess())
     override val providerDefaults = MutableStateFlow(emptyMap<AgentKind, AgentProviderDefaults>())

--- a/src/commonMain/kotlin/app/andy/ui/actions/ProjectWorkflowUi.kt
+++ b/src/commonMain/kotlin/app/andy/ui/actions/ProjectWorkflowUi.kt
@@ -792,6 +792,7 @@ internal fun SpecTaskDialog(
     onSaved: (String) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
+    val providerModels by services.agentRuns.providerModels.collectAsState()
     val initialProfile = existing?.profile ?: workflow.profiles[ProjectTaskKind.Spec] ?: ProjectAgentProfile()
     var title by remember(existing?.id) { mutableStateOf(existing?.title.orEmpty()) }
     var brief by remember(existing?.id) { mutableStateOf(existing?.instructions.orEmpty()) }
@@ -848,7 +849,7 @@ internal fun SpecTaskDialog(
                         )
                     }
                 }
-                ProjectAgentProfileEditor("SPEC PROFILE", profile, { profile = it }, cliStatuses, ProjectTaskKind.Spec)
+                ProjectAgentProfileEditor("SPEC PROFILE", profile, { profile = it }, cliStatuses, providerModels, ProjectTaskKind.Spec)
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         FilterPill("Include scratchpad", includeScratchpad, Cyan) { includeScratchpad = !includeScratchpad }
@@ -916,6 +917,7 @@ internal fun BuildPairDialog(
     onSaved: (String) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
+    val providerModels by services.agentRuns.providerModels.collectAsState()
     val existing = seed.buildTaskId?.let { id -> workflow.tasks.firstOrNull { it.id == id } }
     val linkedReview = existing?.linkedReviewTaskId?.let { id -> workflow.tasks.firstOrNull { it.id == id } }
     val linkedVerify = existing?.linkedVerificationTaskId?.let { id -> workflow.tasks.firstOrNull { it.id == id } }
@@ -998,20 +1000,20 @@ internal fun BuildPairDialog(
                 }
                 LabeledField("Build notes (optional)", buildNotes, { buildNotes = it }, Modifier.fillMaxWidth(), singleLine = false, minHeight = 90.dp, testTag = "build-notes-field")
                 LabeledField("Reported-cost guardrail in USD (optional)", budgetText, { budgetText = it.filter { char -> char.isDigit() || char == '.' } }, Modifier.fillMaxWidth())
-                ProjectAgentProfileEditor("BUILD PROFILE", buildProfile, { buildProfile = it }, cliStatuses, ProjectTaskKind.Build)
+                ProjectAgentProfileEditor("BUILD PROFILE", buildProfile, { buildProfile = it }, cliStatuses, providerModels, ProjectTaskKind.Build)
                 FilterPill("Build gets scratchpad snapshot", includeBuildScratchpad, Cyan) { includeBuildScratchpad = !includeBuildScratchpad }
                 FilterPill("Run review before verification", reviewEnabled, AndyColors.Blue) { reviewEnabled = !reviewEnabled }
                 AnimatedVisibility(reviewEnabled) {
                     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         LabeledField("Custom review instructions (optional)", reviewInstructions, { reviewInstructions = it }, Modifier.fillMaxWidth(), singleLine = false, minHeight = 100.dp)
-                        ProjectAgentProfileEditor("REVIEW PROFILE · BUILD WORKSPACE INHERITED", reviewProfile, { reviewProfile = it }, cliStatuses, ProjectTaskKind.Review)
+                        ProjectAgentProfileEditor("REVIEW PROFILE · BUILD WORKSPACE INHERITED", reviewProfile, { reviewProfile = it }, cliStatuses, providerModels, ProjectTaskKind.Review)
                         FilterPill("Reviewer gets scratchpad snapshot", includeReviewScratchpad, AndyColors.Blue) { includeReviewScratchpad = !includeReviewScratchpad }
                     }
                 }
                 LabeledField("Verification instructions (optional)", verificationInstructions, { verificationInstructions = it }, Modifier.fillMaxWidth(), singleLine = false, minHeight = 130.dp)
                 AnimatedVisibility(verificationInstructions.isNotBlank()) {
                     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        ProjectAgentProfileEditor("VERIFICATION PROFILE", verifyProfile, { verifyProfile = it }, cliStatuses, ProjectTaskKind.Verification)
+                        ProjectAgentProfileEditor("VERIFICATION PROFILE", verifyProfile, { verifyProfile = it }, cliStatuses, providerModels, ProjectTaskKind.Verification)
                         FilterPill("Verifier gets scratchpad snapshot", includeVerifyScratchpad, Cyan) { includeVerifyScratchpad = !includeVerifyScratchpad }
                     }
                 }
@@ -1056,6 +1058,7 @@ internal fun ProjectProfilesDialog(
     onDismiss: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
+    val providerModels by services.agentRuns.providerModels.collectAsState()
     var spec by remember(workflow.projectId) { mutableStateOf(workflow.profiles[ProjectTaskKind.Spec] ?: ProjectAgentProfile()) }
     var build by remember(workflow.projectId) { mutableStateOf(workflow.profiles[ProjectTaskKind.Build] ?: ProjectAgentProfile()) }
     var review by remember(workflow.projectId) { mutableStateOf(workflow.profiles[ProjectTaskKind.Review] ?: ProjectAgentProfile()) }
@@ -1076,10 +1079,10 @@ internal fun ProjectProfilesDialog(
                     }
                 }
                 when (selectedRole) {
-                    ProjectTaskKind.Spec -> ProjectAgentProfileEditor("SPEC · PLAN + READ ONLY LOCKED", spec, { spec = it }, cliStatuses, ProjectTaskKind.Spec)
-                    ProjectTaskKind.Build -> ProjectAgentProfileEditor("BUILD", build, { build = it }, cliStatuses, ProjectTaskKind.Build)
-                    ProjectTaskKind.Review -> ProjectAgentProfileEditor("REVIEW · BUILD WORKSPACE INHERITED", review, { review = it }, cliStatuses, ProjectTaskKind.Review)
-                    ProjectTaskKind.Verification -> ProjectAgentProfileEditor("VERIFY · BUILD WORKSPACE INHERITED", verify, { verify = it }, cliStatuses, ProjectTaskKind.Verification)
+                    ProjectTaskKind.Spec -> ProjectAgentProfileEditor("SPEC · PLAN + READ ONLY LOCKED", spec, { spec = it }, cliStatuses, providerModels, ProjectTaskKind.Spec)
+                    ProjectTaskKind.Build -> ProjectAgentProfileEditor("BUILD", build, { build = it }, cliStatuses, providerModels, ProjectTaskKind.Build)
+                    ProjectTaskKind.Review -> ProjectAgentProfileEditor("REVIEW · BUILD WORKSPACE INHERITED", review, { review = it }, cliStatuses, providerModels, ProjectTaskKind.Review)
+                    ProjectTaskKind.Verification -> ProjectAgentProfileEditor("VERIFY · BUILD WORKSPACE INHERITED", verify, { verify = it }, cliStatuses, providerModels, ProjectTaskKind.Verification)
                 }
             }
         },
@@ -1104,6 +1107,7 @@ internal fun ProjectAgentProfileEditor(
     profile: ProjectAgentProfile,
     onChange: (ProjectAgentProfile) -> Unit,
     cliStatuses: List<AgentCliStatus>,
+    providerModels: Map<AgentKind, List<app.andy.model.AgentModelOption>>,
     role: ProjectTaskKind,
 ) {
     Column(Modifier.fillMaxWidth().background(AndyColors.Neutral900, RoundedCornerShape(AndyRadius.R3)).border(1.dp, Border, RoundedCornerShape(AndyRadius.R3)).padding(12.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -1112,6 +1116,7 @@ internal fun ProjectAgentProfileEditor(
             profile = profile,
             onChange = onChange,
             cliStatuses = cliStatuses,
+            providerModels = providerModels,
             showUnavailableAsPills = true,
             showProviderIcons = false,
             showModelControls = false,
@@ -1122,6 +1127,7 @@ internal fun ProjectAgentProfileEditor(
                 profile = profile,
                 onChange = onChange,
                 cliStatuses = cliStatuses,
+                providerModels = providerModels,
                 showProviderControls = false,
                 showUnavailableAsPills = true,
                 showProviderIcons = false,

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentProfileControls.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentProfileControls.kt
@@ -17,7 +17,9 @@ import androidx.compose.ui.unit.sp
 import app.andy.model.AgentCliStatus
 import app.andy.model.AgentKind
 import app.andy.model.AgentModelCatalog
+import app.andy.model.AgentModelOption
 import app.andy.model.ProjectAgentProfile
+import app.andy.model.groupedByModelFamily
 import app.andy.ui.components.FilterPill
 import app.andy.ui.components.LabeledField
 import app.andy.ui.theme.Cyan
@@ -31,6 +33,7 @@ internal fun AgentProviderModelProfileControls(
     profile: ProjectAgentProfile,
     onChange: (ProjectAgentProfile) -> Unit,
     cliStatuses: List<AgentCliStatus>,
+    providerModels: Map<AgentKind, List<AgentModelOption>> = emptyMap(),
     providerSelectionActive: Boolean = true,
     showProviderControls: Boolean = true,
     showModelControls: Boolean = true,
@@ -41,8 +44,10 @@ internal fun AgentProviderModelProfileControls(
     wrapOptions: Boolean = false,
     showModelLabel: Boolean = true,
 ) {
-    val selectedModel = AgentModelCatalog.option(profile.agent, profile.model)
+    val modelOptions = AgentModelCatalog.options(profile.agent, providerModels)
+    val selectedModel = AgentModelCatalog.option(profile.agent, profile.model, providerModels)
     val customModel = profile.model != null && selectedModel == null
+    val groupedModels = if (profile.agent == AgentKind.Cursor) modelOptions.groupedByModelFamily() else null
 
     if (showProviderControls) {
         Text("Agent", color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 11.sp)
@@ -88,17 +93,46 @@ internal fun AgentProviderModelProfileControls(
     if (showModelLabel) {
         Text("Model", color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 11.sp)
     }
-    ProfileOptionRow(wrapOptions) {
-        FilterPill("provider default", profile.model == null, Cyan) {
-            onChange(profile.copy(model = null, reasoningEffort = null, fastMode = false))
-        }
-        AgentModelCatalog.options(profile.agent).forEach { option ->
-            FilterPill(option.label, selectedModel?.id == option.id, agentColor(profile.agent)) {
-                onChange(profile.copy(model = option.id, reasoningEffort = null, fastMode = false))
+    if (groupedModels != null) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            ProfileOptionRow(wrapOptions) {
+                FilterPill("provider default", profile.model == null, Cyan) {
+                    onChange(profile.copy(model = null, reasoningEffort = null, fastMode = false))
+                }
+                FilterPill("custom", customModel, Rust) {
+                    onChange(profile.copy(model = profile.model.takeIf { customModel }.orEmpty(), reasoningEffort = null, fastMode = false))
+                }
+            }
+            groupedModels.forEach { (family, options) ->
+                Text(
+                    family.label.uppercase(),
+                    color = TextSecondary.copy(alpha = 0.75f),
+                    fontFamily = MonoFont,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 9.sp,
+                )
+                ProfileOptionRow(wrapOptions) {
+                    options.forEach { option ->
+                        FilterPill(option.label, selectedModel?.id == option.id, agentColor(profile.agent)) {
+                            onChange(profile.copy(model = option.id, reasoningEffort = null, fastMode = false))
+                        }
+                    }
+                }
             }
         }
-        FilterPill("custom", customModel, Rust) {
-            onChange(profile.copy(model = profile.model.takeIf { customModel }.orEmpty(), reasoningEffort = null, fastMode = false))
+    } else {
+        ProfileOptionRow(wrapOptions) {
+            FilterPill("provider default", profile.model == null, Cyan) {
+                onChange(profile.copy(model = null, reasoningEffort = null, fastMode = false))
+            }
+            modelOptions.forEach { option ->
+                FilterPill(option.label, selectedModel?.id == option.id, agentColor(profile.agent)) {
+                    onChange(profile.copy(model = option.id, reasoningEffort = null, fastMode = false))
+                }
+            }
+            FilterPill("custom", customModel, Rust) {
+                onChange(profile.copy(model = profile.model.takeIf { customModel }.orEmpty(), reasoningEffort = null, fastMode = false))
+            }
         }
     }
     if (customModel) {
@@ -142,7 +176,7 @@ internal fun AgentProviderModelProfileControls(
             Text(
                 when (profile.agent) {
                     AgentKind.Cursor -> "Cursor receives the selected provider variant. Availability follows your Cursor account."
-                    AgentKind.Antigravity -> "Antigravity receives its model plus level as one variant; its installed CLI/account remains authoritative."
+                    AgentKind.Antigravity -> "Antigravity receives its model slug plus effort as one variant from the live CLI model list."
                     else -> "The selected model and reasoning level are passed directly to the ${profile.agent.label} CLI."
                 },
                 color = TextSecondary,

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentProfileControls.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentProfileControls.kt
@@ -114,7 +114,7 @@ internal fun AgentProviderModelProfileControls(
                 ProfileOptionRow(wrapOptions) {
                     options.forEach { option ->
                         FilterPill(option.label, selectedModel?.id == option.id, agentColor(profile.agent)) {
-                            onChange(profile.copy(model = option.id, reasoningEffort = null, fastMode = false))
+                            onChange(profile.copy(model = option.id, reasoningEffort = null, fastMode = option.fastRequired))
                         }
                     }
                 }
@@ -127,7 +127,7 @@ internal fun AgentProviderModelProfileControls(
             }
             modelOptions.forEach { option ->
                 FilterPill(option.label, selectedModel?.id == option.id, agentColor(profile.agent)) {
-                    onChange(profile.copy(model = option.id, reasoningEffort = null, fastMode = false))
+                    onChange(profile.copy(model = option.id, reasoningEffort = null, fastMode = option.fastRequired))
                 }
             }
             FilterPill("custom", customModel, Rust) {
@@ -167,7 +167,7 @@ internal fun AgentProviderModelProfileControls(
                 }
             }
         }
-        if (selectedModel.supportsFastMode) {
+        if (selectedModel.supportsFastMode && !selectedModel.fastRequired) {
             FilterPill("fast", profile.fastMode, app.andy.ui.theme.Green) {
                 onChange(profile.copy(fastMode = !profile.fastMode))
             }

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
@@ -68,6 +68,7 @@ import app.andy.model.AgentTaskDraft
 import app.andy.model.ProjectAgentProfile
 import app.andy.model.defaultSandboxMode
 import app.andy.model.descriptionFor
+import app.andy.model.groupedByModelFamily
 import app.andy.model.labelFor
 import app.andy.model.parseAgentGoalCommand
 import app.andy.model.sandboxControlLabel
@@ -236,9 +237,9 @@ private class AgentTaskComposerFormState(
         skillMenuDismissed = false
     }
 
-    fun applyProviderDefaults(defaults: AgentProviderDefaults?, agent: AgentKind) {
+    fun applyProviderDefaults(defaults: AgentProviderDefaults?, agent: AgentKind, discovered: Map<AgentKind, List<AgentModelOption>> = emptyMap()) {
         val savedModel = defaults?.model
-        val catalogModel = AgentModelCatalog.option(agent, savedModel)
+        val catalogModel = AgentModelCatalog.option(agent, savedModel, discovered)
         modelId = when {
             savedModel == null -> null
             catalogModel != null -> catalogModel.id
@@ -265,10 +266,13 @@ private fun AgentTaskComposerFormState.providerProfile(): ProjectAgentProfile = 
     fastMode = fastMode,
 )
 
-private fun AgentTaskComposerFormState.applyProviderProfile(profile: ProjectAgentProfile) {
+private fun AgentTaskComposerFormState.applyProviderProfile(
+    profile: ProjectAgentProfile,
+    discovered: Map<AgentKind, List<AgentModelOption>> = emptyMap(),
+) {
     providerChosenInComposer = true
     agent = profile.agent
-    val catalogModel = AgentModelCatalog.option(profile.agent, profile.model)
+    val catalogModel = AgentModelCatalog.option(profile.agent, profile.model, discovered)
     modelId = when {
         profile.model == null -> null
         catalogModel != null -> catalogModel.id
@@ -286,6 +290,7 @@ private fun rememberAgentTaskComposerForm(
     projectContext: ActionProject?,
 ): AgentTaskComposerForm {
     val providerDefaults by services.agentRuns.providerDefaults.collectAsState()
+    val providerModels by services.agentRuns.providerModels.collectAsState()
     val lastUsedAgent by services.agentRuns.lastUsedAgent.collectAsState()
     val scope = rememberCoroutineScope()
     val formsByProject = remember { mutableMapOf<String?, AgentTaskComposerFormState>() }
@@ -301,7 +306,8 @@ private fun rememberAgentTaskComposerForm(
     }.collectAsState()
     val selectedCliAvailable = cliStatuses.any { it.kind == state.agent && it.ready }
     val showModelSection = state.providerChosenInComposer && selectedCliAvailable
-    val selectedModel = AgentModelCatalog.option(state.agent, state.modelId)
+    val modelOptions = AgentModelCatalog.options(state.agent, providerModels)
+    val selectedModel = AgentModelCatalog.option(state.agent, state.modelId, providerModels)
     val slashCommand = findComposerSlashCommand(state.prompt)
     val matchingCommands = slashCommand?.let { command ->
         AgentNativeSlashCommands.forAgent(state.agent).filter { nativeCommand ->
@@ -340,10 +346,10 @@ private fun rememberAgentTaskComposerForm(
 
     // Apply defaults when the agent changes, or once for a newly created project draft.
     // Do not re-apply merely because we navigated back to an existing draft.
-    LaunchedEffect(state, state.agent, providerDefaults[state.agent]) {
+    LaunchedEffect(state, state.agent, providerDefaults[state.agent], providerModels) {
         val agent = state.agent
         if (state.defaultsSeededForAgent != agent) {
-            state.applyProviderDefaults(providerDefaults[agent], agent)
+            state.applyProviderDefaults(providerDefaults[agent], agent, providerModels)
             state.defaultsSeededForAgent = agent
         }
     }
@@ -352,7 +358,7 @@ private fun rememberAgentTaskComposerForm(
         state.directoryIsGitRepo = directory?.let { services.agentRuns.isGitRepo(it) } == true
         if (!state.directoryIsGitRepo) state.useWorktree = false
     }
-    LaunchedEffect(state.agent, state.modelId) {
+    LaunchedEffect(state.agent, state.modelId, selectedModel) {
         val model = selectedModel
         when {
             state.usesCustomModel || model == null || model.efforts.isEmpty() -> state.reasoningEffort = null
@@ -368,6 +374,8 @@ private fun rememberAgentTaskComposerForm(
         state = state,
         services = services,
         cliStatuses = cliStatuses,
+        providerModels = providerModels,
+        modelOptions = modelOptions,
         projectContext = projectContext,
         directory = directory,
         showModelSection = showModelSection,
@@ -386,6 +394,8 @@ private class AgentTaskComposerForm(
     val state: AgentTaskComposerFormState,
     val services: AndyServices,
     val cliStatuses: List<AgentCliStatus>,
+    val providerModels: Map<AgentKind, List<AgentModelOption>>,
+    val modelOptions: List<AgentModelOption>,
     val projectContext: ActionProject?,
     val directory: String?,
     val showModelSection: Boolean,
@@ -680,14 +690,41 @@ private fun AgentChatComposer(
                             modelMenuExpanded = false
                         },
                     )
-                    AgentModelCatalog.options(state.agent).forEach { option ->
-                        DropdownMenuItem(
-                            text = { Text(option.label, color = TextPrimary) },
-                            onClick = {
-                                state.modelId = option.id
-                                modelMenuExpanded = false
-                            },
-                        )
+                    if (state.agent == AgentKind.Cursor) {
+                        form.modelOptions.groupedByModelFamily().forEach { (family, options) ->
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        family.label.uppercase(),
+                                        color = TextSecondary,
+                                        fontFamily = MonoFont,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 10.sp,
+                                    )
+                                },
+                                onClick = {},
+                                enabled = false,
+                            )
+                            options.forEach { option ->
+                                DropdownMenuItem(
+                                    text = { Text(option.label, color = TextPrimary) },
+                                    onClick = {
+                                        state.modelId = option.id
+                                        modelMenuExpanded = false
+                                    },
+                                )
+                            }
+                        }
+                    } else {
+                        form.modelOptions.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(option.label, color = TextPrimary) },
+                                onClick = {
+                                    state.modelId = option.id
+                                    modelMenuExpanded = false
+                                },
+                            )
+                        }
                     }
                     DropdownMenuItem(
                         text = { Text("custom", color = TextPrimary) },
@@ -764,8 +801,9 @@ private fun AgentTaskComposerFields(
         if (showAgentControls) {
             AgentProviderModelProfileControls(
                 profile = state.providerProfile(),
-                onChange = state::applyProviderProfile,
+                onChange = { state.applyProviderProfile(it, form.providerModels) },
                 cliStatuses = form.cliStatuses,
+                providerModels = form.providerModels,
                 providerSelectionActive = state.providerChosenInComposer,
                 showModelControls = false,
             )
@@ -779,8 +817,9 @@ private fun AgentTaskComposerFields(
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 AgentProviderModelProfileControls(
                     profile = state.providerProfile(),
-                    onChange = state::applyProviderProfile,
+                    onChange = { state.applyProviderProfile(it, form.providerModels) },
                     cliStatuses = form.cliStatuses,
+                    providerModels = form.providerModels,
                     showProviderControls = false,
                     showVersion = true,
                     showModelHelp = true,

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
@@ -367,7 +367,11 @@ private fun rememberAgentTaskComposerForm(
                 state.reasoningEffort = if (state.agent == AgentKind.Cursor) model.preferredEffort() else null
             }
         }
-        if (model?.supportsFastMode != true) state.fastMode = false
+        if (model?.supportsFastMode != true) {
+            state.fastMode = false
+        } else if (model.fastRequired) {
+            state.fastMode = true
+        }
     }
 
     return AgentTaskComposerForm(
@@ -745,7 +749,9 @@ private fun AgentChatComposer(
                             selectedModel.efforts.forEach { effort -> DropdownMenuItem(text = { Text(effort.label, color = TextPrimary) }, onClick = { state.reasoningEffort = effort; effortMenuExpanded = false }) }
                         }
                     }
-                    if (selectedModel.supportsFastMode) FilterPill("fast", state.fastMode, Green) { state.fastMode = !state.fastMode }
+                    if (selectedModel.supportsFastMode && !selectedModel.fastRequired) {
+                        FilterPill("fast", state.fastMode, Green) { state.fastMode = !state.fastMode }
+                    }
                 }
                 FilterPill("plan", state.planMode, Green) { state.planMode = !state.planMode }
                 Box {

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -303,7 +303,6 @@ internal fun AgentTaskDetail(
                     )
                 }
             },
-            completedContentKey = changeSummary?.files?.size,
             eventsReady = eventsReady,
             onSkillOpen = { skill -> scope.launch { services.agentRuns.openSkill(skill.path) } },
             restoreScrollKey = task.id,

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -27,10 +27,9 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.DisableSelection
@@ -38,12 +37,13 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameMillis
@@ -60,6 +60,7 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -72,6 +73,7 @@ import app.andy.loadImageBitmap
 import app.andy.model.AgentEvent
 import app.andy.model.AgentSkill
 import app.andy.ui.components.AndyMarkdownDensity
+import app.andy.ui.components.Button
 import app.andy.ui.components.ChatMarkdown
 import app.andy.ui.components.DraggableScrollbar
 import app.andy.ui.components.EmptyState
@@ -85,23 +87,23 @@ import app.andy.ui.theme.Red
 import app.andy.ui.theme.Rust
 import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
-import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-
-private const val TRANSCRIPT_BOTTOM_THRESHOLD_PX = 32
 
 /** Explicit per-task scroll snapshot. */
 internal data class TranscriptScrollPosition(
     val index: Int,
     val offset: Int,
     val stickToBottom: Boolean,
+    /** Stable row identity keeps the same viewport when newer rows arrive while this chat is away. */
+    val anchorKey: String? = null,
 )
 
 private sealed class TranscriptRestorePlan {
     data object StickToBottom : TranscriptRestorePlan()
-    data class Exact(val index: Int, val offset: Int) : TranscriptRestorePlan()
+    data class Exact(val index: Int, val offset: Int, val anchorKey: String?) : TranscriptRestorePlan()
 }
 
 /**
@@ -121,22 +123,6 @@ internal class TranscriptScrollMemory {
     }
 }
 
-/** Suppresses stick-to-bottom updates while we programmatically scroll. */
-private class TranscriptScrollGate {
-    private var depth = 0
-    val isAutoScrolling: Boolean get() = depth > 0
-
-    suspend fun <T> run(block: suspend () -> T): T {
-        depth += 1
-        try {
-            return block()
-        } finally {
-            withFrameMillis { }
-            depth -= 1
-        }
-    }
-}
-
 @Composable
 internal fun AgentTranscript(
     events: List<AgentEvent>,
@@ -148,8 +134,6 @@ internal fun AgentTranscript(
     originalPrompt: String? = null,
     originalImagePaths: List<String> = emptyList(),
     completedContent: (@Composable () -> Unit)? = null,
-    /** Changes when trailing completed UI (e.g. change summary) mounts after first layout. */
-    completedContentKey: Any? = null,
     /**
      * False while a completed chat's transcript (and trailing UI) is still loading.
      * Prevents pinning to the prompt-only stub before history arrives.
@@ -160,76 +144,75 @@ internal fun AgentTranscript(
     scrollMemory: TranscriptScrollMemory? = null,
     modifier: Modifier = Modifier,
 ) {
+    val scope = rememberCoroutineScope()
     val displayItems = remember(events, compactToolCalls) { transcriptDisplayItems(events, compactToolCalls) }
     val originalPromptVisible = !originalPrompt.isNullOrBlank() || originalImagePaths.isNotEmpty()
     val latestTaskResultItemIndex = displayItems.indexOfLast { item ->
         item is TranscriptDisplayItem.Event && item.event is AgentEvent.TaskResult
     }
     val taskId = restoreScrollKey
-    // Freeze restore intent for this visit from memory at entry — never mutate this plan mid-load.
+    // Freeze restore intent for this visit. A bottom-origin list makes index 0 the live edge;
+    // streamed rows can then grow upward without any imperative per-token scrolling.
     val restorePlan = remember(taskId) {
         val saved = taskId?.let { scrollMemory?.get(it) }
         when {
             saved == null || saved.stickToBottom -> TranscriptRestorePlan.StickToBottom
-            else -> TranscriptRestorePlan.Exact(saved.index, saved.offset)
+            else -> TranscriptRestorePlan.Exact(saved.index, saved.offset, saved.anchorKey)
         }
     }
-    val listState = remember(taskId) {
-        when (val plan = restorePlan) {
-            is TranscriptRestorePlan.Exact -> LazyListState(plan.index, plan.offset)
-            TranscriptRestorePlan.StickToBottom -> LazyListState(0, 0)
-        }
-    }
+    // Always start at the live edge. Exact restoration happens only after async history is
+    // ready, so a prompt-only loading stub cannot clamp a saved index back to zero.
+    val listState = remember(taskId) { LazyListState(0, 0) }
     var stickToBottom by remember(taskId) {
         mutableStateOf(restorePlan is TranscriptRestorePlan.StickToBottom)
     }
     var scrollInitialized by remember(taskId) { mutableStateOf(false) }
-    val scrollGate = remember(taskId) { TranscriptScrollGate() }
     var expandedToolKeys by remember(taskId) { mutableStateOf(setOf<String>()) }
     var expandedToolGroups by remember(taskId) { mutableStateOf(setOf<String>()) }
-    // Bumped on real user scroll (mouse wheel / trackpad) — desktop often skips isScrollInProgress.
+    // Desktop wheel/trackpad input can complete without isScrollInProgress ever becoming true.
     var userScrollGeneration by remember(taskId) { mutableStateOf(0) }
-    val bottomItemIndex = remember(
-        displayItems.size,
-        headerContent != null,
-        pendingContent != null,
-        originalPromptVisible,
-        isActive,
-    ) {
-        transcriptBottomItemIndex(
-            displayItemCount = displayItems.size,
-            hasHeader = headerContent != null,
-            hasPending = pendingContent != null,
-            hasOriginalPrompt = originalPromptVisible,
-            isActive = isActive,
-        )
-    }
-    val scrollAnchor = remember(
+    val rowKeys = remember(
         displayItems,
-        headerContent != null,
-        pendingContent != null,
-        originalPromptVisible,
         isActive,
-        completedContentKey,
+        originalPromptVisible,
+        pendingContent != null,
+        headerContent != null,
     ) {
-        transcriptScrollAnchor(
-            displayItems = displayItems,
-            hasHeader = headerContent != null,
-            hasPending = pendingContent != null,
-            hasOriginalPrompt = originalPromptVisible,
-            isActive = isActive,
-            completedContentKey = completedContentKey,
-        )
+        buildList {
+            if (isActive) add("agent-thinking")
+            displayItems.asReversed().forEach { add(transcriptDisplayItemKey(it)) }
+            if (originalPromptVisible) add("original-prompt")
+            if (pendingContent != null) add("pending-task-input")
+            if (headerContent != null) add("task-header")
+        }
     }
-    val scrollInitializedState = rememberUpdatedState(scrollInitialized)
-    val stickToBottomState = rememberUpdatedState(stickToBottom)
-    // Observable content fingerprint so a single snapshotFlow can react to streamed text
-    // growth without a keyed LaunchedEffect restarting (and cancelling a mid-scroll) per token.
-    val scrollAnchorState = rememberUpdatedState(scrollAnchor)
-    val isActiveState = rememberUpdatedState(isActive)
 
-    // Only persist AFTER init — saving during the loading stub was overwriting mid-scroll
-    // positions with "stick=true at index 0" when the prompt alone fit the viewport.
+    LaunchedEffect(taskId, eventsReady, listState.layoutInfo.totalItemsCount, rowKeys) {
+        if (scrollInitialized || !eventsReady) return@LaunchedEffect
+        val itemCount = listState.layoutInfo.totalItemsCount
+        when (val plan = restorePlan) {
+            TranscriptRestorePlan.StickToBottom -> {
+                // Index zero is bottom in reverseLayout. No settling loop or post-layout nudge.
+                stickToBottom = true
+                scrollInitialized = true
+            }
+            is TranscriptRestorePlan.Exact -> {
+                if (itemCount == 0) return@LaunchedEffect
+                val anchoredIndex = plan.anchorKey
+                    ?.let(rowKeys::indexOf)
+                    ?.takeIf { it >= 0 }
+                listState.scrollToItem(
+                    index = (anchoredIndex ?: plan.index).coerceIn(0, itemCount - 1),
+                    scrollOffset = plan.offset,
+                )
+                stickToBottom = false
+                scrollInitialized = true
+            }
+        }
+    }
+
+    // Persist each conversation independently. Streaming does not touch these coordinates
+    // when detached because its changing rows live below the visible reverse-layout anchor.
     LaunchedEffect(taskId, listState, scrollInitialized) {
         if (!scrollInitialized) return@LaunchedEffect
         val id = taskId ?: return@LaunchedEffect
@@ -238,125 +221,76 @@ internal fun AgentTranscript(
             TranscriptScrollPosition(
                 index = listState.firstVisibleItemIndex,
                 offset = listState.firstVisibleItemScrollOffset,
-                stickToBottom = stickToBottomState.value,
+                stickToBottom = stickToBottom,
+                anchorKey = listState.firstVisibleAnchorKey(),
             )
         }.distinctUntilChanged().collect { memory.save(id, it) }
     }
-
-    LaunchedEffect(
-        taskId,
-        bottomItemIndex,
-        listState.layoutInfo.totalItemsCount,
-        eventsReady,
-        displayItems.size,
-        completedContentKey,
-    ) {
-        if (scrollInitialized || bottomItemIndex < 0) return@LaunchedEffect
-        if (!eventsReady) return@LaunchedEffect
-        val itemCount = listState.layoutInfo.totalItemsCount
-        if (itemCount == 0) return@LaunchedEffect
-        scrollGate.run {
-            when (val plan = restorePlan) {
-                TranscriptRestorePlan.StickToBottom -> {
-                    stickToBottom = true
-                    // Keep settling until truly pinned — change-summary can mount a frame late.
-                    repeat(24) {
-                        listState.scrollToEndAligned(settleFrames = 1)
-                        if (listState.isNearBottom(thresholdPx = 1) && !listState.canScrollForward) {
-                            withFrameMillis { }
-                            listState.scrollToEndAligned(settleFrames = 1)
-                            if (listState.isNearBottom(thresholdPx = 1) && !listState.canScrollForward) return@run
-                        }
-                        withFrameMillis { }
-                    }
-                }
-                is TranscriptRestorePlan.Exact -> {
-                    stickToBottom = false
-                    listState.scrollToItem(
-                        plan.index.coerceIn(0, itemCount - 1),
-                        plan.offset,
-                    )
-                }
+    DisposableEffect(taskId, listState, scrollInitialized, stickToBottom) {
+        onDispose {
+            if (scrollInitialized && taskId != null && scrollMemory != null) {
+                scrollMemory.save(
+                    taskId,
+                    TranscriptScrollPosition(
+                        index = listState.firstVisibleItemIndex,
+                        offset = listState.firstVisibleItemScrollOffset,
+                        stickToBottom = stickToBottom,
+                        anchorKey = listState.firstVisibleAnchorKey(),
+                    ),
+                )
             }
         }
-        scrollInitialized = true
     }
-    // Re-pin only on stick (re)engaging or the completed chat becoming ready — NOT per token.
-    LaunchedEffect(stickToBottom, scrollInitialized, eventsReady) {
-        if (!scrollInitialized || !stickToBottom || !eventsReady) return@LaunchedEffect
-        scrollGate.run { listState.scrollToEndAligned() }
-    }
-    // Non-active settle: images, change-summary, and restored history all mount/measure
-    // after the fact. React to those layout changes so a finished chat pins cleanly.
-    // While the agent is active, the per-frame follower below owns pinning instead.
-    LaunchedEffect(listState, taskId, scrollInitialized) {
+
+    // Detect non-pointer scrolling (keyboard, accessibility, scrollbar). Position changes do
+    // not drive auto-scroll; they only re-arm following once index zero is reached exactly.
+    LaunchedEffect(taskId, listState, scrollInitialized) {
         if (!scrollInitialized) return@LaunchedEffect
         snapshotFlow {
-            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()
-            scrollAnchorState.value to listOf(
-                listState.bottomGapPx(),
-                last?.index,
-                last?.size,
-                listState.canScrollForward,
-                listState.layoutInfo.totalItemsCount,
+            Triple(
+                listState.firstVisibleItemIndex,
+                listState.firstVisibleItemScrollOffset,
+                listState.isScrollInProgress,
             )
-        }.distinctUntilChanged().collect {
-            if (isActiveState.value) return@collect
-            if (!stickToBottomState.value || scrollGate.isAutoScrolling) return@collect
-            if (!listState.isNearBottom(thresholdPx = 1)) {
-                scrollGate.run { listState.scrollToEndAligned() }
-            }
-        }
-    }
-    // Streaming follower: while the agent is active, re-check the bottom every frame and
-    // nudge back by the exact remaining delta. Per-frame coverage means we never drift more
-    // than one frame off the bottom; the exact-delta nudge (no scrollToItem jump, no second
-    // competing driver) means an already-pinned list does nothing, so there is no flicker.
-    LaunchedEffect(taskId, scrollInitialized, isActive) {
-        if (!scrollInitialized || !isActive) return@LaunchedEffect
-        while (true) {
-            withFrameMillis { }
-            if (!stickToBottomState.value || scrollGate.isAutoScrolling) continue
-            if (!listState.isNearBottom(thresholdPx = 1)) {
-                scrollGate.run { listState.scrollToEndAligned(settleFrames = 1) }
+        }.distinctUntilChanged().collect { (index, offset, inProgress) ->
+            if (transcriptIsAtBottom(index, offset)) {
+                stickToBottom = true
+            } else if (inProgress) {
+                stickToBottom = false
             }
         }
     }
     LaunchedEffect(userScrollGeneration, scrollInitialized) {
         if (!scrollInitialized || userScrollGeneration == 0) return@LaunchedEffect
-        // Let the wheel/trackpad scroll apply, then sync stick from the settled
-        // position. Detach immediately on Scroll (below) so streaming doesn't yank
-        // an upward gesture; this settle is what re-locks after scrolling back down.
-        // Without it, the near-bottom snapshotFlow often won't re-emit — nearBottom
-        // was already true when the last wheel tick cleared stickToBottom.
+        // Let wheel/trackpad input settle. A blocked downward tick at the live edge has no
+        // position change, so explicitly re-arm in that case.
         withFrameMillis { }
         withFrameMillis { }
-        if (!scrollGate.isAutoScrolling) {
-            stickToBottom = listState.isNearBottom()
+        if (transcriptIsAtBottom(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset)) {
+            stickToBottom = true
         }
     }
-    LaunchedEffect(listState, taskId, scrollInitialized) {
-        if (!scrollInitialized) return@LaunchedEffect
-        snapshotFlow { listState.isNearBottom() to listState.isScrollInProgress }
-            .distinctUntilChanged()
-            .collect { (nearBottom, inProgress) ->
-                if (scrollGate.isAutoScrolling || !scrollInitializedState.value) return@collect
-                if (nearBottom) stickToBottom = true
-                else if (inProgress) stickToBottom = false
-            }
+
+    fun jumpToLatest() {
+        stickToBottom = true
+        scope.launch { listState.scrollToItem(0) }
     }
+
     Box(
         modifier
-            .background(AndyColors.Neutral900.copy(alpha = 0.45f), RoundedCornerShape(AndyRadius.R4))
-            .border(1.dp, Border, RoundedCornerShape(AndyRadius.R4)),
+            .clip(RoundedCornerShape(AndyRadius.R4))
+            .background(AndyColors.Neutral900.copy(alpha = 0.38f))
+            .border(1.dp, Border.copy(alpha = 0.76f), RoundedCornerShape(AndyRadius.R4)),
     ) {
         if (events.isEmpty() && !originalPromptVisible && !isActive) {
             EmptyState("waiting for agent output")
         } else {
             LazyColumn(
                 state = listState,
+                reverseLayout = true,
                 modifier = Modifier
                     .fillMaxSize()
+                    .testTag("transcript-list")
                     .graphicsLayer { alpha = if (scrollInitialized) 1f else 0f }
                     .padding(end = 8.dp)
                     .pointerInput(taskId) {
@@ -364,48 +298,39 @@ internal fun AgentTranscript(
                             while (true) {
                                 val event = awaitPointerEvent(PointerEventPass.Main)
                                 if (event.type == PointerEventType.Scroll) {
-                                    // Detach the instant the user scrolls so the per-frame
-                                    // follower doesn't yank an upward gesture during streaming.
-                                    // userScrollGeneration's settle effect re-locks once the
-                                    // wheel/trackpad stops near the bottom.
+                                    // Detach before the wheel delta is applied. New streaming
+                                    // content then grows below this viewport without moving it.
                                     stickToBottom = false
                                     userScrollGeneration++
                                 }
                             }
                         }
                     },
-                contentPadding = PaddingValues(start = 14.dp, top = 12.dp, end = 14.dp, bottom = 0.dp),
+                contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 14.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                if (headerContent != null) {
-                    item(key = "task-header") { headerContent() }
+                // reverseLayout lays index zero at the visual bottom, so declare rows newest
+                // first while preserving the transcript's chronological reading order.
+                if (isActive) {
+                    item(key = "agent-thinking", contentType = "presence") { AgentThinkingIndicator() }
                 }
-                if (pendingContent != null) {
-                    item(key = "pending-task-input") { pendingContent() }
-                }
-                if (originalPromptVisible) {
-                    item(key = "original-prompt") {
-                        SelectionContainer {
-                            ChatMessageBubble(
-                                author = "you",
-                                authorColor = Rust,
-                                alignEnd = true,
-                            ) {
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    originalPrompt?.takeIf { it.isNotBlank() }?.let { prompt ->
-                                        ChatMarkdown(prompt, lineHeight = 18.sp)
-                                    }
-                                    ChatAttachedImages(originalImagePaths)
-                                }
-                            }
+                items(
+                    count = displayItems.size,
+                    key = { reversedIndex ->
+                        transcriptDisplayItemKey(displayItems[displayItems.lastIndex - reversedIndex])
+                    },
+                    contentType = { reversedIndex ->
+                        when (displayItems[displayItems.lastIndex - reversedIndex]) {
+                            is TranscriptDisplayItem.Event -> "event"
+                            is TranscriptDisplayItem.ToolCalls -> "tool-group"
                         }
-                    }
-                }
-                itemsIndexed(
-                    items = displayItems,
-                    key = { _, item -> transcriptDisplayItemKey(item) },
-                ) { itemIndex, item ->
-                    SelectionContainer {
+                    },
+                ) { reversedIndex ->
+                    val itemIndex = displayItems.lastIndex - reversedIndex
+                    val item = displayItems[itemIndex]
+                    SelectionContainer(
+                        modifier = Modifier.testTag("transcript-row-${transcriptDisplayItemKey(item)}"),
+                    ) {
                         when (item) {
                             is TranscriptDisplayItem.Event -> TranscriptEvent(
                                 event = item.event,
@@ -434,120 +359,66 @@ internal fun AgentTranscript(
                         }
                     }
                 }
-                if (isActive) {
-                    item(key = "agent-thinking") { AgentThinkingIndicator() }
+                if (originalPromptVisible) {
+                    item(key = "original-prompt", contentType = "message") {
+                        SelectionContainer {
+                            ChatMessageBubble(
+                                author = "you",
+                                authorColor = Rust,
+                                alignEnd = true,
+                            ) {
+                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    originalPrompt?.takeIf { it.isNotBlank() }?.let { prompt ->
+                                        ChatMarkdown(prompt, lineHeight = 18.sp)
+                                    }
+                                    ChatAttachedImages(originalImagePaths)
+                                }
+                            }
+                        }
+                    }
+                }
+                if (pendingContent != null) {
+                    item(key = "pending-task-input", contentType = "request") { pendingContent() }
+                }
+                if (headerContent != null) {
+                    item(key = "task-header", contentType = "header") { headerContent() }
                 }
             }
             DraggableScrollbar(
                 listState = listState,
+                reverseLayout = true,
+                onScroll = { stickToBottom = false },
                 modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
             )
+            AnimatedVisibility(
+                visible = scrollInitialized && !stickToBottom,
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 14.dp),
+            ) {
+                Button(
+                    onClick = ::jumpToLatest,
+                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 7.dp),
+                    shape = RoundedCornerShape(AndyRadius.Pill),
+                ) {
+                    Text(
+                        if (isActive) "↓  follow live" else "↓  latest",
+                        fontFamily = MonoFont,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
         }
     }
 }
 
-internal fun transcriptBottomItemIndex(
-    displayItemCount: Int,
-    hasHeader: Boolean,
-    hasPending: Boolean,
-    hasOriginalPrompt: Boolean,
-    isActive: Boolean,
-): Int {
-    var index = -1
-    if (hasHeader) index++
-    if (hasPending) index++
-    if (hasOriginalPrompt) index++
-    index += displayItemCount
-    if (isActive) index++
-    return index
-}
+/** Bottom is an invariant instead of a layout estimate in the reverse transcript. */
+internal fun transcriptIsAtBottom(firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int): Boolean =
+    firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset <= 1
 
-internal fun transcriptBottomGapPx(
-    lastItemIndex: Int,
-    lastItemOffset: Int,
-    lastItemSize: Int,
-    totalItems: Int,
-    viewportEndOffset: Int,
-    canScrollForward: Boolean,
-    canScrollBackward: Boolean,
-): Int? {
-    if (totalItems <= 0) return 0
-    if (!canScrollForward && !canScrollBackward) return 0
-    if (lastItemIndex < totalItems - 1) return null
-    return (lastItemOffset + lastItemSize) - viewportEndOffset
-}
-
-internal fun transcriptIsNearBottom(
-    gapPx: Int?,
-    thresholdPx: Int = TRANSCRIPT_BOTTOM_THRESHOLD_PX,
-): Boolean = gapPx != null && abs(gapPx) <= thresholdPx
-
-private fun LazyListState.isNearBottom(
-    thresholdPx: Int = TRANSCRIPT_BOTTOM_THRESHOLD_PX,
-): Boolean = transcriptIsNearBottom(gapPx = bottomGapPx(), thresholdPx = thresholdPx)
-
-private fun LazyListState.bottomGapPx(): Int? {
-    val layout = layoutInfo
-    val lastVisible = layout.visibleItemsInfo.lastOrNull()
-    return transcriptBottomGapPx(
-        lastItemIndex = lastVisible?.index ?: -1,
-        lastItemOffset = lastVisible?.offset ?: 0,
-        lastItemSize = lastVisible?.size ?: 0,
-        totalItems = layout.totalItemsCount,
-        viewportEndOffset = layout.viewportEndOffset - layout.afterContentPadding,
-        canScrollForward = canScrollForward,
-        canScrollBackward = canScrollBackward,
-    )
-}
-
-/**
- * Scroll so the bottom of the last item sits on the bottom of the viewport.
- * Prefer [scrollBy] when the last item is already visible — [scrollToItem] alone
- * parks it at the *top* and causes a visible flash during streaming.
- */
-private suspend fun LazyListState.scrollToEndAligned(settleFrames: Int = 4) {
-    // Markdown/images/change-summary often measure across multiple frames after content arrives.
-    var stable = 0
-    var previousGap: Int? = null
-    repeat(settleFrames.coerceAtLeast(1)) { attempt ->
-        alignLastItemToBottom()
-        val gap = bottomGapPx()
-        if (gap != null && abs(gap) <= 1 && !canScrollForward) {
-            if (gap == previousGap) stable++ else stable = 1
-            previousGap = gap
-            if (stable >= 2) return
-        } else {
-            stable = 0
-            previousGap = gap
-        }
-        if (attempt < settleFrames - 1) withFrameMillis { }
-    }
-}
-
-private suspend fun LazyListState.alignLastItemToBottom() {
-    val lastIndex = layoutInfo.totalItemsCount - 1
-    if (lastIndex < 0) return
-
-    var lastItem = layoutInfo.visibleItemsInfo.firstOrNull { it.index == lastIndex }
-    if (lastItem == null) {
-        // Jump near the end in one shot, then fine-tune with scrollBy so we never
-        // paint a frame with the last item parked at the top of the viewport.
-        scrollToItem(lastIndex, scrollOffset = Int.MAX_VALUE / 4)
-        lastItem = layoutInfo.visibleItemsInfo.firstOrNull { it.index == lastIndex } ?: return
-        val viewportEnd = layoutInfo.viewportEndOffset - layoutInfo.afterContentPadding
-        val jumpDelta = (lastItem.offset + lastItem.size) - viewportEnd
-        if (abs(jumpDelta) > 1) {
-            scroll { scrollBy(jumpDelta.toFloat()) }
-        }
-        return
-    }
-
-    val viewportEnd = layoutInfo.viewportEndOffset - layoutInfo.afterContentPadding
-    val delta = (lastItem.offset + lastItem.size) - viewportEnd
-    if (abs(delta) > 1) {
-        scroll { scrollBy(delta.toFloat()) }
-    }
-}
+private fun LazyListState.firstVisibleAnchorKey(): String? = layoutInfo.visibleItemsInfo
+    .firstOrNull { it.index == firstVisibleItemIndex }
+    ?.key
+    ?.toString()
 
 /**
  * Providers commonly emit the final response once as an assistant message and
@@ -594,38 +465,6 @@ internal fun transcriptDisplayItems(
         }
     }
     return items
-}
-
-/**
- * Fingerprint for transcript auto-scroll. Streamed assistant/thinking text grows in place,
- * so the anchor tracks content length rather than relying on [ScrollState.maxValue] keys.
- */
-internal fun transcriptScrollAnchor(
-    displayItems: List<TranscriptDisplayItem>,
-    hasHeader: Boolean,
-    hasPending: Boolean,
-    hasOriginalPrompt: Boolean,
-    isActive: Boolean,
-    completedContentKey: Any? = null,
-): List<Any?> {
-    val lastMarker = when (val last = displayItems.lastOrNull()) {
-        is TranscriptDisplayItem.Event -> when (val event = last.event) {
-            is AgentEvent.AssistantText -> listOf("assistant", event.text.length, event.text.takeLast(96))
-            is AgentEvent.Thinking -> listOf("thinking", event.text.length, event.text.takeLast(96))
-            else -> listOf(transcriptEventKey(last.index, last.event))
-        }
-        is TranscriptDisplayItem.ToolCalls -> listOf(transcriptDisplayItemKey(last), last.events.size)
-        null -> listOf("empty")
-    }
-    return listOf(
-        displayItems.size,
-        lastMarker,
-        hasHeader,
-        hasPending,
-        hasOriginalPrompt,
-        isActive,
-        completedContentKey,
-    )
 }
 
 private fun AgentEvent.isToolTranscriptEvent(): Boolean =

--- a/src/commonMain/kotlin/app/andy/ui/components/MarkdownPreview.kt
+++ b/src/commonMain/kotlin/app/andy/ui/components/MarkdownPreview.kt
@@ -98,11 +98,29 @@ internal fun ChatMarkdown(
 ) {
     if (text.isBlank()) return
     AndyMarkdown(
-        text = text,
+        // CommonMark treats a single newline as a soft break, which most renderers display as
+        // a space. In a chat transcript, pressing Shift+Enter or pasting multiline text is an
+        // explicit formatting choice, so promote those breaks to Markdown hard breaks.
+        text = text.withChatLineBreaks(),
         density = density,
         bodyLineHeight = lineHeight,
         modifier = modifier.fillMaxWidth(),
     )
+}
+
+/** Preserves chat line breaks without changing blank-line paragraphs or fenced code blocks. */
+internal fun String.withChatLineBreaks(): String {
+    val lines = replace("\r\n", "\n").split('\n')
+    var inFence = false
+    return lines.mapIndexed { index, line ->
+        val fence = line.trimStart().startsWith("```") || line.trimStart().startsWith("~~~")
+        val next = lines.getOrNull(index + 1)
+        val nextIsFence = next?.trimStart()?.let { it.startsWith("```") || it.startsWith("~~~") } == true
+        val hardBreak = !inFence && !fence && !nextIsFence && line.isNotBlank() && next != null && next.isNotBlank()
+        val renderedLine = if (hardBreak && !line.endsWith("  ") && !line.endsWith("\\")) "$line  " else line
+        if (fence) inFence = !inFence
+        renderedLine
+    }.joinToString("\n")
 }
 
 internal enum class AndyMarkdownDensity {

--- a/src/commonMain/kotlin/app/andy/ui/components/Scrollbars.kt
+++ b/src/commonMain/kotlin/app/andy/ui/components/Scrollbars.kt
@@ -77,6 +77,7 @@ internal fun lazyScrollbarMetrics(
     measuredItemSizes: Map<Int, Int>,
     viewportSize: Int,
     itemSpacing: Int,
+    reverseLayout: Boolean = false,
 ): LazyScrollbarMetrics {
     if (totalItems <= 0 || viewportSize <= 0) return LazyScrollbarMetrics(0, 0, 0)
 
@@ -103,9 +104,10 @@ internal fun lazyScrollbarMetrics(
     val measuredBeforeDiff = measuredItemSizes.entries
         .filter { it.key in 0 until currentIndex }
         .sumOf { (_, size) -> (size.coerceAtLeast(1) - averageItemSize).toLong() }
-    val scrollOffset = (baseBefore + measuredBeforeDiff + firstVisibleItemScrollOffset)
+    val distanceFromStart = (baseBefore + measuredBeforeDiff + firstVisibleItemScrollOffset)
         .coerceIn(0, maxScrollOffset.toLong())
         .toInt()
+    val scrollOffset = if (reverseLayout) maxScrollOffset - distanceFromStart else distanceFromStart
     return LazyScrollbarMetrics(contentSize, scrollOffset, maxScrollOffset)
 }
 
@@ -116,6 +118,7 @@ internal fun lazyScrollbarTarget(
     measuredItemSizes: Map<Int, Int>,
     viewportSize: Int,
     itemSpacing: Int,
+    reverseLayout: Boolean = false,
 ): LazyScrollbarTarget {
     val metrics = lazyScrollbarMetrics(
         totalItems = totalItems,
@@ -124,6 +127,7 @@ internal fun lazyScrollbarTarget(
         measuredItemSizes = measuredItemSizes,
         viewportSize = viewportSize,
         itemSpacing = itemSpacing,
+        reverseLayout = reverseLayout,
     )
     if (totalItems <= 0) return LazyScrollbarTarget(0, 0)
 
@@ -137,7 +141,8 @@ internal fun lazyScrollbarTarget(
     val spacing = itemSpacing.coerceAtLeast(0)
     val step = (averageItemSize + spacing).coerceAtLeast(1)
 
-    var remaining = scrollOffset.coerceIn(0, metrics.maxScrollOffset).toLong()
+    val clampedOffset = scrollOffset.coerceIn(0, metrics.maxScrollOffset)
+    var remaining = (if (reverseLayout) metrics.maxScrollOffset - clampedOffset else clampedOffset).toLong()
     val measured = measuredItemSizes.entries
         .filter { it.key in 0 until totalItems }
         .sortedBy { it.key }
@@ -305,6 +310,8 @@ internal fun DraggableScrollbar(
 internal fun DraggableScrollbar(
     listState: LazyListState,
     modifier: Modifier = Modifier,
+    reverseLayout: Boolean = false,
+    onScroll: () -> Unit = {},
 ) {
     val layoutInfo = listState.layoutInfo
     val measuredItemSizes = remember(listState) { mutableStateMapOf<Int, Int>() }
@@ -327,6 +334,7 @@ internal fun DraggableScrollbar(
         measuredItemSizes = knownItemSizes,
         viewportSize = viewportSize,
         itemSpacing = layoutInfo.mainAxisItemSpacing,
+        reverseLayout = reverseLayout,
     )
     if (!metrics.canScroll) return
 
@@ -351,7 +359,9 @@ internal fun DraggableScrollbar(
             measuredItemSizes = currentItemSizes,
             viewportSize = currentViewportSize,
             itemSpacing = currentItemSpacing,
+            reverseLayout = reverseLayout,
         )
+        onScroll()
         scope.launch { listState.scrollToItem(target.itemIndex, target.itemScrollOffset) }
     }
 
@@ -361,13 +371,13 @@ internal fun DraggableScrollbar(
             .width(14.dp)
             .semantics { contentDescription = "Scrollbar" }
             .pointerHoverIcon(PointerIcon.Hand)
-            .pointerInput(listState) {
+            .pointerInput(listState, reverseLayout) {
                 detectTapGestures { offset ->
                     val thumb = scrollbarThumb(size.height.toFloat(), minThumbHeight, currentMetrics)
                     currentScrollToThumb((offset.y - thumb.height / 2f), size.height.toFloat())
                 }
             }
-            .pointerInput(listState) {
+            .pointerInput(listState, reverseLayout) {
                 detectDragGestures(
                     onDragStart = { offset ->
                         dragging = true

--- a/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/files/FilesScreen.kt
@@ -245,6 +245,11 @@ private fun DeviceFilesBrowser(
         if (transfer.status.isNotBlank()) message = transfer.status
     }
 
+    if (serial == null) {
+        InspectorEmptyState("Select an online device to browse files.")
+        return
+    }
+
     Column(
         Modifier
             .fillMaxSize()

--- a/src/commonTest/kotlin/app/andy/model/ProviderModelParsingTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/ProviderModelParsingTest.kt
@@ -83,6 +83,7 @@ class ProviderModelParsingTest {
         val composer = options.single { it.id == "composer-2.5" }
         assertEquals(emptyList(), composer.efforts)
         assertTrue(composer.supportsFastMode)
+        assertFalse(composer.fastRequired)
 
         assertEquals("auto", options.single { it.id == "auto" }.id)
     }
@@ -131,6 +132,31 @@ class ProviderModelParsingTest {
     fun catalogResolvesLegacyAntigravityDisplayNames() {
         val option = AgentModelCatalog.option(AgentKind.Antigravity, "Gemini 3.6 Flash")
         assertEquals("gemini-3.6-flash", option?.id)
+    }
+
+    @Test
+    fun fastOnlyCursorModelRequiresFastSuffix() {
+        val options = parseCursorModels(
+            """
+            composer-2.5-fast - Composer 2.5 Fast
+            """.trimIndent(),
+        )
+
+        val composer = options.single { it.id == "composer-2.5" }
+        assertTrue(composer.supportsFastMode)
+        assertTrue(composer.fastRequired)
+
+        val task = AgentTask(
+            id = "1",
+            title = "t",
+            prompt = "p",
+            agent = AgentKind.Cursor,
+            model = "composer-2.5",
+            reasoningEffort = null,
+            fastMode = false,
+            createdAtMillis = 0,
+        )
+        assertEquals("composer-2.5-fast", task.modelForCli(mapOf(AgentKind.Cursor to options)))
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/model/ProviderModelParsingTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/ProviderModelParsingTest.kt
@@ -1,0 +1,166 @@
+package app.andy.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProviderModelParsingTest {
+    @Test
+    fun parsesAntigravitySlugsIntoBaseModelsWithEfforts() {
+        val options = parseAntigravityModels(
+            """
+            gemini-3.6-flash-high
+            gemini-3.6-flash-medium
+            gemini-3.6-flash-low
+            gemini-3.1-pro-low
+            gemini-3.1-pro-high
+            claude-sonnet-4-6
+            claude-opus-4-6-thinking
+            gpt-oss-120b-medium
+            """.trimIndent(),
+        )
+
+        val flash = options.single { it.id == "gemini-3.6-flash" }
+        assertEquals("Gemini 3.6 Flash", flash.label)
+        assertEquals(
+            listOf(AgentReasoningEffort.Low, AgentReasoningEffort.Medium, AgentReasoningEffort.High),
+            flash.efforts,
+        )
+        assertEquals("high", flash.effortToken(AgentReasoningEffort.High))
+
+        val pro = options.single { it.id == "gemini-3.1-pro" }
+        assertEquals(listOf(AgentReasoningEffort.Low, AgentReasoningEffort.High), pro.efforts)
+
+        assertEquals(emptyList(), options.single { it.id == "claude-sonnet-4-6" }.efforts)
+        assertEquals(emptyList(), options.single { it.id == "claude-opus-4-6-thinking" }.efforts)
+        assertEquals(listOf(AgentReasoningEffort.Medium), options.single { it.id == "gpt-oss-120b" }.efforts)
+    }
+
+    @Test
+    fun parsesCursorModelsGroupingEffortAndFast() {
+        val options = parseCursorModels(
+            """
+            Available models
+
+            auto - Auto (default)
+            gemini-3.6-flash-minimal - Gemini 3.6 Flash Minimal
+            gemini-3.6-flash-low - Gemini 3.6 Flash Low
+            gemini-3.6-flash-medium - Gemini 3.6 Flash Medium
+            gemini-3.6-flash-high - Gemini 3.6 Flash
+            cursor-grok-4.5-high - Cursor Grok 4.5
+            cursor-grok-4.5-high-fast - Cursor Grok 4.5 Fast
+            cursor-grok-4.5-low - Cursor Grok 4.5 Low
+            gpt-5.5-extra-high - GPT-5.5 1M Extra High
+            gpt-5.5-extra-high-fast - GPT-5.5 Extra High Fast
+            composer-2.5 - Composer 2.5
+            composer-2.5-fast - Composer 2.5 Fast
+            Tip: use --model <id>
+            """.trimIndent(),
+        )
+
+        val flash = options.single { it.id == "gemini-3.6-flash" }
+        assertEquals("Gemini 3.6 Flash", flash.label)
+        assertEquals(
+            listOf(
+                AgentReasoningEffort.Minimal,
+                AgentReasoningEffort.Low,
+                AgentReasoningEffort.Medium,
+                AgentReasoningEffort.High,
+            ),
+            flash.efforts,
+        )
+        assertFalse(flash.supportsFastMode)
+
+        val grok = options.single { it.id == "cursor-grok-4.5" }
+        assertTrue(grok.supportsFastMode)
+        assertEquals(listOf(AgentReasoningEffort.Low, AgentReasoningEffort.High), grok.efforts)
+
+        val gpt55 = options.single { it.id == "gpt-5.5" }
+        assertEquals("extra-high", gpt55.effortToken(AgentReasoningEffort.ExtraHigh))
+        assertTrue(gpt55.supportsFastMode)
+
+        val composer = options.single { it.id == "composer-2.5" }
+        assertEquals(emptyList(), composer.efforts)
+        assertTrue(composer.supportsFastMode)
+
+        assertEquals("auto", options.single { it.id == "auto" }.id)
+    }
+
+    @Test
+    fun antigravityModelForCliUsesSlugEffortSuffix() {
+        val task = AgentTask(
+            id = "1",
+            title = "t",
+            prompt = "p",
+            agent = AgentKind.Antigravity,
+            model = "gemini-3.6-flash",
+            reasoningEffort = AgentReasoningEffort.Medium,
+            createdAtMillis = 0,
+        )
+        assertEquals("gemini-3.6-flash-medium", task.modelForCli())
+    }
+
+    @Test
+    fun cursorModelForCliUsesDiscoveredExtraHighToken() {
+        val discovered = mapOf(
+            AgentKind.Cursor to listOf(
+                AgentModelOption(
+                    id = "gpt-5.5",
+                    label = "GPT-5.5",
+                    efforts = listOf(AgentReasoningEffort.ExtraHigh),
+                    supportsFastMode = true,
+                    effortTokens = mapOf(AgentReasoningEffort.ExtraHigh to "extra-high"),
+                ),
+            ),
+        )
+        val task = AgentTask(
+            id = "1",
+            title = "t",
+            prompt = "p",
+            agent = AgentKind.Cursor,
+            model = "gpt-5.5",
+            reasoningEffort = AgentReasoningEffort.ExtraHigh,
+            fastMode = true,
+            createdAtMillis = 0,
+        )
+        assertEquals("gpt-5.5-extra-high-fast", task.modelForCli(discovered))
+    }
+
+    @Test
+    fun catalogResolvesLegacyAntigravityDisplayNames() {
+        val option = AgentModelCatalog.option(AgentKind.Antigravity, "Gemini 3.6 Flash")
+        assertEquals("gemini-3.6-flash", option?.id)
+    }
+
+    @Test
+    fun groupsCursorModelsByVendorFamily() {
+        val grouped = listOf(
+            AgentModelOption("auto", "Auto", emptyList()),
+            AgentModelOption("composer-2.5", "Composer 2.5", emptyList()),
+            AgentModelOption("gpt-5.6-sol", "GPT-5.6 Sol", emptyList()),
+            AgentModelOption("claude-opus-4-8", "Opus 4.8", emptyList()),
+            AgentModelOption("gemini-3.6-flash", "Gemini 3.6 Flash", emptyList()),
+            AgentModelOption("kimi-k2.7-code", "Kimi K2.7 Code", emptyList()),
+            AgentModelOption("glm-5.2", "GLM 5.2", emptyList()),
+            AgentModelOption("mystery-model", "Mystery", emptyList()),
+        ).groupedByModelFamily()
+
+        assertEquals(
+            listOf(
+                AgentModelFamily.Cursor,
+                AgentModelFamily.OpenAI,
+                AgentModelFamily.Anthropic,
+                AgentModelFamily.Google,
+                AgentModelFamily.Moonshot,
+                AgentModelFamily.Zhipu,
+                AgentModelFamily.Other,
+            ),
+            grouped.map { it.first },
+        )
+        assertEquals(listOf("auto", "composer-2.5"), grouped.first().second.map { it.id })
+        assertEquals("gpt-5.6-sol", grouped[1].second.single().id)
+        assertEquals(AgentModelFamily.Cursor, modelFamilyForId("cursor-grok-4.5"))
+        assertEquals(AgentModelFamily.XAI, modelFamilyForId("grok-4"))
+    }
+}

--- a/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
+++ b/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
@@ -76,69 +76,40 @@ class AgentTranscriptTest {
     }
 
     @Test
-    fun bottomItemIndexAccountsForOptionalTranscriptRows() {
-        assertEquals(
-            4,
-            transcriptBottomItemIndex(
-                displayItemCount = 2,
-                hasHeader = true,
-                hasPending = false,
-                hasOriginalPrompt = true,
-                isActive = true,
-            ),
-        )
-        assertEquals(
-            1,
-            transcriptBottomItemIndex(
-                displayItemCount = 2,
-                hasHeader = false,
-                hasPending = false,
-                hasOriginalPrompt = false,
-                isActive = false,
-            ),
-        )
+    fun reverseTranscriptBottomIsIndexZeroWithNoOffset() {
+        assertTrue(transcriptIsAtBottom(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0))
+        assertTrue(transcriptIsAtBottom(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 1))
+        assertTrue(!transcriptIsAtBottom(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 2))
+        assertTrue(!transcriptIsAtBottom(firstVisibleItemIndex = 1, firstVisibleItemScrollOffset = 0))
     }
 
     @Test
-    fun scrollAnchorTracksStreamingAssistantGrowth() {
-        val shortItems = transcriptDisplayItems(
-            listOf(AgentEvent.AssistantText(atMillis = 1, text = "Hel")),
-            compactToolCalls = true,
-        )
-        val longItems = transcriptDisplayItems(
-            listOf(AgentEvent.AssistantText(atMillis = 1, text = "Hello world")),
-            compactToolCalls = true,
-        )
+    fun scrollMemoryKeepsIndependentConversationPositions() {
+        val memory = TranscriptScrollMemory()
+        val first = TranscriptScrollPosition(index = 8, offset = 14, stickToBottom = false)
+        val second = TranscriptScrollPosition(index = 0, offset = 0, stickToBottom = true)
 
-        val shortAnchor = transcriptScrollAnchor(shortItems, hasHeader = false, hasPending = false, hasOriginalPrompt = false, isActive = true)
-        val longAnchor = transcriptScrollAnchor(longItems, hasHeader = false, hasPending = false, hasOriginalPrompt = false, isActive = true)
+        memory.save("first", first)
+        memory.save("second", second)
 
-        assertTrue(shortAnchor != longAnchor)
+        assertEquals(first, memory.get("first"))
+        assertEquals(second, memory.get("second"))
+        memory.remove("first")
+        assertEquals(null, memory.get("first"))
+        assertEquals(second, memory.get("second"))
     }
 
     @Test
-    fun scrollAnchorTracksCompletedContentMount() {
-        val items = transcriptDisplayItems(
-            listOf(AgentEvent.TaskResult(atMillis = 1, success = true, finalText = "Done.")),
-            compactToolCalls = true,
+    fun firstConversationVisitHasNoSavedPositionAndDefaultsToLiveEdge() {
+        val memory = TranscriptScrollMemory()
+
+        assertEquals(null, memory.get("new-chat"))
+        assertTrue(
+            transcriptIsAtBottom(
+                firstVisibleItemIndex = 0,
+                firstVisibleItemScrollOffset = 0,
+            ),
         )
-        val before = transcriptScrollAnchor(
-            items,
-            hasHeader = false,
-            hasPending = false,
-            hasOriginalPrompt = false,
-            isActive = false,
-            completedContentKey = null,
-        )
-        val after = transcriptScrollAnchor(
-            items,
-            hasHeader = false,
-            hasPending = false,
-            hasOriginalPrompt = false,
-            isActive = false,
-            completedContentKey = 3,
-        )
-        assertTrue(before != after)
     }
 
     @Test
@@ -172,51 +143,5 @@ class AgentTranscriptTest {
         val text = assertIs<AgentEvent.AssistantText>(merged.single())
         assertEquals(10, text.atMillis)
         assertEquals("Hello", text.text)
-    }
-
-    @Test
-    fun nearBottomRequiresLastItemBottomAlignedNotJustVisible() {
-        // Last item parked at the top of the viewport with empty space below — not pinned.
-        assertTrue(
-            !transcriptIsNearBottom(
-                transcriptBottomGapPx(
-                    lastItemIndex = 4,
-                    lastItemOffset = 0,
-                    lastItemSize = 40,
-                    totalItems = 5,
-                    viewportEndOffset = 800,
-                    canScrollForward = false,
-                    canScrollBackward = true,
-                ),
-            ),
-        )
-        // Tall last item scrolled so its bottom meets the viewport bottom.
-        assertTrue(
-            transcriptIsNearBottom(
-                transcriptBottomGapPx(
-                    lastItemIndex = 4,
-                    lastItemOffset = -1200,
-                    lastItemSize = 2000,
-                    totalItems = 5,
-                    viewportEndOffset = 800,
-                    canScrollForward = false,
-                    canScrollBackward = true,
-                ),
-            ),
-        )
-        // Short transcript that fits entirely.
-        assertTrue(
-            transcriptIsNearBottom(
-                transcriptBottomGapPx(
-                    lastItemIndex = 1,
-                    lastItemOffset = 100,
-                    lastItemSize = 40,
-                    totalItems = 2,
-                    viewportEndOffset = 800,
-                    canScrollForward = false,
-                    canScrollBackward = false,
-                ),
-            ),
-        )
     }
 }

--- a/src/commonTest/kotlin/app/andy/ui/components/ChatMarkdownTest.kt
+++ b/src/commonTest/kotlin/app/andy/ui/components/ChatMarkdownTest.kt
@@ -1,0 +1,19 @@
+package app.andy.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChatMarkdownTest {
+    @Test
+    fun promotesSingleChatNewlinesToMarkdownHardBreaks() {
+        assertEquals("first line  \nsecond line", "first line\nsecond line".withChatLineBreaks())
+    }
+
+    @Test
+    fun keepsParagraphAndFencedCodeFormattingIntact() {
+        assertEquals(
+            "first paragraph\n\nsecond paragraph\n```\nval answer = 42\n```",
+            "first paragraph\n\nsecond paragraph\n```\nval answer = 42\n```".withChatLineBreaks(),
+        )
+    }
+}

--- a/src/commonTest/kotlin/app/andy/ui/components/ScrollbarsTest.kt
+++ b/src/commonTest/kotlin/app/andy/ui/components/ScrollbarsTest.kt
@@ -35,6 +35,46 @@ class ScrollbarsTest {
     }
 
     @Test
+    fun reverseLayoutPlacesLiveEdgeThumbAtTheBottom() {
+        val metrics = lazyScrollbarMetrics(
+            totalItems = 3,
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            measuredItemSizes = mapOf(0 to 2_000, 1 to 120, 2 to 120),
+            viewportSize = 400,
+            itemSpacing = 10,
+            reverseLayout = true,
+        )
+
+        assertEquals(metrics.maxScrollOffset, metrics.scrollOffset)
+        val thumb = scrollbarThumb(400f, 28f, metrics)
+        assertEquals(400f - thumb.height, thumb.top)
+    }
+
+    @Test
+    fun reverseLayoutScrollbarBottomMapsToItemZero() {
+        val metrics = lazyScrollbarMetrics(
+            totalItems = 3,
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+            measuredItemSizes = mapOf(0 to 2_000, 1 to 120, 2 to 120),
+            viewportSize = 400,
+            itemSpacing = 10,
+            reverseLayout = true,
+        )
+        val target = lazyScrollbarTarget(
+            scrollOffset = metrics.maxScrollOffset,
+            totalItems = 3,
+            measuredItemSizes = mapOf(0 to 2_000, 1 to 120, 2 to 120),
+            viewportSize = 400,
+            itemSpacing = 10,
+            reverseLayout = true,
+        )
+
+        assertEquals(LazyScrollbarTarget(itemIndex = 0, itemScrollOffset = 0), target)
+    }
+
+    @Test
     fun scrollbarUsesAUsableMinimumThumbSize() {
         val thumb = scrollbarThumb(
             trackHeight = 600f,

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -5,6 +5,8 @@ import app.andy.model.AgentChangeSummary
 import app.andy.model.AgentEvent
 import app.andy.model.AgentFileDiff
 import app.andy.model.AgentKind
+import app.andy.model.AgentModelCatalog
+import app.andy.model.AgentModelOption
 import app.andy.model.coalesceAgentStreamDeltas
 import app.andy.model.AgentProviderDefaults
 import app.andy.model.AgentQueuedFollowUp
@@ -102,6 +104,9 @@ class DesktopAgentRunService(
     private val _cliStatuses = MutableStateFlow<List<AgentCliStatus>>(emptyList())
     override val cliStatuses: StateFlow<List<AgentCliStatus>> = _cliStatuses
 
+    private val _providerModels = MutableStateFlow<Map<AgentKind, List<AgentModelOption>>>(emptyMap())
+    override val providerModels: StateFlow<Map<AgentKind, List<AgentModelOption>>> = _providerModels
+
     private val _providerQuotas = MutableStateFlow<Map<AgentKind, AgentProviderQuota>>(emptyMap())
     override val providerQuotas: StateFlow<Map<AgentKind, AgentProviderQuota>> = _providerQuotas
 
@@ -131,6 +136,7 @@ class DesktopAgentRunService(
     private val mcpMutex = Mutex()
     private val quotaRefreshMutex = Mutex()
     private val quotaProbe = ProviderQuotaProbe()
+    private val modelProbe = ProviderModelProbe()
     private val ready = CompletableDeferred<Unit>()
     private var binaryOverrides: Map<String, String> = emptyMap()
     private lateinit var slots: Semaphore
@@ -1448,6 +1454,17 @@ class DesktopAgentRunService(
         ready.await()
         val statuses = withContext(Dispatchers.IO) { locator.locateAll(binaryOverrides) }
         _cliStatuses.value = statuses
+        val models = withContext(Dispatchers.IO) {
+            statuses.mapNotNull { status ->
+                val binary = status.binaryPath ?: return@mapNotNull null
+                if (!status.available) return@mapNotNull null
+                modelProbe.query(status.kind, binary)?.let { status.kind to it }
+            }.toMap()
+        }
+        if (models.isNotEmpty()) {
+            _providerModels.update { current -> current + models }
+            AgentModelCatalog.publishDiscovered(_providerModels.value)
+        }
     }
 
     override suspend fun refreshProviderQuotas() {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -49,6 +49,8 @@ import app.andy.service.McpServerService
 import app.andy.service.ProjectWorkflowService
 import app.andy.service.WorkspaceStore
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -1455,11 +1457,14 @@ class DesktopAgentRunService(
         val statuses = withContext(Dispatchers.IO) { locator.locateAll(binaryOverrides) }
         _cliStatuses.value = statuses
         val models = withContext(Dispatchers.IO) {
-            statuses.mapNotNull { status ->
-                val binary = status.binaryPath ?: return@mapNotNull null
-                if (!status.available) return@mapNotNull null
-                modelProbe.query(status.kind, binary)?.let { status.kind to it }
-            }.toMap()
+            statuses
+                .mapNotNull { status ->
+                    val binary = status.binaryPath?.takeIf { status.available } ?: return@mapNotNull null
+                    async { modelProbe.query(status.kind, binary)?.let { status.kind to it } }
+                }
+                .awaitAll()
+                .filterNotNull()
+                .toMap()
         }
         if (models.isNotEmpty()) {
             _providerModels.update { current -> current + models }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/ProviderModelProbe.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/ProviderModelProbe.kt
@@ -27,6 +27,7 @@ internal class ProviderModelProbe {
             .directory(File(System.getProperty("user.home")))
             .redirectErrorStream(true)
             .start()
+        process.outputStream.close()
         val output = StringBuffer()
         val reader = Thread({
             runCatching {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/ProviderModelProbe.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/ProviderModelProbe.kt
@@ -1,0 +1,47 @@
+package app.andy.desktop.service.agents
+
+import app.andy.model.AgentKind
+import app.andy.model.AgentModelOption
+import app.andy.model.parseAntigravityModels
+import app.andy.model.parseCursorModels
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Asks installed provider CLIs for their current model lists so Andy's composer
+ * can stay current without a hardcoded catalog bump for every release.
+ *
+ * Claude Code and Codex do not expose a stable non-interactive list command yet,
+ * so those providers keep using [app.andy.model.AgentModelCatalog].
+ */
+internal class ProviderModelProbe {
+    fun query(agent: AgentKind, binary: String): List<AgentModelOption>? = when (agent) {
+        AgentKind.Antigravity -> runModelsCommand(binary, listOf("models"))?.let(::parseAntigravityModels)?.takeIf { it.isNotEmpty() }
+        AgentKind.Cursor -> runModelsCommand(binary, listOf("models"))?.let(::parseCursorModels)?.takeIf { it.isNotEmpty() }
+        AgentKind.ClaudeCode, AgentKind.Codex -> null
+    }
+
+    private fun runModelsCommand(binary: String, args: List<String>): String? = runCatching {
+        if (!File(binary).canExecute()) return null
+        val process = ProcessBuilder(listOf(binary) + args)
+            .directory(File(System.getProperty("user.home")))
+            .redirectErrorStream(true)
+            .start()
+        val output = StringBuffer()
+        val reader = Thread({
+            runCatching {
+                process.inputStream.bufferedReader().use { stream -> output.append(stream.readText()) }
+            }
+        }, "andy-provider-models").apply { isDaemon = true }
+        reader.start()
+        if (!process.waitFor(15, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            process.waitFor(1, TimeUnit.SECONDS)
+            reader.join(1_000)
+            return null
+        }
+        reader.join(1_000)
+        if (process.exitValue() != 0) return null
+        output.toString().takeIf { it.isNotBlank() }
+    }.getOrNull()
+}

--- a/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
+++ b/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
@@ -435,6 +435,7 @@ internal object ScreenshotServices {
         private val task = AgentTask("task-1", "Tighten checkout validation", "Fix the empty postal code validation and add a regression test.", AgentKind.Codex, "garden", "/workspace/sample-app", "/workspace/sample-app", status = AgentTaskStatus.Completed, createdAtMillis = now - 40_000, startedAtMillis = now - 39_000, finishedAtMillis = now - 3_000, totalCostUsd = 0.18, inputTokens = 2_420, outputTokens = 860, contextTokens = 12_400, contextWindowTokens = 128_000, unread = true)
         override val tasks = MutableStateFlow(listOf(task))
         override val cliStatuses = MutableStateFlow(AgentKind.entries.map { AgentCliStatus(it, "/usr/local/bin/${it.cliName}", "1.0.0") })
+        override val providerModels = MutableStateFlow(emptyMap<AgentKind, List<app.andy.model.AgentModelOption>>())
         override val providerQuotas = MutableStateFlow(mapOf(AgentKind.Codex to AgentProviderQuota(listOf(AgentQuotaWindow("5 hour", 0.64f, now + 10_800_000)), now)))
         override val quotaAccess = MutableStateFlow(AgentQuotaAccess())
         override val providerDefaults = MutableStateFlow(mapOf(AgentKind.Codex to AgentProviderDefaults(model = "gpt-5.2-codex", reasoningEffort = AgentReasoningEffort.High)))

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentAdapterParsingTest.kt
@@ -371,9 +371,13 @@ class AntigravityAdapterTest {
 
     @Test
     fun selectedModelAndLevelBecomeAntigravityVariant() {
-        val configured = task(AgentKind.Antigravity).copy(model = "Gemini 3.5 Flash", reasoningEffort = AgentReasoningEffort.High)
-        val argv = adapter.buildCommand("/bin/agy", configured, mcpUrl = null)
-        assertTrue("--model" in argv && "Gemini 3.5 Flash (High)" in argv)
+        val legacy = task(AgentKind.Antigravity).copy(model = "Gemini 3.5 Flash", reasoningEffort = AgentReasoningEffort.High)
+        val legacyArgv = adapter.buildCommand("/bin/agy", legacy, mcpUrl = null)
+        assertTrue("--model" in legacyArgv && "Gemini 3.5 Flash (High)" in legacyArgv)
+
+        val slug = task(AgentKind.Antigravity).copy(model = "gemini-3.6-flash", reasoningEffort = AgentReasoningEffort.High)
+        val slugArgv = adapter.buildCommand("/bin/agy", slug, mcpUrl = null)
+        assertTrue("--model" in slugArgv && "gemini-3.6-flash-high" in slugArgv)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
@@ -1,0 +1,179 @@
+package app.andy.ui.agents
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.v2.runDesktopComposeUiTest
+import app.andy.model.AgentEvent
+import app.andy.ui.theme.AndyTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class AgentTranscriptUiTest {
+    @Test
+    fun firstVisitStartsAtLatestAndConversationRestoresItsOwnPosition() =
+        runTranscriptUiTest {
+            val memory = TranscriptScrollMemory()
+            var conversationId by mutableStateOf("first")
+            var events by mutableStateOf(
+                (0..40).map { index ->
+                    AgentEvent.UserMessage(atMillis = index.toLong(), text = "conversation row $index")
+                },
+            )
+
+            setContent {
+                AndyTheme {
+                    Box(Modifier.fillMaxSize()) {
+                        AgentTranscript(
+                            events = events,
+                            isActive = false,
+                            restoreScrollKey = conversationId,
+                            scrollMemory = memory,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                }
+            }
+            waitForIdle()
+
+            onNodeWithTag("transcript-row-UserMessage-40-40").assertIsDisplayed()
+
+            onNodeWithTag("transcript-list").performMouseInput {
+                moveTo(center)
+                scroll(-12f)
+            }
+            waitForIdle()
+            val saved = assertNotNull(memory.get("first"))
+            assertFalse(saved.stickToBottom)
+            assertTrue(saved.index > 0 || saved.offset > 0)
+
+            runOnUiThread { conversationId = "second" }
+            waitForIdle()
+            onNodeWithTag("transcript-row-UserMessage-40-40").assertIsDisplayed()
+            assertEquals(true, memory.get("second")?.stickToBottom)
+
+            // New content can arrive while the first conversation is away. Restoration uses
+            // the saved row key, not the now-stale numeric index.
+            runOnUiThread {
+                events = events + AgentEvent.UserMessage(atMillis = 41, text = "conversation row 41")
+            }
+            waitForIdle()
+            runOnUiThread { conversationId = "first" }
+            waitForIdle()
+            val restored = assertNotNull(memory.get("first"))
+            assertEquals(saved.anchorKey, restored.anchorKey)
+            assertEquals(saved.offset, restored.offset)
+            assertEquals(saved.index + 1, restored.index)
+            assertFalse(restored.stickToBottom)
+        }
+
+    @Test
+    fun streamingKeepsDetachedViewportFixedUntilLatestIsRequested() =
+        runTranscriptUiTest {
+            val memory = TranscriptScrollMemory()
+            var events by mutableStateOf(
+                (0..40).map { index ->
+                    AgentEvent.UserMessage(atMillis = index.toLong(), text = "history row $index")
+                } + AgentEvent.AssistantText(atMillis = 41, text = "stream start", isStreamDelta = true),
+            )
+
+            setContent {
+                AndyTheme {
+                    AgentTranscript(
+                        events = events,
+                        isActive = false,
+                        restoreScrollKey = "streaming",
+                        scrollMemory = memory,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+            waitForIdle()
+            assertEquals(true, memory.get("streaming")?.stickToBottom)
+
+            runOnUiThread {
+                events = events.dropLast(1) + AgentEvent.AssistantText(
+                    atMillis = 41,
+                    text = buildString {
+                        appendLine("stream start")
+                        repeat(20) { appendLine("early streamed line $it") }
+                    },
+                    isStreamDelta = true,
+                )
+            }
+            waitForIdle()
+            val pinned = assertNotNull(memory.get("streaming"))
+            assertEquals(true, pinned.stickToBottom)
+            assertEquals(0, pinned.index)
+            assertEquals(0, pinned.offset)
+
+            onNodeWithTag("transcript-list").performMouseInput {
+                moveTo(center)
+                scroll(-12f)
+            }
+            waitForIdle()
+            val detached = assertNotNull(memory.get("streaming"))
+            assertFalse(detached.stickToBottom)
+
+            runOnUiThread {
+                events = events.dropLast(1) + AgentEvent.AssistantText(
+                    atMillis = 41,
+                    text = buildString {
+                        appendLine("stream start")
+                        repeat(120) { appendLine("new streamed line $it") }
+                    },
+                    isStreamDelta = true,
+                )
+            }
+            waitForIdle()
+            assertEquals(detached, memory.get("streaming"))
+
+            onNodeWithTag("transcript-list").performMouseInput {
+                moveTo(center)
+                scroll(100f)
+            }
+            waitForIdle()
+            val relocked = assertNotNull(memory.get("streaming"))
+            assertEquals(true, relocked.stickToBottom)
+            assertEquals(0, relocked.index)
+            assertEquals(0, relocked.offset)
+
+            onNodeWithTag("transcript-list").performMouseInput {
+                moveTo(center)
+                scroll(-12f)
+            }
+            waitForIdle()
+            assertFalse(assertNotNull(memory.get("streaming")).stickToBottom)
+
+            onNodeWithText("↓  latest").performClick()
+            waitForIdle()
+            val followed = assertNotNull(memory.get("streaming"))
+            assertEquals(true, followed.stickToBottom)
+            assertEquals(0, followed.index)
+            assertEquals(0, followed.offset)
+        }
+
+    /** Some existing async service tests can leave one failure queued in coroutines-test. */
+    private fun runTranscriptUiTest(block: ComposeUiTest.() -> Unit) {
+        try {
+            runDesktopComposeUiTest(width = 800, height = 500, block = block)
+        } catch (error: IllegalStateException) {
+            if (error.message?.contains("uncaught exceptions before the test started") != true) throw error
+            runDesktopComposeUiTest(width = 800, height = 500, block = block)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Probe installed Cursor and Antigravity CLIs for live `models` output and parse effort/fast variants into Andy's catalog shape.
- Wire discovered models through `AgentRunService.providerModels` so the composer, profile controls, and CLI model-id builders stay current without hardcoded catalog bumps.
- Refactor agent transcript rendering and tighten markdown/scrollbar behavior, with new parsing and UI tests.

## Test plan
- [x] `./gradlew test`
- [ ] Verify Cursor model picker groups by vendor family when CLI is installed
- [ ] Verify Antigravity effort suffixes compose correctly from live model slugs
- [ ] Spot-check agent transcript markdown for code blocks, tool calls, and scrolling


Made with [Cursor](https://cursor.com)