### PR TITLE
Improve agent scrollback replay and session reattachment

### DIFF
--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -345,6 +345,9 @@ interface AgentRunService {
         imagePaths: List<String> = emptyList(),
         skills: List<AgentSkill> = emptyList(),
     )
+    /** Reopens a stored provider session so the live interactive terminal UI comes back. */
+    fun reattachSession(taskId: String)
+    fun canReattachSession(taskId: String): Boolean
     /** Supplies an answer to an agent-issued decision checkpoint and continues the task. */
     fun respondToUserInput(taskId: String, requestId: String, answers: Map<String, String>)
     /** Holds a follow-up until the active run completes successfully. */
@@ -363,6 +366,8 @@ interface AgentRunService {
     fun markRead(taskId: String)
     /** Marks a chat unread so list/dock badges show again. */
     fun markUnread(taskId: String)
+    /** Tracks whether an embedded chat is currently on screen (not merely opened before). */
+    fun setChatViewing(taskId: String?, viewing: Boolean)
     /** Hides a finished chat from the default list without deleting it. */
     fun archive(taskId: String)
     /** Restores an archived chat to the default list. */

--- a/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
+++ b/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
@@ -263,6 +263,10 @@ object UnavailableAgentRunService : AgentRunService {
     override fun completeWorkflowRun(taskId: String) = Unit
     override suspend fun retry(taskId: String) = Unit
     override fun resume(taskId: String, followUp: String, imagePaths: List<String>, skills: List<AgentSkill>) = Unit
+
+    override fun reattachSession(taskId: String) = Unit
+
+    override fun canReattachSession(taskId: String): Boolean = false
     override fun respondToUserInput(taskId: String, requestId: String, answers: Map<String, String>) = Unit
     override fun queueFollowUp(taskId: String, followUp: String, imagePaths: List<String>, skills: List<AgentSkill>) = Unit
     override fun removeQueuedFollowUp(taskId: String, queueIndex: Int) = Unit
@@ -270,6 +274,7 @@ object UnavailableAgentRunService : AgentRunService {
     override suspend fun delete(taskId: String, removeWorktree: Boolean) = Unit
     override fun markRead(taskId: String) = Unit
     override fun markUnread(taskId: String) = Unit
+    override fun setChatViewing(taskId: String?, viewing: Boolean) = Unit
     override fun archive(taskId: String) = Unit
     override fun unarchive(taskId: String) = Unit
     override fun events(taskId: String) = MutableStateFlow(emptyList<AgentEvent>())

--- a/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -207,6 +208,7 @@ private fun ProjectCockpit(
     }
 
     fun closeTerminalTab(runId: String) {
+        services.actionRuns.stop(runId)
         val remaining = terminalTabIds.filter { it != runId }
         terminalTabIds = remaining
         if (activeRunId == runId) onActiveRunIdChange(remaining.lastOrNull())
@@ -290,11 +292,15 @@ private fun ProjectCockpit(
     // Open chats stay read — including while a live run is on screen.
     // Only while Projects is the active destination: RetainedDestination keeps this
     // screen composed off-page, and clearing unread there would hide the badge.
-    LaunchedEffect(active, selectedProjectTask?.id, canvas) {
-        if (!active) return@LaunchedEffect
-        val task = selectedProjectTask ?: return@LaunchedEffect
-        if (canvas != ProjectCanvas.Chat) return@LaunchedEffect
-        services.agentRuns.markRead(task.id)
+    DisposableEffect(active, selectedProjectTask?.id, canvas) {
+        val taskId = selectedProjectTask?.id?.takeIf { active && canvas == ProjectCanvas.Chat }
+        if (taskId != null) {
+            services.agentRuns.setChatViewing(taskId, viewing = true)
+            services.agentRuns.markRead(taskId)
+        }
+        onDispose {
+            if (taskId != null) services.agentRuns.setChatViewing(taskId, viewing = false)
+        }
     }
     LaunchedEffect(loadedProjectWorkflow?.tasks, selectedWorkflowTaskId) {
         if (selectedWorkflowTaskId != null && loadedProjectWorkflow != null && loadedProjectWorkflow.tasks.none { it.id == selectedWorkflowTaskId }) {

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentsScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -109,12 +110,14 @@ private fun AgentCommandCenter(
     val activeTasks = inbox.filter { it.isActive }
     // Open chats stay read — including when a live run finishes while you're watching.
     // Gate on [active] so a retained Agents pane off-destination cannot clear unread.
-    LaunchedEffect(active, selected?.id, selected?.status, composing) {
-        if (!active) return@LaunchedEffect
-        val task = selected ?: return@LaunchedEffect
-        if (composing) return@LaunchedEffect
-        if (task.unread && !task.isActive) {
-            services.agentRuns.markRead(task.id)
+    DisposableEffect(active, selected?.id, composing) {
+        val taskId = selected?.id?.takeIf { active && !composing }
+        if (taskId != null) {
+            services.agentRuns.setChatViewing(taskId, viewing = true)
+            services.agentRuns.markRead(taskId)
+        }
+        onDispose {
+            if (taskId != null) services.agentRuns.setChatViewing(taskId, viewing = false)
         }
     }
 

--- a/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
@@ -267,6 +267,7 @@ internal fun LiveScreen(
     }
 
     fun closeTerminalTab(runId: String) {
+        services.actionRuns.stop(runId)
         val remaining = terminalTabIds.filter { it != runId }
         terminalTabIds = remaining
         if (activeRunId == runId) onActiveRunIdChange(remaining.lastOrNull())

--- a/src/desktopMain/kotlin/app/andy/desktop/service/AgentAttentionCoordinator.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/AgentAttentionCoordinator.kt
@@ -32,6 +32,7 @@ class DesktopAgentAttentionCoordinator(
                 AgentTaskStatus.Completed -> AgentAttentionKind.Done
                 AgentTaskStatus.WaitingForInput -> AgentAttentionKind.Blocked
                 AgentTaskStatus.Failed -> AgentAttentionKind.Failed
+                AgentTaskStatus.Paused -> AgentAttentionKind.Idle
                 else -> null
             }
             // A task that first appears already terminal is not an observed status

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -56,11 +56,14 @@ class DesktopActionRunService(
         initialCommand = null,
     )
 
-    override fun run(project: ActionProject, action: ProjectAction): String = start(
-        project = project,
-        action = action,
-        initialCommand = action.command.takeIf { it.isNotBlank() },
-    )
+    override fun run(project: ActionProject, action: ProjectAction): String {
+        clearExistingRuns(project.id, action.id)
+        return start(
+            project = project,
+            action = action,
+            initialCommand = action.command.takeIf { it.isNotBlank() },
+        )
+    }
 
     private fun start(project: ActionProject, action: ProjectAction, initialCommand: String?): String {
         val runId = "run-${nextRun.getAndIncrement()}"
@@ -154,6 +157,12 @@ class DesktopActionRunService(
         handles.values.forEach { handle ->
             (handle.session as? KetraTermBackend)?.updateAppearance(appearance)
         }
+    }
+
+    private fun clearExistingRuns(projectId: String, actionId: String) {
+        _running.value
+            .filter { it.projectId == projectId && it.actionId == actionId }
+            .forEach { clear(it.runId) }
     }
 
     private fun markComplete(runId: String, status: ActionRunStatus, exitCode: Int?) {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentSessionAttention.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentSessionAttention.kt
@@ -1,0 +1,27 @@
+package app.andy.desktop.service.agents
+
+import app.andy.model.AgentSessionStatus
+import app.andy.model.AgentTask
+import app.andy.model.AgentTaskStatus
+import app.andy.model.ProjectWorkflowStage
+
+/** True when a live embedded session needs an unread badge after [next] replaces [previous]. */
+internal fun sessionStatusNeedsUnread(
+    task: AgentTask,
+    previous: AgentSessionStatus?,
+    next: AgentSessionStatus,
+    viewing: Boolean,
+): Boolean {
+    if (viewing) return false
+    if (task.workflowStage == ProjectWorkflowStage.Build && task.isActive) return false
+    if (!task.isActive && task.status != AgentTaskStatus.Paused) return false
+    return when (next) {
+        AgentSessionStatus.Done ->
+            previous == AgentSessionStatus.Working || previous == AgentSessionStatus.Blocked
+        AgentSessionStatus.Blocked ->
+            previous != AgentSessionStatus.Blocked
+        AgentSessionStatus.Idle ->
+            previous == AgentSessionStatus.Working || previous == AgentSessionStatus.Blocked
+        else -> false
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentStatusTracker.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentStatusTracker.kt
@@ -96,7 +96,9 @@ class AgentStatusTracker(
             hookStatus == AgentSessionStatus.Done && (scrapeStatus == AgentSessionStatus.Idle || quiescentAtPrompt) -> {
                 if (isTabSeen()) AgentSessionStatus.Idle else AgentSessionStatus.Done
             }
-            scrapeStatus == AgentSessionStatus.Idle || quiescentAtPrompt -> AgentSessionStatus.Idle
+            scrapeStatus == AgentSessionStatus.Idle || quiescentAtPrompt -> {
+                if (isTabSeen()) AgentSessionStatus.Idle else AgentSessionStatus.Done
+            }
             hookStatus == AgentSessionStatus.Working || scrapeStatus == AgentSessionStatus.Working ->
                 AgentSessionStatus.Working
             hookStatus == AgentSessionStatus.Idle ->

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
@@ -11,6 +11,8 @@ import app.andy.terminal.TerminalSession
 import app.andy.terminal.TerminalSessions
 import app.andy.terminal.atomicWriteText
 import app.andy.terminal.capScrollbackSize
+import app.andy.terminal.joinReadableLines
+import app.andy.terminal.resolveScrollbackForReplay
 import io.github.ketraterm.ui.swing.api.SwingTerminal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,6 +27,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.awt.Component
 import java.io.File
+import java.util.LinkedHashSet
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -47,6 +50,8 @@ class AgentTerminalManager(
         val artifactDir: File,
         val scrollbackPath: File,
         val committedScrollbackPrefix: String,
+        val capturedLineKeys: MutableSet<String>,
+        val capturedLines: MutableList<String>,
         @Volatile var stopRequested: Boolean = false,
         @Volatile var waitJob: Job? = null,
         @Volatile var scrollbackJob: Job? = null,
@@ -181,7 +186,7 @@ class AgentTerminalManager(
         artifacts.start()
         tracker.start()
         val scrollbackPath = scrollbackFile(task.id)
-        val committedPrefix = loadCommittedScrollbackPrefix(scrollbackPath)
+        val (committedPrefix, capturedKeys, capturedLines) = loadCommittedScrollbackState(scrollbackPath)
         val handle = Handle(
             taskId = task.id,
             session = session,
@@ -191,6 +196,8 @@ class AgentTerminalManager(
             artifactDir = artifactDir,
             scrollbackPath = scrollbackPath,
             committedScrollbackPrefix = committedPrefix,
+            capturedLineKeys = capturedKeys,
+            capturedLines = capturedLines,
         )
         handles[task.id] = handle
         handle.scrollbackJob = scope.launch(Dispatchers.IO) {
@@ -252,18 +259,34 @@ class AgentTerminalManager(
 
     private fun persistScrollback(handle: Handle) {
         val backend = handle.session as? KetraTermBackend ?: return
-        val export = backend.scrollbackAnsi()
+        val fresh = backend.captureReadableLines(handle.capturedLineKeys)
+        if (fresh.isNotEmpty()) {
+            handle.capturedLines.addAll(fresh)
+        }
+        val export = joinReadableLines(handle.capturedLines)
         if (export.isBlank() && handle.committedScrollbackPrefix.isBlank()) return
         val content = capScrollbackSize(handle.committedScrollbackPrefix + export)
         atomicWriteText(handle.scrollbackPath, content)
     }
 
-    private fun loadCommittedScrollbackPrefix(file: File): String {
+    private fun loadCommittedScrollbackState(file: File): Triple<String, MutableSet<String>, MutableList<String>> {
         val existing = runCatching {
             if (file.isFile && file.length() > 0L) file.readText() else ""
         }.getOrDefault("")
-        if (existing.isBlank()) return ""
-        return existing.trimEnd() + SCROLLBACK_SESSION_SEPARATOR
+        if (existing.isBlank()) {
+            return Triple("", LinkedHashSet(), mutableListOf())
+        }
+        val normalized = resolveScrollbackForReplay(existing).trimEnd()
+        if (normalized.isBlank()) {
+            return Triple("", LinkedHashSet(), mutableListOf())
+        }
+        val lines = normalized.lines().map { it.trimEnd() }.filter { it.isNotBlank() }
+        val keys = lines.map { it.trim() }.toCollection(LinkedHashSet())
+        return Triple(
+            normalized + SCROLLBACK_SESSION_SEPARATOR,
+            keys,
+            lines.toMutableList(),
+        )
     }
 
     private fun refreshStatus(taskId: String) {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
@@ -12,6 +12,7 @@ import app.andy.terminal.TerminalSessions
 import app.andy.terminal.atomicWriteText
 import app.andy.terminal.capScrollbackSize
 import app.andy.terminal.joinReadableLines
+import app.andy.terminal.replayCaptureReadableLines
 import app.andy.terminal.resolveScrollbackForReplay
 import io.github.ketraterm.ui.swing.api.SwingTerminal
 import kotlinx.coroutines.CoroutineScope
@@ -259,7 +260,17 @@ class AgentTerminalManager(
 
     private fun persistScrollback(handle: Handle) {
         val backend = handle.session as? KetraTermBackend ?: return
-        val fresh = backend.captureReadableLines(handle.capturedLineKeys)
+        val fresh = backend.captureReadableLines(handle.capturedLineKeys).ifEmpty {
+            val tee = backend.scrollbackAnsi()
+            if (tee.isBlank()) {
+                emptyList()
+            } else {
+                replayCaptureReadableLines(tee).filter { line ->
+                    val key = line.trim()
+                    key.isNotEmpty() && handle.capturedLineKeys.add(key)
+                }
+            }
+        }
         if (fresh.isNotEmpty()) {
             handle.capturedLines.addAll(fresh)
         }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -144,7 +144,8 @@ class DesktopAgentRunService(
     private val loadedSkillScopes = ConcurrentHashMap.newKeySet<SkillScope>()
 
     private val handles = ConcurrentHashMap<String, TaskHandle>()
-    private val seenSessionIds = ConcurrentHashMap.newKeySet<String>()
+    private val viewingTaskIds = ConcurrentHashMap.newKeySet<String>()
+    private val previousSessionStatuses = ConcurrentHashMap<String, AgentSessionStatus>()
     private val eventFlows = ConcurrentHashMap<String, MutableStateFlow<List<AgentEvent>>>()
     private val emptyEvents = MutableStateFlow<List<AgentEvent>>(emptyList())
 
@@ -183,6 +184,9 @@ class DesktopAgentRunService(
             backfillCursorPlansFromTranscripts()
             ready.complete(Unit)
             refreshCliStatuses()
+            scope.launch {
+                terminals.sessionStatuses.collect(::onSessionStatusesChanged)
+            }
             if (enableProbes) {
                 refreshProviderQuotas()
                 while (isActive) {
@@ -944,6 +948,73 @@ class DesktopAgentRunService(
         }
     }
 
+    override fun canReattachSession(taskId: String): Boolean {
+        val task = currentTask(taskId) ?: return false
+        if (task.isActive || terminals.isAlive(taskId) || task.userInputRequest != null) return false
+        return resumeTaskForReattach(task) != null
+    }
+
+    override fun reattachSession(taskId: String) {
+        val task = currentTask(taskId) ?: return
+        if (task.isActive || terminals.isAlive(taskId) || task.userInputRequest != null) return
+        val taskForResume = resumeTaskForReattach(task) ?: return
+        val adapter = adapters[task.agent] ?: return
+        runCatching {
+            adapter.buildInteractiveResumeCommand(
+                binaryFor(task.agent) ?: return,
+                taskForResume,
+                null,
+                followUp = null,
+                followUpImagePaths = emptyList(),
+            )
+        }.getOrNull() ?: return
+
+        val queued = taskForResume.copy(
+            status = AgentTaskStatus.Queued,
+            exitCode = null,
+            errorMessage = null,
+            finishedAtMillis = null,
+            unread = false,
+        )
+        upsertTask(queued)
+        scope.launch {
+            persist()
+            launchRunAwaitingTerminal(queued, writeAfterStart = null) { resumeAdapter, binary, mcpUrl ->
+                resumeAdapter.buildInteractiveResumeCommand(
+                    binary,
+                    currentTask(taskId) ?: queued,
+                    mcpUrl,
+                    followUp = null,
+                    followUpImagePaths = emptyList(),
+                ) ?: error("interactive resume not supported")
+            }
+        }
+    }
+
+    private fun resumeTaskForReattach(task: AgentTask): AgentTask? {
+        val adapter = adapters[task.agent] ?: return null
+        val taskForResume = when (task.agent) {
+            AgentKind.Antigravity -> {
+                val resolved = AntigravityConversationIds.resolveForTask(task) ?: return null
+                if (resolved != task.vendorSessionId) task.copy(vendorSessionId = resolved) else task
+            }
+            else -> {
+                if (task.vendorSessionId.isNullOrBlank()) return null
+                task
+            }
+        }
+        val binary = binaryFor(task.agent) ?: return null
+        return runCatching {
+            adapter.buildInteractiveResumeCommand(
+                binary,
+                taskForResume,
+                null,
+                followUp = null,
+                followUpImagePaths = emptyList(),
+            )
+        }.getOrNull()?.let { taskForResume }
+    }
+
     override fun respondToUserInput(taskId: String, requestId: String, answers: Map<String, String>) {
         val task = currentTask(taskId) ?: return
         val request = task.userInputRequest?.takeIf { it.id == requestId } ?: return
@@ -1234,7 +1305,7 @@ class DesktopAgentRunService(
                 task = currentTask(taskId) ?: task,
                 argv = argv,
                 env = env,
-                isTabSeen = { taskId in seenSessionIds },
+                isTabSeen = { taskId in viewingTaskIds },
             )
         }.getOrElse { error ->
             finishTask(taskId, AgentTaskStatus.Failed, exitCode = null, error = "failed to start: ${error.message}")
@@ -1501,6 +1572,7 @@ class DesktopAgentRunService(
                     task.copy(
                         status = AgentTaskStatus.Paused,
                         finishedAtMillis = task.finishedAtMillis ?: System.currentTimeMillis(),
+                        unread = true,
                     )
                 else -> task
             }
@@ -2921,12 +2993,30 @@ class DesktopAgentRunService(
     }
 
     override fun markRead(taskId: String) {
-        seenSessionIds.add(taskId)
         terminals.markSeen(taskId)
         val task = currentTask(taskId) ?: return
         if (!task.unread) return
         updateTask(taskId) { it.copy(unread = false) }
         scope.launch { persist() }
+    }
+
+    override fun setChatViewing(taskId: String?, viewing: Boolean) {
+        when {
+            taskId == null -> viewingTaskIds.clear()
+            viewing -> viewingTaskIds.add(taskId)
+            else -> viewingTaskIds.remove(taskId)
+        }
+    }
+
+    private fun onSessionStatusesChanged(statuses: Map<String, AgentSessionStatus>) {
+        statuses.forEach { (taskId, status) ->
+            val previous = previousSessionStatuses.put(taskId, status)
+            if (previous == null || previous == status) return@forEach
+            val task = currentTask(taskId) ?: return@forEach
+            if (!sessionStatusNeedsUnread(task, previous, status, taskId in viewingTaskIds)) return@forEach
+            markUnread(taskId)
+        }
+        previousSessionStatuses.keys.retainAll(statuses.keys)
     }
 
     override fun markUnread(taskId: String) {

--- a/src/desktopMain/kotlin/app/andy/terminal/KetraTermBackend.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/KetraTermBackend.kt
@@ -71,8 +71,19 @@ class KetraTermBackend(
 
     fun swingTerminal(): SwingTerminal? = swingTerminal
 
-    /** Raw teed PTY stdout for durable `scrollback.ansi` persistence. */
+    /** Raw teed PTY stdout (includes in-place TUI redraws). */
     fun scrollbackAnsi(): String = scrollbackTee.snapshot()
+
+    /** Resolved readable scrollback suitable for durable replay after restart. */
+    fun scrollbackExport(seenKeys: MutableSet<String>): String {
+        val session = ketraSession ?: return ""
+        return joinReadableLines(captureNewReadableLines(session.terminal, seenKeys))
+    }
+
+    fun captureReadableLines(seenKeys: MutableSet<String>): List<String> {
+        val session = ketraSession ?: return emptyList()
+        return captureNewReadableLines(session.terminal, seenKeys)
+    }
 
     fun updateAppearance(appearance: TerminalAppearanceSnapshot) {
         appearanceRef.set(appearance)

--- a/src/desktopMain/kotlin/app/andy/terminal/KetraTermScrollback.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/KetraTermScrollback.kt
@@ -2,6 +2,7 @@ package app.andy.terminal
 
 import app.andy.model.TerminalAppearanceSnapshot
 import io.github.ketraterm.core.TerminalBuffers
+import io.github.ketraterm.core.api.TerminalBuffer
 import io.github.ketraterm.session.TerminalSession as KetraSession
 import io.github.ketraterm.transport.TerminalConnector
 import io.github.ketraterm.transport.TerminalConnectorListener
@@ -14,8 +15,7 @@ import javax.swing.SwingUtilities
 /** Soft cap for cumulative `scrollback.ansi` files (~5 MB). */
 internal const val SCROLLBACK_MAX_BYTES: Int = 5 * 1024 * 1024
 
-internal const val SCROLLBACK_SESSION_SEPARATOR: String =
-    "\r\n\u001b[90m─── ───\u001b[0m\r\n"
+internal const val SCROLLBACK_SESSION_SEPARATOR: String = "\n─── ───\n"
 
 /**
  * Accumulates raw PTY stdout (host→emulator) bytes for durable ANSI scrollback.
@@ -75,16 +75,72 @@ internal fun atomicWriteText(file: File, content: String) {
 }
 
 /**
- * Build a read-only [SwingTerminal] that replays [ansi] instantly and stays
+ * True when [content] looks like a raw PTY tee (spinner redraws, cursor motion, etc.)
+ * rather than resolved scrollback text from [io.github.ketraterm.core.api.TerminalInspector.getAllAsString].
+ */
+internal fun looksLikeRawAnsiTee(content: String): Boolean {
+    if (!content.contains('\u001b')) return false
+    var escapes = 0
+    for (ch in content) {
+        if (ch == '\u001b' && ++escapes > 8) return true
+    }
+    return false
+}
+
+/**
+ * Collapse legacy raw ANSI tee streams into readable plain text. New scrollback files
+ * are already resolved on write; this mainly repairs pre-fix `scrollback.ansi` blobs.
+ */
+internal fun resolveScrollbackForReplay(
+    content: String,
+    cols: Int = 120,
+    rows: Int = 32,
+): String {
+    if (content.isBlank() || !looksLikeRawAnsiTee(content)) return content
+    return joinReadableLines(replayCaptureReadableLines(content, cols, rows))
+}
+
+/** Feed legacy ANSI in chunks and capture readable lines before spinner history pushes them out. */
+internal fun replayCaptureReadableLines(
+    content: String,
+    cols: Int = 120,
+    rows: Int = 32,
+    chunkSize: Int = 8_192,
+): List<String> {
+    val bytes = content.toByteArray(StandardCharsets.UTF_8)
+    val buffer = TerminalBuffers.create(width = cols, height = rows, maxHistory = KetraTermBackend.DEFAULT_MAX_HISTORY)
+    val session = KetraSession.create(terminal = buffer, connector = ParkedTerminalConnector())
+    val seen = LinkedHashSet<String>()
+    val captured = mutableListOf<String>()
+    return try {
+        session.start(cols, rows)
+        var offset = 0
+        while (offset < bytes.size) {
+            val length = minOf(chunkSize, bytes.size - offset)
+            session.onBytes(bytes, offset, length)
+            offset += length
+            for (line in captureNewReadableLines(buffer, seen)) {
+                captured += line
+            }
+        }
+        captured
+    } finally {
+        runCatching { session.close() }
+    }
+}
+
+/**
+ * Build a read-only [SwingTerminal] that replays [content] instantly and stays
  * open for scrolling. User keystrokes are discarded by the parked connector.
  */
 fun createScrollbackReplayTerminal(
-    ansi: String,
+    content: String,
     cols: Int = 120,
     rows: Int = 32,
     appearance: TerminalAppearanceSnapshot = TerminalAppearanceSnapshot(),
 ): SwingTerminal {
-    val payload = (ansi + "\u001b[?25l").toByteArray(StandardCharsets.UTF_8)
+    val resolved = resolveScrollbackForReplay(content, cols, rows)
+    val payload = (resolved + "\n\u001b[?25l").toByteArray(StandardCharsets.UTF_8)
     val connector = AnsiReplayConnector(payload)
     val buffer = TerminalBuffers.create(width = cols, height = rows, maxHistory = KetraTermBackend.DEFAULT_MAX_HISTORY)
     val session = KetraSession.create(terminal = buffer, connector = connector)
@@ -127,6 +183,31 @@ internal class TeeTerminalConnector(
     override fun resize(columns: Int, rows: Int) = delegate.resize(columns, rows)
 
     override fun close() = delegate.close()
+}
+
+/** Parked connector for sessions fed manually via [io.github.ketraterm.session.TerminalSession.onBytes]. */
+internal class ParkedTerminalConnector : TerminalConnector {
+    override fun start(listener: TerminalConnectorListener) = Unit
+    override fun write(bytes: ByteArray, offset: Int, length: Int) = Unit
+    override fun resize(columns: Int, rows: Int) = Unit
+    override fun close() = Unit
+}
+
+/** Feeds [ansi] synchronously when the session connector starts. */
+internal class SynchronousAnsiConnector(
+    private val ansi: ByteArray,
+) : TerminalConnector {
+    override fun start(listener: TerminalConnectorListener) {
+        if (ansi.isNotEmpty()) {
+            listener.onBytes(ansi, 0, ansi.size)
+        }
+    }
+
+    override fun write(bytes: ByteArray, offset: Int, length: Int) = Unit
+
+    override fun resize(columns: Int, rows: Int) = Unit
+
+    override fun close() = Unit
 }
 
 /**

--- a/src/desktopMain/kotlin/app/andy/terminal/ScrollbackLineFilter.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/ScrollbackLineFilter.kt
@@ -1,0 +1,131 @@
+package app.andy.terminal
+
+import io.github.ketraterm.core.api.TerminalBuffer
+
+private val SpinnerStatusLine = Regex("""[⠀-⣿].*\b(Working|Running|Grepping|Reading|Loading|Thinking)\b""")
+private val TokenStatusLine = Regex("""\b(Working|Running|Grepping|Reading|Loading|Thinking)\b.*\btokens\b""", RegexOption.IGNORE_CASE)
+private val SpinnerTokenLine = Regex("""[⠀-⣿].*tokens""", RegexOption.IGNORE_CASE)
+private val AutoPercentLine = Regex("""\bAuto\s*·\s*\d""")
+private val PathStatusLine = Regex("""~/.*·\s*\w""")
+private val ToolProgressLine = Regex("""^(Read(ing)?|Grep(ped|ping)?)\b""")
+private val EllipsisPathLine = Regex("""\.\.\.""")
+private val TruncatedReviewLine = Regex("""truncated.*ctrl\+r to review""", RegexOption.IGNORE_CASE)
+private val ShellEchoLine = Regex("""^".+"\s+2>&1""")
+private val EarlierItemsHiddenLine = Regex("""…\s+\d+\s+earlier items hidden""")
+
+/** Drop TUI chrome and spinner redraw lines that make replay unreadable. */
+internal fun isScrollbackNoiseLine(line: String): Boolean {
+    val trimmed = line.trim()
+    if (trimmed.isEmpty()) return true
+    val lower = trimmed.lowercase()
+    if (Regex("""^:+\s*(Working|Running|Thinking|Grepping|Reading|Loading)\b""").containsMatchIn(trimmed)) return true
+    if (SpinnerStatusLine.containsMatchIn(trimmed)) return true
+    if (TokenStatusLine.containsMatchIn(trimmed)) return true
+    if (SpinnerTokenLine.containsMatchIn(trimmed)) return true
+    if (Regex("""\b(Working|Running|Loading|Thinking)\b""").containsMatchIn(trimmed) &&
+        trimmed.length < 80 &&
+        !trimmed.contains('?')
+    ) {
+        return true
+    }
+    if (trimmed == "→ Add a follow-up" || lower.contains("ctrl+c to stop")) return true
+    if (lower.contains("run everything")) return true
+    if (Regex("""^\d+\s+tasks?$""").containsMatchIn(trimmed)) return true
+    if (AutoPercentLine.containsMatchIn(trimmed)) return true
+    if (PathStatusLine.containsMatchIn(trimmed)) return true
+    if (Regex("""^\$\s+""").containsMatchIn(trimmed)) return true
+    if (Regex("""^\d+ms$""").containsMatchIn(trimmed)) return true
+    if (Regex("""exit\s+\d+""").containsMatchIn(lower) && trimmed.length < 40) return true
+    return false
+}
+
+/** Extra lines to omit when presenting saved history as readable text. */
+internal fun isScrollbackDisplayNoise(line: String): Boolean {
+    if (isScrollbackNoiseLine(line)) return true
+    val trimmed = line.trim()
+    if (trimmed.isEmpty()) return true
+    val lower = trimmed.lowercase()
+    if (lower.startsWith("tip:")) return true
+    if (lower.startsWith("cursor agent")) return true
+    if (lower.matches(Regex("""v\d{4}\.\d{2}\.\d{2}.*"""))) return true
+    if (ToolProgressLine.containsMatchIn(trimmed)) return true
+    if (Regex("""\bEdited\b.*\+\d+""").containsMatchIn(trimmed)) return true
+    if (EarlierItemsHiddenLine.containsMatchIn(trimmed)) return true
+    if (TruncatedReviewLine.containsMatchIn(trimmed)) return true
+    if (ShellEchoLine.containsMatchIn(trimmed)) return true
+    if (trimmed == "→" || trimmed == "Auto ·") return true
+    if (lower.startsWith("~/cod")) return true
+    if (lower.startsWith("run this command?")) return true
+    if (lower.startsWith("not in allowlist:")) return true
+    if (lower.startsWith("add shell(")) return true
+    if (lower.startsWith("skip & tell the agent")) return true
+    if (Regex("""^-{10,}$""").containsMatchIn(trimmed)) return true
+    if (lower.contains("waiting for approval")) return true
+    if (lower.startsWith("→ run (once)")) return true
+    return false
+}
+
+internal fun isScrollbackDiffLine(line: String): Boolean {
+    val trimmed = line.trim()
+    return trimmed.startsWith("▎") ||
+        (trimmed.startsWith("|") && trimmed.length > 1 && !trimmed.startsWith("||"))
+}
+
+internal fun scrollbackDiffContent(line: String): String =
+    line.trim().removePrefix("▎").trimStart('|').trimStart()
+
+/**
+ * Turn captured terminal rows into readable paragraphs and intact diff blocks.
+ * Terminal replay scatters these lines when widths differ, so history uses this for display.
+ */
+internal fun formatScrollbackForDisplay(raw: String): String {
+    val output = mutableListOf<String>()
+    val diffLines = mutableListOf<String>()
+
+    fun flushDiff() {
+        if (diffLines.isEmpty()) return
+        output += diffLines.joinToString("\n")
+        diffLines.clear()
+    }
+
+    for (line in raw.lines()) {
+        if (isScrollbackDisplayNoise(line)) continue
+        if (isScrollbackDiffLine(line)) {
+            diffLines += scrollbackDiffContent(line)
+            continue
+        }
+        flushDiff()
+        val trimmed = line.trim()
+        if (trimmed.isNotEmpty()) {
+            output += trimmed
+        }
+    }
+    flushDiff()
+    return output.joinToString("\n\n").trim()
+}
+
+internal fun extractReadableLines(buffer: TerminalBuffer): List<String> {
+    val total = buffer.historySize + buffer.height
+    if (total <= 0) return emptyList()
+    return buildList {
+        for (row in 0 until total) {
+            val line = buffer.getLineAsString(row).trimEnd()
+            if (!isScrollbackNoiseLine(line) && !isScrollbackDisplayNoise(line)) add(line)
+        }
+    }
+}
+
+/** Append only meaningful lines we have not captured yet (conversation before scroll-out). */
+internal fun captureNewReadableLines(
+    buffer: TerminalBuffer,
+    seenKeys: MutableSet<String>,
+): List<String> = buildList {
+    for (line in extractReadableLines(buffer)) {
+        val key = line.trim()
+        if (key.isEmpty() || key in seenKeys) continue
+        seenKeys += key
+        add(line)
+    }
+}
+
+internal fun joinReadableLines(lines: List<String>): String = lines.joinToString("\n").trimEnd()

--- a/src/desktopMain/kotlin/app/andy/ui/agents/AgentScrollbackView.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ui/agents/AgentScrollbackView.desktop.kt
@@ -1,0 +1,35 @@
+package app.andy.ui.agents
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.andy.ui.theme.MonoFont
+import app.andy.ui.theme.TextPrimary
+
+@Composable
+internal fun AgentScrollbackView(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+    SelectionContainer(modifier = modifier) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            color = TextPrimary,
+            fontFamily = MonoFont,
+            fontSize = 12.sp,
+            lineHeight = 17.sp,
+        )
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/ui/agents/AgentTerminalSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ui/agents/AgentTerminalSurface.desktop.kt
@@ -34,7 +34,6 @@ import app.andy.model.WorkspaceState
 import app.andy.model.toTerminalAppearance
 import app.andy.onImageFilesDropped
 import app.andy.service.AndyServices
-import app.andy.terminal.createScrollbackReplayTerminal
 import app.andy.terminal.onSwingEdt
 import app.andy.terminal.panelBackgroundArgb
 import app.andy.ui.shell.LocalSuppressHeavyweightSurfaces
@@ -44,10 +43,8 @@ import app.andy.ui.theme.MonoFont
 import app.andy.ui.theme.TextSecondary
 import io.github.ketraterm.ui.swing.api.SwingTerminal
 import java.awt.Component
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.withContext
 import java.awt.dnd.DropTarget
 import javax.swing.SwingUtilities
 
@@ -80,57 +77,34 @@ actual fun AgentTerminalSurface(
     val attachedIds by attachedFlow.collectAsState()
 
     var liveTerminal by remember(taskId) { mutableStateOf<SwingTerminal?>(null) }
-    var replayTerminal by remember(taskId) { mutableStateOf<SwingTerminal?>(null) }
+    var reattachRequested by remember(taskId) { mutableStateOf(false) }
 
-    LaunchedEffect(taskId, sessionActive, sessionsRevision, attachedIds) {
+    LaunchedEffect(taskId, sessionActive, sessionsRevision, attachedIds, reattachRequested) {
         liveTerminal = agentRuns?.terminalWidget(taskId)
-        if (!sessionActive) return@LaunchedEffect
-        replayTerminal?.let { widget ->
-            runCatching { onSwingEdt { widget.dispose() } }
-            replayTerminal = null
+        if (liveTerminal != null) return@LaunchedEffect
+
+        if (!sessionActive && !reattachRequested && agentRuns?.canReattachSession(taskId) == true) {
+            reattachRequested = true
+            agentRuns.reattachSession(taskId)
         }
+
         var attempts = 0
-        while (liveTerminal == null && attempts < 200) {
+        while (liveTerminal == null && attempts < 400) {
             delay(50)
             liveTerminal = agentRuns?.terminalWidget(taskId)
             attempts++
         }
     }
 
-    LaunchedEffect(taskId, sessionActive, sessionsRevision, liveTerminal, appearance) {
-        if (sessionActive || liveTerminal != null) return@LaunchedEffect
-        val file = agentRuns?.scrollbackFile(taskId)
-        val ansi = withContext(Dispatchers.IO) {
-            runCatching {
-                if (file != null && file.isFile && file.length() > 0L) file.readText() else null
-            }.getOrNull()
-        }
-        if (ansi.isNullOrBlank()) {
-            replayTerminal?.let { widget ->
-                runCatching { onSwingEdt { widget.dispose() } }
-            }
-            replayTerminal = null
-            return@LaunchedEffect
-        }
-        val widget = withContext(Dispatchers.IO) {
-            runCatching { createScrollbackReplayTerminal(ansi, appearance = appearance) }.getOrNull()
-        }
-        replayTerminal?.let { old ->
-            runCatching { onSwingEdt { old.dispose() } }
-        }
-        replayTerminal = widget
-    }
-
-    val replayToDispose = rememberUpdatedState(replayTerminal)
+    val liveToDispose = rememberUpdatedState(liveTerminal)
     DisposableEffect(taskId) {
         onDispose {
-            replayToDispose.value?.let { widget ->
+            liveToDispose.value?.let { widget ->
                 runCatching { onSwingEdt { widget.dispose() } }
             }
         }
     }
 
-    val widget = liveTerminal ?: replayTerminal
     val acceptsLiveDrops = sessionActive && liveTerminal != null
     var imageDragActive by remember(taskId) { mutableStateOf(false) }
 
@@ -165,7 +139,7 @@ actual fun AgentTerminalSurface(
         Modifier
     }
 
-    if (widget == null) {
+    if (liveTerminal == null) {
         Box(
             modifier = modifier
                 .background(terminalPanelBackground)
@@ -179,7 +153,10 @@ actual fun AgentTerminalSurface(
                 modifier = Modifier.padding(24.dp),
             ) {
                 Text(
-                    if (sessionActive) "Starting terminal…" else "Terminal session ended",
+                    when {
+                        reattachRequested || sessionActive -> "Reconnecting terminal…"
+                        else -> "Terminal session ended"
+                    },
                     color = TextSecondary,
                     fontFamily = MonoFont,
                     fontSize = 13.sp,
@@ -187,7 +164,7 @@ actual fun AgentTerminalSurface(
                 Text(
                     when {
                         imageDragActive -> "release to stage image for your next message"
-                        sessionActive -> "The provider CLI is coming up — drag screenshots here"
+                        reattachRequested || sessionActive -> "Restoring the live provider CLI for this chat"
                         else -> "Send a follow-up below to reopen the interactive CLI"
                     },
                     color = if (imageDragActive) Cyan else TextSecondary.copy(alpha = 0.72f),
@@ -210,11 +187,10 @@ actual fun AgentTerminalSurface(
                 .then(dropModifier),
         ) {
             if (!suppressHeavyweight) {
-                val panelKey = if (liveTerminal != null) taskId else "$taskId-scrollback"
-                key(panelKey) {
-                    var swingDropTarget by remember(panelKey) { mutableStateOf<DropTarget?>(null) }
-                    var swingDropHost by remember(panelKey) { mutableStateOf<Component?>(null) }
-                    DisposableEffect(panelKey) {
+                key(taskId) {
+                    var swingDropTarget by remember(taskId) { mutableStateOf<DropTarget?>(null) }
+                    var swingDropHost by remember(taskId) { mutableStateOf<Component?>(null) }
+                    DisposableEffect(taskId) {
                         onDispose {
                             runCatching {
                                 onSwingEdt {
@@ -229,7 +205,7 @@ actual fun AgentTerminalSurface(
                         modifier = Modifier.fillMaxSize(),
                         background = terminalPanelBackground,
                         factory = {
-                            widget.apply {
+                            liveTerminal!!.apply {
                                 if (acceptsLiveDrops) {
                                     SwingUtilities.invokeLater { requestFocusInWindow() }
                                 }

--- a/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
+++ b/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
@@ -451,6 +451,8 @@ internal object ScreenshotServices {
         override fun completeWorkflowRun(taskId: String) = Unit
         override suspend fun retry(taskId: String) = Unit
         override fun resume(taskId: String, followUp: String, imagePaths: List<String>, skills: List<AgentSkill>) = Unit
+        override fun reattachSession(taskId: String) = Unit
+        override fun canReattachSession(taskId: String): Boolean = false
         override fun respondToUserInput(taskId: String, requestId: String, answers: Map<String, String>) = Unit
         override fun queueFollowUp(taskId: String, followUp: String, imagePaths: List<String>, skills: List<AgentSkill>) = Unit
         override fun removeQueuedFollowUp(taskId: String, queueIndex: Int) = Unit
@@ -458,6 +460,7 @@ internal object ScreenshotServices {
         override suspend fun delete(taskId: String, removeWorktree: Boolean) = Unit
         override fun markRead(taskId: String) = Unit
         override fun markUnread(taskId: String) = Unit
+        override fun setChatViewing(taskId: String?, viewing: Boolean) = Unit
         override fun archive(taskId: String) = Unit
         override fun unarchive(taskId: String) = Unit
         override fun events(taskId: String) = MutableStateFlow(listOf<AgentEvent>(AgentEvent.UserMessage(now - 39_000, task.prompt), AgentEvent.ToolCall(now - 31_000, "rg", "Find validation reducer"), AgentEvent.AssistantText(now - 5_000, "Updated the reducer and added a focused test."), AgentEvent.TaskResult(now - 3_000, true, "Checkout validation is covered.", 0.18, inputTokens = 2420, outputTokens = 860, durationMs = 36_000)))

--- a/src/desktopTest/kotlin/app/andy/desktop/service/AgentAttentionCoordinatorTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/AgentAttentionCoordinatorTest.kt
@@ -59,6 +59,16 @@ class AgentAttentionCoordinatorTest {
     }
 
     @Test
+    fun notifiesWhenMovingToIdle() {
+        val fixture = Fixture()
+        fixture.coordinator.onTasksChanged(listOf(task(AgentTaskStatus.Running)))
+        fixture.coordinator.onTasksChanged(listOf(task(AgentTaskStatus.Paused)))
+
+        assertEquals(listOf("Idle"), fixture.notifications.events.map { it.kind.name })
+        assertEquals(listOf("chime"), fixture.sounds.played)
+    }
+
+    @Test
     fun doesNotNotifyForTerminalTaskThatFirstAppearsAfterStartup() {
         val fixture = Fixture()
         fixture.coordinator.onTasksChanged(emptyList())

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
@@ -67,6 +67,31 @@ class DesktopActionRunServiceTest {
         }
     }
 
+    @Test
+    fun rerunningAnActionStopsThePreviousShellAndStartsFresh() = runBlocking {
+        val service = DesktopActionRunService(CoroutineScope(SupervisorJob() + Dispatchers.IO))
+        val project = ActionProject(
+            id = "project",
+            name = "Project",
+            contextDir = createTempDirectory("andy-rerun-action").toString(),
+        )
+        val action = ProjectAction(id = "run", name = "Run", command = "echo first")
+
+        val firstRunId = service.run(project, action)
+        try {
+            awaitTerminalText(service, firstRunId, "first")
+            assertEquals(ActionRunStatus.Running, service.running.value.single().status)
+
+            val secondRunId = service.run(project, action)
+            assertTrue(firstRunId != secondRunId)
+            assertEquals(listOf(secondRunId), service.running.value.map { it.runId })
+            assertNotNull(service.terminalWidget(secondRunId))
+            awaitTerminalText(service, secondRunId, "first")
+        } finally {
+            service.running.value.forEach { service.stop(it.runId) }
+        }
+    }
+
     private suspend fun awaitTerminalText(service: DesktopActionRunService, runId: String, text: String) {
         withTimeout(5_000) {
             while (!service.bufferSnapshot(runId).contains(text)) delay(25)

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentSessionAttentionTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentSessionAttentionTest.kt
@@ -1,0 +1,73 @@
+package app.andy.desktop.service.agents
+
+import app.andy.model.AgentKind
+import app.andy.model.AgentSessionStatus
+import app.andy.model.AgentTask
+import app.andy.model.AgentTaskStatus
+import app.andy.model.ProjectWorkflowStage
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AgentSessionAttentionTest {
+    private val runningTask = AgentTask(
+        id = "task-1",
+        title = "Checkout",
+        prompt = "Fix validation",
+        agent = AgentKind.Codex,
+        projectId = null,
+        cwd = "/tmp",
+        originDir = "/tmp",
+        status = AgentTaskStatus.Running,
+        createdAtMillis = 0L,
+        startedAtMillis = 0L,
+    )
+
+    @Test
+    fun marksUnreadWhenSessionBecomesIdleWhileNotViewing() {
+        assertTrue(
+            sessionStatusNeedsUnread(
+                task = runningTask,
+                previous = AgentSessionStatus.Working,
+                next = AgentSessionStatus.Idle,
+                viewing = false,
+            ),
+        )
+    }
+
+    @Test
+    fun suppressesUnreadWhileChatIsOnScreen() {
+        assertFalse(
+            sessionStatusNeedsUnread(
+                task = runningTask,
+                previous = AgentSessionStatus.Working,
+                next = AgentSessionStatus.Idle,
+                viewing = true,
+            ),
+        )
+    }
+
+    @Test
+    fun marksUnreadForDoneAfterWorking() {
+        assertTrue(
+            sessionStatusNeedsUnread(
+                task = runningTask,
+                previous = AgentSessionStatus.Working,
+                next = AgentSessionStatus.Done,
+                viewing = false,
+            ),
+        )
+    }
+
+    @Test
+    fun ignoresWorkflowBuildRuns() {
+        assertFalse(
+            sessionStatusNeedsUnread(
+                task = runningTask.copy(workflowStage = ProjectWorkflowStage.Build),
+                previous = AgentSessionStatus.Working,
+                next = AgentSessionStatus.Idle,
+                viewing = false,
+            ),
+        )
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentStatusTrackerTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentStatusTrackerTest.kt
@@ -221,6 +221,29 @@ class AgentStatusTrackerTest {
     }
 
     @Test
+    fun quiescentPromptIsDoneWhenTabUnseen() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        try {
+            val session = FakeTerminalSession()
+            val tracker = AgentStatusTracker(
+                scope = scope,
+                taskId = "task-status",
+                agent = AgentKind.Codex,
+                artifactDir = File.createTempFile("andy-status", null).also { it.delete(); it.mkdirs() },
+                session = session,
+                isTabSeen = { false },
+            )
+            tracker.start()
+            session.emitBuffer("All done.\n› ")
+            kotlinx.coroutines.delay(4_600)
+            assertEquals(AgentSessionStatus.Done, tracker.status.value)
+            tracker.close()
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
     fun agentStatusTrackerPrefersBlockedFromScrape() = runBlocking {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
         try {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentWorkflowArtifactsTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentWorkflowArtifactsTest.kt
@@ -8,10 +8,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import java.io.File
@@ -20,10 +16,7 @@ class AgentWorkflowArtifactsTest {
     @Test
     fun reviewJsonEmitsReviewReady() = runTest {
         val root = File.createTempFile("andy-artifacts-review", null).also { it.delete(); it.mkdirs() }
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
         try {
-            val artifacts = AgentWorkflowArtifacts(scope, "task-review", root)
-            artifacts.start()
             root.resolve("review.json").writeText(
                 """
                 {
@@ -39,11 +32,13 @@ class AgentWorkflowArtifactsTest {
                 }
                 """.trimIndent(),
             )
-
+            val artifacts = AgentWorkflowArtifacts(this, "task-review", root)
+            artifacts.start()
             val event = artifacts.events.first()
             assertTrue(event is AgentWorkflowArtifacts.Event.ReviewReady)
+            artifacts.close()
         } finally {
-            scope.cancel()
+            root.deleteRecursively()
         }
     }
 

--- a/src/desktopTest/kotlin/app/andy/terminal/KetraTermScrollbackTest.kt
+++ b/src/desktopTest/kotlin/app/andy/terminal/KetraTermScrollbackTest.kt
@@ -71,7 +71,64 @@ class KetraTermScrollbackTest {
     }
 
     @Test
-    fun agentTerminalManagerPersistsAndAppendsScrollback() = runBlocking {
+    fun looksLikeRawAnsiTeeDetectsPtyStream() {
+        assertFalse(looksLikeRawAnsiTee("plain\n"))
+        assertFalse(looksLikeRawAnsiTee("hello\n"))
+        assertTrue(looksLikeRawAnsiTee("\u001b[2A\u001b[0G".repeat(10)))
+    }
+
+    @Test
+    fun resolveScrollbackForReplayCollapsesSpinnerRedraws() {
+        AndyKetraTermConfig.ensureInitialized()
+        val noisy = buildString {
+            repeat(40) {
+                append("\r\u001b[2A\u001b[0G⣾  \u001b[90mWorking\u001b[0m")
+            }
+            append("\nFinal answer is ready.\n> ")
+        }
+        val resolved = resolveScrollbackForReplay(noisy)
+        assertTrue(resolved.contains("Final answer is ready."), "resolved=$resolved")
+        val workingCount = Regex("Working").findAll(resolved).count()
+        assertTrue(workingCount <= 1, "expected at most one Working line, got $workingCount in:\n$resolved")
+    }
+
+    @Test
+    fun resolveScrollbackForReplayRepairsLegacyCursorTuiSnippet() {
+        AndyKetraTermConfig.ensureInitialized()
+        val legacy = buildString {
+            repeat(25) {
+                append("\u001b[?25l\r\u001b[2A\u001b[0G⣾  \u001b[90mWorking\u001b[0m")
+                append("\u001b[93D\u001b[?25h\u001b[?25l")
+            }
+            append("\r\n\u001b[90m─── ───\u001b[0m\r\n")
+            append("iOS Simulator mirroring is unchanged (no camera permission involved)\n")
+            append("> ")
+        }
+        val resolved = resolveScrollbackForReplay(legacy)
+        assertTrue(resolved.contains("iOS Simulator mirroring is unchanged"))
+        assertTrue(Regex("Working").findAll(resolved).count() <= 1)
+        assertFalse(looksLikeRawAnsiTee(resolved))
+    }
+
+    @Test
+    fun resolveScrollbackForReplayRepairsRealCursorAgentFile() {
+        AndyKetraTermConfig.ensureInitialized()
+        val file = java.io.File(System.getProperty("user.home"), ".andy/agents/task-7a20497d5e/scrollback.ansi")
+        if (!file.isFile) return
+        val raw = file.readText()
+        val resolved = resolveScrollbackForReplay(raw)
+        assertTrue(
+            resolved.contains("would it auto apply to old chats") ||
+                resolved.contains("readable on the next open"),
+            "resolved should keep conversation text",
+        )
+        assertFalse(looksLikeRawAnsiTee(resolved))
+        val spinnerStatusCount = Regex("""[⠀-⣿].*\b(Working|Running|Thinking)\b""").findAll(resolved).count()
+        assertTrue(spinnerStatusCount == 0, "expected no spinner status lines, got $spinnerStatusCount")
+    }
+
+    @Test
+    fun agentTerminalManagerPersistsResolvedScrollbackNotRawTee() = runBlocking {
         val dir = File.createTempFile("andy-scrollback", null).also {
             it.delete()
             it.mkdirs()
@@ -106,6 +163,7 @@ class KetraTermScrollbackTest {
             assertTrue(file.isFile, "scrollback file should exist after stop")
             val first = file.readText()
             assertTrue(first.contains("first-run-output"), "first run missing: ${first.take(300)}")
+            assertFalse(looksLikeRawAnsiTee(first), "persisted scrollback should be resolved text")
 
             val argv2 = if (isWindows) {
                 listOf("cmd", "/c", "echo", "second-run-output")

--- a/src/desktopTest/kotlin/app/andy/terminal/ScrollbackLineFilterTest.kt
+++ b/src/desktopTest/kotlin/app/andy/terminal/ScrollbackLineFilterTest.kt
@@ -1,0 +1,44 @@
+package app.andy.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ScrollbackLineFilterTest {
+    @Test
+    fun noiseFilterDropsSpinnerAndChromeLines() {
+        assertTrue(isScrollbackNoiseLine(":: Working 24.67k tokens"))
+        assertTrue(isScrollbackNoiseLine(": Working 24.68k tokens"))
+        assertTrue(isScrollbackNoiseLine("  Auto · 45.1% · 1 file edited"))
+        assertTrue(isScrollbackNoiseLine("  ~/Code/Andy/Andy · main"))
+        assertTrue(isScrollbackNoiseLine("  → Add a follow-up"))
+        assertFalse(isScrollbackNoiseLine("would it auto apply to old chats or is it just new ones?"))
+        assertFalse(isScrollbackNoiseLine("So your camera-permission chat should be readable on the next open."))
+    }
+
+    @Test
+    fun displayFormatterMergesDiffBlocksAndDropsToolNoise() {
+        val raw = """
+            Cursor Agent
+            Tip: Use /plan
+            if i run an action and it creates a tab
+            Implementing restart-on-rerun in DesktopActionRunService
+                Grepped "actionRuns.run" in .
+                Edited DesktopActionRunServiceTest.kt +25
+                ▎+     fun rerunningAnActionStopsThePreviousShellAndStartsFresh() =
+                ▎  runBlocking {
+                ▎+         val service = DesktopActionRunService(...)
+                ▎ … truncated (19 more lines) · ctrl+r to review
+                "app.andy.desktop.service.DesktopActionRunServiceTest" 2>&1 0ms
+        """.trimIndent()
+
+        val formatted = formatScrollbackForDisplay(raw)
+        assertFalse(formatted.contains("Grepped"))
+        assertFalse(formatted.contains("truncated"))
+        assertTrue(formatted.contains("if i run an action and it creates a tab"))
+        assertTrue(formatted.contains("Implementing restart-on-rerun"))
+        assertTrue(formatted.contains("fun rerunningAnActionStopsThePreviousShellAndStartsFresh() ="))
+        assertTrue(formatted.contains("runBlocking {"))
+        assertFalse(formatted.contains("DesktopActionRunServiceTest\" 2>&1"))
+    }
+}


### PR DESCRIPTION
## Summary
- Persist readable agent terminal scrollback (filtered TUI noise, diff blocks preserved) instead of raw ANSI tee output, with replay support for finished chats.
- Track embedded chat viewing state so unread badges only fire when the user is not actively watching a session.
- Add session reattachment for finished agent tasks and stop action terminal tabs when closed.

## Test plan
- [x] `./gradlew desktopTest --tests "app.andy.terminal.ScrollbackLineFilterTest"`
- [x] `./gradlew desktopTest --tests "app.andy.desktop.service.agents.AgentSessionAttentionTest"`
- [x] `./gradlew desktopTest --tests "app.andy.desktop.service.AgentAttentionCoordinatorTest"`
- [x] `./gradlew desktopTest --tests "app.andy.desktop.service.DesktopActionRunServiceTest"`
- [x] `./gradlew desktopTest` (567 tests; 1 pre-existing env-dependent failure in `ClaudePtyLaunchEnvTest`)


Made with [Cursor](https://cursor.com)