### PR TITLE
Improve iOS HID keyboard and emulator high-FPS mirroring

### DIFF
--- a/native/andy-mirror/jni/andy_ios_sim.m
+++ b/native/andy-mirror/jni/andy_ios_sim.m
@@ -43,6 +43,7 @@ typedef struct {
     void *(*indigo_mouse)(CGPoint *, CGPoint *, uint32_t, uint32_t, uint32_t, double, double, double, double);
     void *(*indigo_mouse_edge)(CGPoint *, CGPoint *, uint32_t, uint32_t, uint32_t, double, double);
     void *(*indigo_keyboard)(void *, unsigned short, int);
+    void *(*indigo_hid_arbitrary)(uint32_t, uint32_t, uint32_t, uint32_t);
     void *(*indigo_button)(int, int, int);
     void *(*indigo_scroll)(uint32_t, double, double, double, int);
     void *(*create_pointer_service)(void);
@@ -196,6 +197,10 @@ static bool probe_ios_sim_runtime(void) {
     sim_runtime.indigo_mouse = indigo_mouse_symbol;
     sim_runtime.indigo_mouse_edge = indigo_mouse_symbol;
     sim_runtime.indigo_keyboard = dlsym(sim_runtime.simulator_kit, "IndigoHIDMessageForKeyboardNSEvent");
+    sim_runtime.indigo_hid_arbitrary = dlsym(sim_runtime.simulator_kit, "IndigoHIDMessageForHIDArbitrary");
+    if (!sim_runtime.indigo_hid_arbitrary) {
+        sim_runtime.indigo_hid_arbitrary = dlsym(sim_runtime.simulator_kit, "IndigoHIDMessageForKeyboardArbitrary");
+    }
     sim_runtime.indigo_button = dlsym(sim_runtime.simulator_kit, "IndigoHIDMessageForButton");
     sim_runtime.indigo_scroll = dlsym(sim_runtime.simulator_kit, "IndigoHIDMessageForScrollEvent");
     sim_runtime.create_pointer_service = dlsym(sim_runtime.simulator_kit, "IndigoHIDMessageToCreatePointerService");
@@ -572,7 +577,22 @@ Java_app_andy_desktop_service_ios_NativeIosSimJni_nativeContentSizePoints(JNIEnv
 
 // HID input implementation continues in second part - sendTouch, sendKey, etc.
 
+static const uint32_t kAndyIosHidKeyboardPage = 7;
+static const uint32_t kAndyIosHidKeyDown = 1;
+static const uint32_t kAndyIosHidKeyUp = 2;
+static const uint32_t kAndyIosHidModifierShift = 0xE1;
+
+typedef struct {
+    uint32_t usage;
+    bool shift;
+} AndyIosHidKeystroke;
+
 static bool send_hid_message_sync(void *message);
+static bool send_hid_arbitrary(uint32_t page, uint32_t usage, uint32_t operation);
+static bool send_hid_key_usage(uint32_t usage);
+static bool send_hid_keystroke(AndyIosHidKeystroke stroke);
+static bool ascii_to_hid_keystroke(unichar character, AndyIosHidKeystroke *stroke_out);
+static void send_text_via_keyboard_nsevent(NSString *value);
 static void activate_simulator_app(void);
 static void post_simulator_keyboard_shortcut(CGKeyCode key_code, CGEventFlags flags);
 
@@ -763,14 +783,99 @@ Java_app_andy_desktop_service_ios_NativeIosSimJni_nativeSendScroll(
     send_hid_message(message);
 }
 
-JNIEXPORT void JNICALL
-Java_app_andy_desktop_service_ios_NativeIosSimJni_nativeSendText(
-        JNIEnv *env, jclass clazz, jstring text) {
-    (void) clazz;
-    if (!sim_runtime.indigo_keyboard || !text) return;
-    const char *utf = (*env)->GetStringUTFChars(env, text, NULL);
-    if (!utf) return;
-    NSString *value = [NSString stringWithUTF8String:utf];
+static bool send_hid_arbitrary(uint32_t page, uint32_t usage, uint32_t operation) {
+    if (!sim_runtime.indigo_hid_arbitrary) return false;
+    void *message = sim_runtime.indigo_hid_arbitrary(kAndyIosHidTarget, page, usage, operation);
+    return message && send_hid_message_sync(message);
+}
+
+static bool send_hid_key_usage(uint32_t usage) {
+    if (!send_hid_arbitrary(kAndyIosHidKeyboardPage, usage, kAndyIosHidKeyDown)) return false;
+    return send_hid_arbitrary(kAndyIosHidKeyboardPage, usage, kAndyIosHidKeyUp);
+}
+
+static bool send_hid_keystroke(AndyIosHidKeystroke stroke) {
+    if (stroke.shift && !send_hid_arbitrary(kAndyIosHidKeyboardPage, kAndyIosHidModifierShift, kAndyIosHidKeyDown)) {
+        return false;
+    }
+    const bool ok = send_hid_key_usage(stroke.usage);
+    if (stroke.shift) {
+        (void) send_hid_arbitrary(kAndyIosHidKeyboardPage, kAndyIosHidModifierShift, kAndyIosHidKeyUp);
+    }
+    return ok;
+}
+
+static bool ascii_to_hid_keystroke(unichar character, AndyIosHidKeystroke *stroke_out) {
+    if (!stroke_out) return false;
+    stroke_out->shift = false;
+    if (character >= 'a' && character <= 'z') {
+        stroke_out->usage = 0x04u + (uint32_t) (character - 'a');
+        return true;
+    }
+    if (character >= 'A' && character <= 'Z') {
+        stroke_out->usage = 0x04u + (uint32_t) (character - 'A');
+        stroke_out->shift = true;
+        return true;
+    }
+    if (character >= '1' && character <= '9') {
+        stroke_out->usage = 0x1Eu + (uint32_t) (character - '1');
+        return true;
+    }
+    if (character == '0') {
+        stroke_out->usage = 0x27u;
+        return true;
+    }
+    if (character == ' ') {
+        stroke_out->usage = 0x2Cu;
+        return true;
+    }
+    if (character == '\n' || character == '\r') {
+        stroke_out->usage = 0x28u;
+        return true;
+    }
+    if (character == '\t') {
+        stroke_out->usage = 0x2Bu;
+        return true;
+    }
+    switch (character) {
+        case '-': stroke_out->usage = 0x2Du; return true;
+        case '_': stroke_out->usage = 0x2Du; stroke_out->shift = true; return true;
+        case '=': stroke_out->usage = 0x2Eu; return true;
+        case '+': stroke_out->usage = 0x2Eu; stroke_out->shift = true; return true;
+        case '[': stroke_out->usage = 0x2Fu; return true;
+        case '{': stroke_out->usage = 0x2Fu; stroke_out->shift = true; return true;
+        case ']': stroke_out->usage = 0x30u; return true;
+        case '}': stroke_out->usage = 0x30u; stroke_out->shift = true; return true;
+        case '\\': stroke_out->usage = 0x31u; return true;
+        case '|': stroke_out->usage = 0x31u; stroke_out->shift = true; return true;
+        case ';': stroke_out->usage = 0x33u; return true;
+        case ':': stroke_out->usage = 0x33u; stroke_out->shift = true; return true;
+        case '\'': stroke_out->usage = 0x34u; return true;
+        case '"': stroke_out->usage = 0x34u; stroke_out->shift = true; return true;
+        case '`': stroke_out->usage = 0x35u; return true;
+        case '~': stroke_out->usage = 0x35u; stroke_out->shift = true; return true;
+        case ',': stroke_out->usage = 0x36u; return true;
+        case '<': stroke_out->usage = 0x36u; stroke_out->shift = true; return true;
+        case '.': stroke_out->usage = 0x37u; return true;
+        case '>': stroke_out->usage = 0x37u; stroke_out->shift = true; return true;
+        case '/': stroke_out->usage = 0x38u; return true;
+        case '?': stroke_out->usage = 0x38u; stroke_out->shift = true; return true;
+        case '!': stroke_out->usage = 0x1Eu; stroke_out->shift = true; return true;
+        case '@': stroke_out->usage = 0x1Fu; stroke_out->shift = true; return true;
+        case '#': stroke_out->usage = 0x20u; stroke_out->shift = true; return true;
+        case '$': stroke_out->usage = 0x21u; stroke_out->shift = true; return true;
+        case '%': stroke_out->usage = 0x22u; stroke_out->shift = true; return true;
+        case '^': stroke_out->usage = 0x23u; stroke_out->shift = true; return true;
+        case '&': stroke_out->usage = 0x24u; stroke_out->shift = true; return true;
+        case '*': stroke_out->usage = 0x25u; stroke_out->shift = true; return true;
+        case '(': stroke_out->usage = 0x26u; stroke_out->shift = true; return true;
+        case ')': stroke_out->usage = 0x27u; stroke_out->shift = true; return true;
+        default: return false;
+    }
+}
+
+static void send_text_via_keyboard_nsevent(NSString *value) {
+    if (!sim_runtime.indigo_keyboard || !value) return;
     for (NSUInteger i = 0; i < value.length; i++) {
         const unichar character = [value characterAtIndex:i];
         void *message = sim_runtime.indigo_keyboard(NULL, character, NSEventTypeKeyDown);
@@ -778,7 +883,35 @@ Java_app_andy_desktop_service_ios_NativeIosSimJni_nativeSendText(
         message = sim_runtime.indigo_keyboard(NULL, character, NSEventTypeKeyUp);
         send_hid_message(message);
     }
+}
+
+JNIEXPORT void JNICALL
+Java_app_andy_desktop_service_ios_NativeIosSimJni_nativeSendText(
+        JNIEnv *env, jclass clazz, jstring text) {
+    (void) clazz;
+    if (!text) return;
+    const char *utf = (*env)->GetStringUTFChars(env, text, NULL);
+    if (!utf) return;
+    NSString *value = [NSString stringWithUTF8String:utf];
+    if (sim_runtime.indigo_hid_arbitrary) {
+        for (NSUInteger i = 0; i < value.length; i++) {
+            AndyIosHidKeystroke stroke = {0};
+            if (!ascii_to_hid_keystroke([value characterAtIndex:i], &stroke)) continue;
+            (void) send_hid_keystroke(stroke);
+        }
+    } else {
+        send_text_via_keyboard_nsevent(value);
+    }
     (*env)->ReleaseStringUTFChars(env, text, utf);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_app_andy_desktop_service_ios_NativeIosSimJni_nativeSendKey(
+        JNIEnv *env, jclass clazz, jint hid_usage) {
+    (void) env;
+    (void) clazz;
+    if (hid_usage <= 0 || !sim_runtime.indigo_hid_arbitrary) return JNI_FALSE;
+    return send_hid_key_usage((uint32_t) hid_usage) ? JNI_TRUE : JNI_FALSE;
 }
 
 static void send_home_gesture(void) {

--- a/src/commonMain/kotlin/app/andy/service/RoutingMirrorEngine.kt
+++ b/src/commonMain/kotlin/app/andy/service/RoutingMirrorEngine.kt
@@ -51,17 +51,35 @@ class RoutingMirrorEngine(
     init {
         scope.launch {
             androidEngine.flatMapLatest { it.session }.collect { session ->
-                if (session != null && IosTargetRegistry.isIosTarget(session.serial)) return@collect
-                if (session != null || _session.value?.let { !IosTargetRegistry.isIosTarget(it.serial) } != false) {
+                if (session != null) {
+                    if (IosTargetRegistry.isIosTarget(session.serial)) return@collect
                     _session.value = session
+                    return@collect
+                }
+                // Ignore stale disconnects once the Android engine has already reconnected.
+                val current = _session.value
+                if (current != null &&
+                    !IosTargetRegistry.isIosTarget(current.serial) &&
+                    android().session.value == null
+                ) {
+                    _session.compareAndSet(current, null)
                 }
             }
         }
         scope.launch {
             ios.session.collect { session ->
-                if (session != null && !IosTargetRegistry.isIosTarget(session.serial)) return@collect
-                if (session != null || _session.value?.let { IosTargetRegistry.isIosTarget(it.serial) } != false) {
+                if (session != null) {
+                    if (!IosTargetRegistry.isIosTarget(session.serial)) return@collect
                     _session.value = session
+                    return@collect
+                }
+                // Ignore stale disconnects once the iOS engine has already reconnected.
+                val current = _session.value
+                if (current != null &&
+                    IosTargetRegistry.isIosTarget(current.serial) &&
+                    ios.session.value == null
+                ) {
+                    _session.compareAndSet(current, null)
                 }
             }
         }

--- a/src/commonMain/kotlin/app/andy/ui/live/LiveDevicePane.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/LiveDevicePane.kt
@@ -126,6 +126,7 @@ internal fun LiveDevicePane(
     showChromeControls: Boolean = true,
     showAndroidNavButtons: Boolean = true,
     showHardwareControls: Boolean = showChromeControls,
+    showClipTextControl: Boolean = false,
     showContainerChrome: Boolean = true,
     deviceBorderWidth: Dp = 5.dp,
     deviceCornerRadius: Dp = 10.dp,
@@ -191,6 +192,11 @@ internal fun LiveDevicePane(
                 recordEnabled = recordEnabled,
                 recordingDuration = recordingDuration,
                 showRecord = showRecord,
+                onClipText = onClipText,
+            )
+        } else if (showClipTextControl) {
+            LiveClipTextToolbar(
+                enabled = serial != null,
                 onClipText = onClipText,
             )
         }
@@ -427,6 +433,30 @@ internal fun CompactHardwareButton(label: String, serial: String?, onClick: () -
         contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
     ) {
         Text(label, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+}
+
+@Composable
+internal fun LiveClipTextToolbar(
+    enabled: Boolean,
+    onClipText: () -> Unit,
+) {
+    Box(
+        Modifier.width(68.dp).fillMaxHeight(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            Modifier
+                .width(58.dp)
+                .clip(RoundedCornerShape(15.dp))
+                .background(AndyColors.Neutral900.copy(alpha = 0.92f))
+                .border(1.dp, Color.White.copy(alpha = 0.04f), RoundedCornerShape(15.dp))
+                .padding(vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(3.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            ToolbarButton(HardwareIcon.Clip, "Clip", enabled, onClipText)
+        }
     }
 }
 

--- a/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
@@ -468,6 +468,7 @@ internal fun LiveScreen(
                 },
                 showAndroidNavButtons = !isIosTarget,
                 showHardwareControls = !isIosTarget,
+                showClipTextControl = !isIosTarget || iosInputEnabled,
                 passThroughInput = !isIosTarget || iosInputEnabled,
                 terminalPlacement = terminalPlacement.takeIf { iosSinglePane },
                 onTerminalToggle = if (iosSinglePane) ::toggleTerminal else null,

--- a/src/commonTest/kotlin/app/andy/service/RoutingMirrorEngineTest.kt
+++ b/src/commonTest/kotlin/app/andy/service/RoutingMirrorEngineTest.kt
@@ -8,12 +8,18 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class RoutingMirrorEngineTest {
+    @AfterTest
+    fun tearDown() {
+        IosTargetRegistry.update(emptyList())
+    }
+
     @Test
     fun connectToIosDisconnectsAndroidFirst() = runBlocking {
         val android = TrackingMirrorEngine("android")

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopAvdService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopAvdService.kt
@@ -457,6 +457,8 @@ class DesktopAvdService(
             "hw.camera.front" to config.frontCamera.configValue,
             "locale" to config.locale.takeIf { it.isNotBlank() },
             "hw.keyboard" to config.hardwareKeyboard.toString(),
+            // Guest display defaults to 60 Hz; raise so Live maxFps>60 can actually land.
+            "hw.lcd.vsync" to emulatorVsyncRate().toString(),
         ).filterValues { it != null }.mapValues { it.value.orEmpty() }
         configFile.parentFile?.mkdirs()
         val existing = if (configFile.exists()) configFile.readLines().toMutableList() else mutableListOf()
@@ -608,11 +610,51 @@ internal data class EmulatorLaunchPorts(
     val grpc: Int,
 )
 
+/** Default guest vsync; matches Andy's Live maxFps ceiling. Override with ANDY_EMULATOR_VSYNC_RATE. */
+internal const val DEFAULT_EMULATOR_VSYNC_RATE = 120
+
+internal const val EMULATOR_VSYNC_RATE_ENV = "ANDY_EMULATOR_VSYNC_RATE"
+
+/**
+ * Guest display refresh in Hz for `-vsync-rate` / `hw.lcd.vsync`.
+ * Emulator docs: rates above the host refresh are undefined — use the env override on 60 Hz hosts.
+ */
+internal fun emulatorVsyncRate(env: (String) -> String? = System::getenv): Int {
+    val override = env(EMULATOR_VSYNC_RATE_ENV)?.trim()?.toIntOrNull()
+    return override?.takeIf { it > 0 } ?: DEFAULT_EMULATOR_VSYNC_RATE
+}
+
+/**
+ * `-vsync-rate` only raises the guest *mode* ceiling. Android still defaults
+ * `mActiveRenderFrameRate` to 60 until peak/min refresh settings (and optionally the
+ * user-preferred mode) match the target. Apply these before scrcpy starts.
+ */
+internal fun emulatorGuestRefreshShellCommands(
+    rateHz: Int,
+    displayWidth: Int = 0,
+    displayHeight: Int = 0,
+): List<List<String>> {
+    val hz = rateHz.coerceIn(1, 240)
+    val commands = mutableListOf(
+        listOf("settings", "put", "system", "peak_refresh_rate", hz.toString()),
+        listOf("settings", "put", "system", "min_refresh_rate", hz.toString()),
+    )
+    if (displayWidth > 0 && displayHeight > 0) {
+        commands += listOf(
+            "cmd", "display", "set-user-preferred-display-mode",
+            displayWidth.toString(), displayHeight.toString(), hz.toString(),
+            "0", "false",
+        )
+    }
+    return commands
+}
+
 internal fun emulatorStudioStyleLaunchCommand(
     emulator: String,
     name: String,
     extraArgs: List<String> = emptyList(),
     ports: EmulatorLaunchPorts = EmulatorLaunchPorts(console = 5554, adb = 5555, grpc = 8554),
+    vsyncRate: Int = emulatorVsyncRate(),
 ): List<String> {
     return listOf(
         emulator,
@@ -625,5 +667,6 @@ internal fun emulatorStudioStyleLaunchCommand(
         "-no-boot-anim",
         "-gpu", "auto",
         "-writable-system",
+        "-vsync-rate", vsyncRate.toString(),
     )
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/ios/DesktopIosMirrorEngine.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/ios/DesktopIosMirrorEngine.kt
@@ -441,8 +441,7 @@ class DesktopIosMirrorEngine(
         return withContext(Dispatchers.IO) {
             val requiresHid = when (input) {
                 MirrorInput.Back,
-                MirrorInput.Recents,
-                is MirrorInput.Key -> false
+                MirrorInput.Recents -> false
                 else -> true
             }
             if (requiresHid) {
@@ -507,7 +506,15 @@ class DesktopIosMirrorEngine(
                     CommandResult.success("Sent")
                 }
                 MirrorInput.Back, MirrorInput.Recents -> CommandResult.failure("No iOS equivalent")
-                is MirrorInput.Key -> CommandResult.failure("Use text input for iOS keyboard")
+                is MirrorInput.Key -> {
+                    val hidUsage = androidKeyCodeToIosHidUsage(input.keyCode)
+                        ?: return@withContext CommandResult.failure("Unsupported iOS key ${input.keyCode}")
+                    if (NativeIosSimJni.sendKey(hidUsage)) {
+                        CommandResult.success("Sent")
+                    } else {
+                        CommandResult.failure("Simulator HID did not accept key ${input.keyCode}")
+                    }
+                }
             }
         }
     }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/ios/IosHidKeyboard.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/ios/IosHidKeyboard.kt
@@ -1,0 +1,18 @@
+package app.andy.desktop.service.ios
+
+/**
+ * Maps Android [android.view.KeyEvent] key codes (what [app.andy.MirrorVideoSurface] emits as
+ * [app.andy.service.MirrorInput.Key]) to USB HID keyboard usages (page 7) for SimulatorKit.
+ */
+internal fun androidKeyCodeToIosHidUsage(keyCode: Int): Int? = when (keyCode) {
+    66 -> 0x28 // ENTER
+    67 -> 0x2A // DEL / BACKSPACE
+    112 -> 0x4C // FORWARD_DEL
+    61 -> 0x2B // TAB
+    111 -> 0x29 // ESCAPE
+    19 -> 0x52 // DPAD_UP
+    20 -> 0x51 // DPAD_DOWN
+    21 -> 0x50 // DPAD_LEFT
+    22 -> 0x4F // DPAD_RIGHT
+    else -> null
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/service/ios/NativeIosJni.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/ios/NativeIosJni.kt
@@ -52,6 +52,9 @@ internal object NativeIosSimJni {
         if (ensureLoaded().isSuccess) runCatching { nativeSendText(value) }
     }
 
+    fun sendKey(hidUsage: Int): Boolean =
+        ensureLoaded().isSuccess && runCatching { nativeSendKey(hidUsage) }.getOrDefault(false)
+
     fun sendButton(button: Int) {
         if (ensureLoaded().isSuccess) runCatching { nativeSendButton(button) }
     }
@@ -91,6 +94,7 @@ internal object NativeIosSimJni {
     private external fun nativeSendTouch(action: Int, nx: Float, ny: Float): Boolean
     private external fun nativeSendSwipe(startX: Float, startY: Float, endX: Float, endY: Float, steps: Int)
     private external fun nativeSendText(value: String)
+    private external fun nativeSendKey(hidUsage: Int): Boolean
     private external fun nativeSendButton(button: Int)
 }
 

--- a/src/desktopMain/kotlin/app/andy/desktop/service/mirror/DesktopMirrorEngine.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/mirror/DesktopMirrorEngine.kt
@@ -3,6 +3,8 @@ package app.andy.desktop.service.mirror
 import app.andy.desktop.service.CommandRunner
 import app.andy.desktop.service.DesktopDeviceService
 import app.andy.desktop.parser.AndroidParsers
+import app.andy.desktop.service.emulatorGuestRefreshShellCommands
+import app.andy.desktop.service.emulatorVsyncRate
 import app.andy.desktop.service.emulator.EMULATOR_IMAGE_BYTES_PER_PIXEL
 import app.andy.desktop.service.emulator.EmulatorGrpcClient
 import app.andy.desktop.service.emulator.EmulatorMappedFramebuffer
@@ -369,6 +371,8 @@ class DesktopMirrorEngine(
             val wireless = isWirelessAdbSerial(serial)
             if (emulator) {
                 awaitEmulatorReady(adb, serial)
+                // -vsync-rate alone leaves renderFrameRate at 60; force peak/min to match Live FPS.
+                applyEmulatorGuestRefreshRate(adb, serial, config.maxFps)
             }
             var coldStartAttempt = 0
             while (isActive && connectedSerial == serial) {
@@ -701,6 +705,23 @@ class DesktopMirrorEngine(
             delay(EMULATOR_BOOT_POLL_MILLIS)
         }
         status.value = "Emulator boot wait timed out — starting mirror anyway"
+    }
+
+    /**
+     * Emulator guest vsync can be 120 while Android still renders at 60 (`defaultRefreshRate`).
+     * Align system peak/min refresh (and preferred mode) with Live maxFps before scrcpy captures.
+     */
+    private suspend fun applyEmulatorGuestRefreshRate(adb: String, serial: String, maxFps: Int) {
+        val rate = maxOf(maxFps, emulatorVsyncRate()).coerceIn(1, 240)
+        val display = readEmulatorDisplaySize(adb, serial)
+        val commands = emulatorGuestRefreshShellCommands(
+            rateHz = rate,
+            displayWidth = display?.width ?: 0,
+            displayHeight = display?.height ?: 0,
+        )
+        for (shellArgs in commands) {
+            runner.run(listOf(adb, "-s", serial, "shell") + shellArgs, timeoutSeconds = 3)
+        }
     }
 
     override suspend fun screenshot(serial: String): ByteArray? {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopServicesMockDeviceTest.kt
@@ -108,12 +108,49 @@ class DesktopServicesMockDeviceTest {
         assertTrue(command.windowed(2).any { it == listOf("-grpc", "8560") })
         assertTrue(command.windowed(2).any { it == listOf("-idle-grpc-timeout", "300") })
         assertTrue(command.windowed(2).any { it == listOf("-gpu", "auto") })
+        assertTrue(command.windowed(2).any { it == listOf("-vsync-rate", "120") })
         assertTrue("-writable-system" in command)
         assertTrue("-no-snapshot-load" in command)
         assertTrue("-no-snapshot-save" in command)
         assertFalse("-no-window" in command)
         assertFalse("-grpc-use-token" in command)
         assertFalse("swiftshader_indirect" in command)
+    }
+
+    @Test
+    fun emulatorVsyncRateDefaultsTo120AndHonorsEnvOverride() {
+        assertEquals(120, emulatorVsyncRate { null })
+        assertEquals(120, emulatorVsyncRate { "" })
+        assertEquals(120, emulatorVsyncRate { "0" })
+        assertEquals(120, emulatorVsyncRate { "nope" })
+        assertEquals(90, emulatorVsyncRate { key ->
+            if (key == EMULATOR_VSYNC_RATE_ENV) "90" else null
+        })
+        val command = emulatorStudioStyleLaunchCommand(
+            emulator = "/sdk/emulator/emulator",
+            name = "Pixel_8",
+            vsyncRate = 90,
+        )
+        assertTrue(command.windowed(2).any { it == listOf("-vsync-rate", "90") })
+    }
+
+    @Test
+    fun emulatorGuestRefreshShellCommandsForcePeakAndMin() {
+        assertEquals(
+            listOf(
+                listOf("settings", "put", "system", "peak_refresh_rate", "120"),
+                listOf("settings", "put", "system", "min_refresh_rate", "120"),
+            ),
+            emulatorGuestRefreshShellCommands(120),
+        )
+        assertEquals(
+            listOf(
+                listOf("settings", "put", "system", "peak_refresh_rate", "120"),
+                listOf("settings", "put", "system", "min_refresh_rate", "120"),
+                listOf("cmd", "display", "set-user-preferred-display-mode", "1080", "2424", "120", "0", "false"),
+            ),
+            emulatorGuestRefreshShellCommands(120, displayWidth = 1080, displayHeight = 2424),
+        )
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/ios/IosHidKeyboardTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/ios/IosHidKeyboardTest.kt
@@ -1,0 +1,21 @@
+package app.andy.desktop.service.ios
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class IosHidKeyboardTest {
+    @Test
+    fun mapsCommonAndroidKeyCodesToHidUsages() {
+        assertEquals(0x28, androidKeyCodeToIosHidUsage(66))
+        assertEquals(0x2A, androidKeyCodeToIosHidUsage(67))
+        assertEquals(0x2B, androidKeyCodeToIosHidUsage(61))
+        assertEquals(0x52, androidKeyCodeToIosHidUsage(19))
+        assertEquals(0x4F, androidKeyCodeToIosHidUsage(22))
+    }
+
+    @Test
+    fun ignoresUnsupportedAndroidKeyCodes() {
+        assertNull(androidKeyCodeToIosHidUsage(24))
+    }
+}


### PR DESCRIPTION
## Summary
- Route iOS Simulator text and special keys through HID usages (with NSEvent keyboard fallback), and map Android key codes for Live keyboard input.
- Show the clip-text control for iOS targets when mirror input is enabled.
- Raise emulator guest vsync (`-vsync-rate` / `hw.lcd.vsync`) and apply peak/min refresh settings so Live FPS above 60 can take effect.

## Test plan
- [x] `./gradlew desktopTest --tests 'app.andy.desktop.service.ios.IosHidKeyboardTest' --tests 'app.andy.desktop.service.DesktopServicesMockDeviceTest'`
- [ ] Manually type and use Enter/Backspace/arrows on an iOS Simulator mirror session
- [ ] Confirm clip-text appears for iOS when input is enabled
- [ ] Launch an AVD and verify guest refresh aligns with Live max FPS (or `ANDY_EMULATOR_VSYNC_RATE`)


Made with [Cursor](https://cursor.com)