### PR TITLE
Rewrite vendor status hooks, fix long tmux launches, and stop leaking reattached tmux sessions

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -1,1 +1,31 @@
-{}
+{
+    "andy-status": {
+        "enabled": true,
+        "PreInvocation": [
+            {
+                "type": "command",
+                "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" working empty",
+                "timeout": 5
+            }
+        ],
+        "Stop": [
+            {
+                "type": "command",
+                "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" done empty fully-idle",
+                "timeout": 5
+            }
+        ],
+        "PreToolUse": [
+            {
+                "matcher": "ask_question|ask_permission",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" blocked allow",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,54 @@
 {
-    "hooks": {}
+    "hooks": {
+        "UserPromptSubmit": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" working"
+                    }
+                ]
+            }
+        ],
+        "Stop": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" done"
+                    }
+                ]
+            }
+        ],
+        "PermissionRequest": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" blocked"
+                    }
+                ]
+            }
+        ],
+        "Notification": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" blocked"
+                    }
+                ],
+                "matcher": "permission_prompt|agent_needs_input|elicitation_dialog"
+            },
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" done"
+                    }
+                ],
+                "matcher": "idle_prompt|agent_completed"
+            }
+        ]
+    }
 }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,3 +1,37 @@
 {
-    "hooks": {}
+    "hooks": {
+        "UserPromptSubmit": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" working empty",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ],
+        "Stop": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" done empty",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ],
+        "PermissionRequest": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" blocked empty",
+                        "timeout": 5
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentStatusHooks.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentStatusHooks.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import java.io.File
 
@@ -17,27 +18,33 @@ private const val ANDY_HOOK_MARKER = "andy-status-hook"
 private const val ANTIGRAVITY_HOOK_NAME = "andy-status"
 
 /**
- * Prepares per-task artifact pointers for Andy.
+ * Installs vendor lifecycle hooks that append state to `.andy/<taskId>/status.json`
+ * via the user-global `~/.andy/bin/andy-status-hook.sh` and `.andy/active-task`.
  *
- * Badge status for Claude / Cursor / Codex / Antigravity is **screen-manifest only**
- * (Herdr session-identity agents — see https://herdr.dev/docs/agents/). Incomplete
- * vendor lifecycle hooks are intentionally not installed for Working/Blocked/Done;
- * they race Stop vs permissions and can revive Working after Done.
+ * Preferred status mapping (when the vendor emits the event):
+ * - working ← prompt submit / pre-invocation
+ * - done ← turn stop / idle-complete notifications
+ * - blocked ← permission / ask-user
  *
- * This still writes `.andy/active-task` and ensures the optional MCP status helper
- * script exists. Any previously installed Andy status hooks are removed on the next
- * chat start so projects stop appending conflicting status.json lines.
+ * **Badge authority** is screen-manifest scrape only ([AgentStatusTracker] — Herdr parity).
+ * Hooks do not drive Working/Done/Blocked in the UI; they write optional `status.json`
+ * artifacts for MCP/debug. Merge preserves user hooks and replaces only `andy-status-hook`
+ * entries per event.
+ *
+ * Screen scrape remains the fallback when hooks are absent (notably Cursor
+ * approval chrome, which has no permission-wait hook).
  */
 fun installStatusSignals(
     agent: AgentKind,
     worktreeOrCwd: File,
     artifactDir: File,
 ) {
-    artifactDir.mkdirs()
-    AndyStatusHookInstaller.ensureInstalled()
-    AndyStatusHookInstaller.writeActiveTask(artifactDir)
-    if (shouldSkipProjectHooks(worktreeOrCwd)) return
-    removeAndyStatusHooks(agent, worktreeOrCwd)
+    when (agent) {
+        AgentKind.ClaudeCode -> installClaudeStatusHooks(worktreeOrCwd, artifactDir)
+        AgentKind.Cursor -> installCursorStatusHooks(worktreeOrCwd, artifactDir)
+        AgentKind.Codex -> installCodexStatusHooks(worktreeOrCwd, artifactDir)
+        AgentKind.Antigravity -> installAntigravityStatusHooks(worktreeOrCwd, artifactDir)
+    }
 }
 
 /**
@@ -50,72 +57,311 @@ internal fun installGenericStatusHookScript(artifactDir: File) {
     AndyStatusHookInstaller.writeActiveTask(artifactDir)
 }
 
+private fun statusHookCommand(
+    status: String,
+    respond: String = "none",
+    gate: String = "none",
+): String {
+    val base = "${AndyStatusHookInstaller.STABLE_HOOK_COMMAND} $status"
+    val withRespond = if (respond == "none" && gate == "none") base else "$base $respond"
+    return if (gate == "none") withRespond else "$withRespond $gate"
+}
+
+private fun prepareStatusHooks(artifactDir: File) {
+    AndyStatusHookInstaller.ensureInstalled()
+    AndyStatusHookInstaller.writeActiveTask(artifactDir)
+}
+
 private fun shouldSkipProjectHooks(worktreeOrCwd: File): Boolean {
     val home = File(System.getProperty("user.home")).absoluteFile.normalize()
     val cwd = worktreeOrCwd.absoluteFile.normalize()
     return cwd == home
 }
 
-/** Strip legacy Andy status-hook entries from vendor config so they cannot fight scrape. */
-private fun removeAndyStatusHooks(agent: AgentKind, worktreeOrCwd: File) {
-    when (agent) {
-        AgentKind.ClaudeCode -> {
-            val home = File(System.getProperty("user.home")).absoluteFile.normalize()
-            val settingsDir = File(worktreeOrCwd, ".claude").absoluteFile.normalize()
-            if (settingsDir == File(home, ".claude").absoluteFile.normalize()) return
-            val settings = File(settingsDir, "settings.json")
-            stripAndyHooksFromClaudeStyleFile(settings)
-        }
-        AgentKind.Codex -> stripAndyHooksFromClaudeStyleFile(File(worktreeOrCwd, ".codex/hooks.json"))
-        AgentKind.Cursor -> stripAndyHooksFromCursorFile(File(worktreeOrCwd, ".cursor/hooks.json"))
-        AgentKind.Antigravity -> stripAndyAntigravityHook(File(worktreeOrCwd, ".agents/hooks.json"))
-    }
+private fun writeHooksIfChanged(file: File, merged: JsonObject) {
+    val encoded = hooksJson.encodeToString(JsonObject.serializer(), merged) + "\n"
+    val existing = file.takeIf { it.isFile }?.readText()
+    if (existing == encoded) return
+    file.parentFile?.mkdirs()
+    file.writeText(encoded)
 }
 
-private fun stripAndyHooksFromClaudeStyleFile(file: File) {
-    if (!file.isFile) return
-    val root = runCatching { hooksJson.parseToJsonElement(file.readText()).jsonObject }.getOrNull() ?: return
-    val events = mutableJsonMap(root["hooks"] as? JsonObject)
-    if (events.isEmpty()) return
-    var changed = false
-    for (key in events.keys.toList()) {
-        val current = (events[key] as? JsonArray)?.toList().orEmpty()
+/**
+ * Claude Code: `.claude/settings.json` hooks.
+ * working ← UserPromptSubmit
+ * done ← Stop + Notification(idle_prompt|agent_completed)
+ * blocked ← PermissionRequest + Notification(permission/elicitation/needs_input)
+ */
+fun installClaudeStatusHooks(worktreeOrCwd: File, artifactDir: File) {
+    if (shouldSkipProjectHooks(worktreeOrCwd)) return
+
+    val home = File(System.getProperty("user.home")).absoluteFile.normalize()
+    val cwd = worktreeOrCwd.absoluteFile.normalize()
+    val settingsDir = File(cwd, ".claude").absoluteFile.normalize()
+    if (settingsDir == File(home, ".claude").absoluteFile.normalize()) return
+
+    settingsDir.mkdirs()
+    prepareStatusHooks(artifactDir)
+
+    val workingCmd = statusHookCommand("working")
+    val doneCmd = statusHookCommand("done")
+    val blockedCmd = statusHookCommand("blocked")
+    val andyHooks = JsonObject(
+        mapOf(
+            "UserPromptSubmit" to claudeCommandMatchers(workingCmd),
+            "Stop" to claudeCommandMatchers(doneCmd),
+            "PermissionRequest" to claudeCommandMatchers(blockedCmd),
+            "Notification" to JsonArray(
+                listOf(
+                    claudeMatcherEntry(
+                        matcher = "permission_prompt|agent_needs_input|elicitation_dialog",
+                        command = blockedCmd,
+                    ),
+                    claudeMatcherEntry(
+                        matcher = "idle_prompt|agent_completed",
+                        command = doneCmd,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    val settings = File(settingsDir, "settings.json")
+    writeHooksIfChanged(settings, mergeClaudeStyleEventHooks(settings, andyHooks))
+}
+
+/**
+ * Cursor: `.cursor/hooks.json`.
+ * working ← sessionStart + beforeSubmitPrompt; done ← stop (status completed|aborted).
+ * No reliable permission-wait hook — blocked stays on screen scrape.
+ */
+fun installCursorStatusHooks(worktreeOrCwd: File, artifactDir: File) {
+    if (shouldSkipProjectHooks(worktreeOrCwd)) return
+
+    val hooksDir = File(worktreeOrCwd, ".cursor").absoluteFile.normalize()
+    hooksDir.mkdirs()
+    prepareStatusHooks(artifactDir)
+
+    val workingCmd = statusHookCommand("working", respond = "empty")
+    val doneCmd = statusHookCommand("done", respond = "empty", gate = "completed")
+    val andyHooks = JsonObject(
+        mapOf(
+            "sessionStart" to JsonArray(listOf(cursorCommandEntry(workingCmd))),
+            "beforeSubmitPrompt" to JsonArray(listOf(cursorCommandEntry(workingCmd))),
+            "stop" to JsonArray(listOf(cursorCommandEntry(doneCmd))),
+        ),
+    )
+
+    val hooksFile = File(hooksDir, "hooks.json")
+    writeHooksIfChanged(hooksFile, mergeCursorHooks(hooksFile, andyHooks))
+}
+
+/**
+ * Codex: `.codex/hooks.json`.
+ * working ← UserPromptSubmit; done ← Stop; blocked ← PermissionRequest.
+ * Stop/PermissionRequest expect JSON on stdout (`empty` respond mode).
+ */
+fun installCodexStatusHooks(worktreeOrCwd: File, artifactDir: File) {
+    if (shouldSkipProjectHooks(worktreeOrCwd)) return
+
+    val hooksDir = File(worktreeOrCwd, ".codex").absoluteFile.normalize()
+    hooksDir.mkdirs()
+    prepareStatusHooks(artifactDir)
+
+    val workingCmd = statusHookCommand("working", respond = "empty")
+    val doneCmd = statusHookCommand("done", respond = "empty")
+    val blockedCmd = statusHookCommand("blocked", respond = "empty")
+    val andyHooks = JsonObject(
+        mapOf(
+            "UserPromptSubmit" to codexCommandMatchers(workingCmd),
+            "Stop" to codexCommandMatchers(doneCmd),
+            "PermissionRequest" to codexCommandMatchers(blockedCmd),
+        ),
+    )
+
+    val hooksFile = File(hooksDir, "hooks.json")
+    writeHooksIfChanged(hooksFile, mergeClaudeStyleEventHooks(hooksFile, andyHooks))
+}
+
+/**
+ * Antigravity: `.agents/hooks.json` named hook `andy-status`.
+ * working ← PreInvocation; done ← Stop gated on fullyIdle; blocked ← ask_* tools.
+ * Stop always returns `{}` (allow natural termination); only records done when idle.
+ */
+fun installAntigravityStatusHooks(worktreeOrCwd: File, artifactDir: File) {
+    if (shouldSkipProjectHooks(worktreeOrCwd)) return
+
+    val agentsDir = File(worktreeOrCwd, ".agents").absoluteFile.normalize()
+    agentsDir.mkdirs()
+    prepareStatusHooks(artifactDir)
+
+    val workingCmd = statusHookCommand("working", respond = "empty")
+    val doneCmd = statusHookCommand("done", respond = "empty", gate = "fully-idle")
+    val blockedCmd = statusHookCommand("blocked", respond = "allow")
+    val andyHook = JsonObject(
+        mapOf(
+            "enabled" to JsonPrimitive(true),
+            "PreInvocation" to JsonArray(
+                listOf(
+                    JsonObject(
+                        mapOf(
+                            "type" to JsonPrimitive("command"),
+                            "command" to JsonPrimitive(workingCmd),
+                            "timeout" to JsonPrimitive(5),
+                        ),
+                    ),
+                ),
+            ),
+            "Stop" to JsonArray(
+                listOf(
+                    JsonObject(
+                        mapOf(
+                            "type" to JsonPrimitive("command"),
+                            "command" to JsonPrimitive(doneCmd),
+                            "timeout" to JsonPrimitive(5),
+                        ),
+                    ),
+                ),
+            ),
+            "PreToolUse" to JsonArray(
+                listOf(
+                    JsonObject(
+                        mapOf(
+                            "matcher" to JsonPrimitive("ask_question|ask_permission"),
+                            "hooks" to JsonArray(
+                                listOf(
+                                    JsonObject(
+                                        mapOf(
+                                            "type" to JsonPrimitive("command"),
+                                            "command" to JsonPrimitive(blockedCmd),
+                                            "timeout" to JsonPrimitive(5),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    val hooksFile = File(agentsDir, "hooks.json")
+    writeHooksIfChanged(hooksFile, mergeAntigravityHooks(hooksFile, andyHook))
+}
+
+private fun claudeCommandMatchers(command: String): JsonArray =
+    JsonArray(listOf(claudeMatcherEntry(matcher = null, command = command)))
+
+private fun claudeMatcherEntry(matcher: String?, command: String): JsonObject {
+    val fields = mutableMapOf<String, JsonElement>(
+        "hooks" to JsonArray(
+            listOf(
+                JsonObject(
+                    mapOf(
+                        "type" to JsonPrimitive("command"),
+                        "command" to JsonPrimitive(command),
+                    ),
+                ),
+            ),
+        ),
+    )
+    if (matcher != null) fields["matcher"] = JsonPrimitive(matcher)
+    return JsonObject(fields)
+}
+
+private fun codexCommandMatchers(command: String): JsonArray =
+    JsonArray(
+        listOf(
+            JsonObject(
+                mapOf(
+                    "hooks" to JsonArray(
+                        listOf(
+                            JsonObject(
+                                mapOf(
+                                    "type" to JsonPrimitive("command"),
+                                    "command" to JsonPrimitive(command),
+                                    "timeout" to JsonPrimitive(5),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+private fun cursorCommandEntry(command: String): JsonObject =
+    JsonObject(mapOf("command" to JsonPrimitive(command)))
+
+/**
+ * Merge Andy event hooks into a Claude/Codex-style `{ "hooks": { Event: [...] } }` file.
+ * Preserves non-Andy entries; replaces prior Andy `andy-status-hook` entries per event.
+ */
+internal fun mergeClaudeStyleEventHooks(
+    settingsFile: File,
+    andyEventHooks: JsonObject,
+): JsonObject {
+    val existingRoot = if (settingsFile.isFile) {
+        runCatching { hooksJson.parseToJsonElement(settingsFile.readText()).jsonObject }.getOrNull()
+    } else {
+        null
+    }
+    val root = mutableJsonMap(existingRoot)
+    val existingEvents = mutableJsonMap(root["hooks"] as? JsonObject)
+
+    for ((event, andyMatchers) in andyEventHooks) {
+        val current = (existingEvents[event] as? JsonArray)?.toList().orEmpty()
         val preserved = current.filterNot(::jsonContainsAndyHook)
-        if (preserved.size != current.size) changed = true
-        if (preserved.isEmpty()) events.remove(key) else events[key] = JsonArray(preserved)
+        val andyList = (andyMatchers as? JsonArray)?.toList().orEmpty()
+        existingEvents[event] = JsonArray(preserved + andyList)
     }
-    if (!changed) return
-    val next = JsonObject(mutableJsonMap(root).also { it["hooks"] = JsonObject(events) })
-    file.writeText(hooksJson.encodeToString(JsonObject.serializer(), next) + "\n")
+
+    // Drop legacy Andy SubagentStop→done wiring that falsely marks the parent Done.
+    val subagentStop = existingEvents["SubagentStop"] as? JsonArray
+    if (subagentStop != null) {
+        val preserved = subagentStop.filterNot(::jsonContainsAndyHook)
+        if (preserved.isEmpty()) existingEvents.remove("SubagentStop")
+        else existingEvents["SubagentStop"] = JsonArray(preserved)
+    }
+
+    root["hooks"] = JsonObject(existingEvents)
+    return JsonObject(root)
 }
 
-private fun stripAndyHooksFromCursorFile(file: File) {
-    if (!file.isFile) return
-    val root = runCatching { hooksJson.parseToJsonElement(file.readText()).jsonObject }.getOrNull() ?: return
-    val events = mutableJsonMap(root["hooks"] as? JsonObject)
-    if (events.isEmpty()) return
-    var changed = false
-    for (key in events.keys.toList()) {
-        val current = (events[key] as? JsonArray)?.toList().orEmpty()
+internal fun mergeCursorHooks(hooksFile: File, andyEventHooks: JsonObject): JsonObject {
+    val existingRoot = if (hooksFile.isFile) {
+        runCatching { hooksJson.parseToJsonElement(hooksFile.readText()).jsonObject }.getOrNull()
+    } else {
+        null
+    }
+    val root = mutableJsonMap(existingRoot)
+    if (!root.containsKey("version")) root["version"] = JsonPrimitive(1)
+    val existingEvents = mutableJsonMap(root["hooks"] as? JsonObject)
+
+    for ((event, andyMatchers) in andyEventHooks) {
+        val current = (existingEvents[event] as? JsonArray)?.toList().orEmpty()
         val preserved = current.filterNot(::jsonContainsAndyHook)
-        if (preserved.size != current.size) changed = true
-        if (preserved.isEmpty()) events.remove(key) else events[key] = JsonArray(preserved)
+        val andyList = (andyMatchers as? JsonArray)?.toList().orEmpty()
+        existingEvents[event] = JsonArray(preserved + andyList)
     }
-    if (!changed) return
-    val next = JsonObject(mutableJsonMap(root).also { it["hooks"] = JsonObject(events) })
-    file.writeText(hooksJson.encodeToString(JsonObject.serializer(), next) + "\n")
+    root["hooks"] = JsonObject(existingEvents)
+    return JsonObject(root)
 }
 
-private fun stripAndyAntigravityHook(file: File) {
-    if (!file.isFile) return
-    val root = runCatching { hooksJson.parseToJsonElement(file.readText()).jsonObject }.getOrNull() ?: return
-    if (!root.containsKey(ANTIGRAVITY_HOOK_NAME)) return
-    val next = JsonObject(root.filterKeys { it != ANTIGRAVITY_HOOK_NAME })
-    file.writeText(hooksJson.encodeToString(JsonObject.serializer(), next) + "\n")
+internal fun mergeAntigravityHooks(hooksFile: File, andyHook: JsonObject): JsonObject {
+    val existingRoot = if (hooksFile.isFile) {
+        runCatching { hooksJson.parseToJsonElement(hooksFile.readText()).jsonObject }.getOrNull()
+    } else {
+        null
+    }
+    val root = mutableJsonMap(existingRoot)
+    root[ANTIGRAVITY_HOOK_NAME] = andyHook
+    return JsonObject(root)
 }
+
+private fun mutableJsonMap(source: JsonObject?): MutableMap<String, JsonElement> =
+    source?.entries?.associateTo(mutableMapOf()) { it.key to it.value } ?: mutableMapOf()
 
 private fun jsonContainsAndyHook(element: JsonElement): Boolean =
     element.toString().contains(ANDY_HOOK_MARKER)
-
-private fun mutableJsonMap(obj: JsonObject?): MutableMap<String, JsonElement> =
-    obj?.toMutableMap() ?: mutableMapOf()

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
@@ -770,7 +770,11 @@ class AgentTerminalManager(
             runCatching { handle.session.close() }
             // Direct PTY output can land in the buffer just after process exit.
             runCatching { persistScrollback(handle) }
-        } else if (TmuxAndy.isAvailable() && TmuxAndy.hasSession(taskId)) {
+        }
+        // stop() always means terminate, unlike session.close() which a reattached
+        // TmuxAttachBackend honors with killTmuxOnClose = false. Force it here so a
+        // chat that was reattached after a dropped handle doesn't leak its tmux session.
+        if (TmuxAndy.isAvailable() && TmuxAndy.hasSession(taskId)) {
             TmuxAndy.killSession(taskId)
         }
         bumpSessionsRevision()

--- a/src/desktopMain/kotlin/app/andy/terminal/TmuxAndy.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/TmuxAndy.kt
@@ -236,10 +236,18 @@ object TmuxAndy {
     private fun createDetachedSession(taskId: String, sessionCwd: String, launch: String) {
         if (hasSession(taskId)) killSession(taskId)
         val name = sessionName(taskId)
+        // tmux's client/server IPC caps a single command message at roughly 16-20KB
+        // ("command too long"). A long build/review prompt (a whole frozen plan or
+        // diff) blows past that if inlined with `-c launch`, so hand tmux a short
+        // script path instead — the command line stays tiny no matter how big the
+        // agent prompt is.
+        val scriptFile = launchScriptFile(name)
+        scriptFile.parentFile?.mkdirs()
+        scriptFile.writeText(launch)
         val cmd = listOf(
             tmuxBinary(), "-L", SERVER, "new-session", "-d", "-s", name,
             "-c", sessionCwd,
-            "--", "/bin/sh", "-c", launch,
+            "--", "/bin/sh", scriptFile.absolutePath,
         )
         val result = run(cmd, workingDirectory = File(sessionCwd))
         invalidateSessionCache()
@@ -247,6 +255,12 @@ object TmuxAndy {
             "failed to create tmux session $name: ${result.stderr.ifBlank { result.stdout }}"
         }
     }
+
+    private fun launchScriptDir(): File =
+        File(System.getProperty("user.home"), ".andy/tmux-launch")
+
+    private fun launchScriptFile(sessionName: String): File =
+        File(launchScriptDir(), "$sessionName.sh")
 
     /** True when a newly spawned pane shows getcwd / uv_cwd failure within [timeoutMs]. */
     private fun sessionLooksBrokenSoon(taskId: String, timeoutMs: Long = 600): Boolean {
@@ -266,6 +280,7 @@ object TmuxAndy {
             checkExit = false,
         )
         invalidateSessionCache()
+        launchScriptFile(sessionName(taskId)).delete()
     }
 
     /** Drop the Andy tmux server (all sessions). Next [startServer] boots from a safe cwd. */

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentStatusTrackerTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentStatusTrackerTest.kt
@@ -872,18 +872,33 @@ class AgentStatusTrackerTest {
     }
 
     @Test
-    fun installStatusSignalsWritesActiveTaskWithoutClaudeStatusHooks() {
+    fun installClaudeStatusHooksWritesWorkingDoneBlockedMapping() {
         val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
         val previousHome = System.getProperty("user.home")
         try {
             System.setProperty("user.home", home.absolutePath)
             val cwd = File(home, "project").also { it.mkdirs() }
             val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
-            installStatusSignals(AgentKind.ClaudeCode, cwd, artifacts)
+            installClaudeStatusHooks(cwd, artifacts)
 
-            assertEquals("task-hooks", File(cwd, ".andy/active-task").readText().trim())
+            val settings = File(cwd, ".claude/settings.json")
+            assertTrue(settings.isFile)
+            val text = settings.readText()
+            val hooks = kotlinx.serialization.json.Json.parseToJsonElement(text).jsonObject["hooks"]!!.jsonObject
+            assertTrue(hooks.containsKey("UserPromptSubmit"))
+            assertTrue(hooks.containsKey("Stop"))
+            assertTrue(hooks.containsKey("PermissionRequest"))
+            assertTrue(hooks.containsKey("Notification"))
+            assertFalse(hooks.containsKey("SubagentStop"), "SubagentStop must not mark parent Done")
+            assertTrue("working" in text)
+            assertTrue("idle_prompt|agent_completed" in text)
+            assertTrue("permission_prompt|agent_needs_input|elicitation_dialog" in text)
+            assertTrue(
+                "\$HOME/.andy/bin/andy-status-hook.sh" in text,
+                "hooks must use stable \$HOME helper path",
+            )
             assertTrue(AndyStatusHookInstaller.scriptFile(home).canExecute())
-            assertFalse(File(cwd, ".claude/settings.json").exists())
+            assertEquals("task-hooks", File(cwd, ".andy/active-task").readText().trim())
             assertTrue(!File(home, ".claude/settings.json").exists())
         } finally {
             System.setProperty("user.home", previousHome)
@@ -892,7 +907,7 @@ class AgentStatusTrackerTest {
     }
 
     @Test
-    fun installStatusSignalsStripsClaudeAndyHooksButPreservesUserHooks() {
+    fun installClaudeStatusHooksMergesWithoutClobberingUserHooks() {
         val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
         val previousHome = System.getProperty("user.home")
         try {
@@ -903,50 +918,10 @@ class AgentStatusTrackerTest {
                 """
                 {
                   "hooks": {
-                    "UserPromptSubmit": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' working" }
-                        ]
-                      }
-                    ],
-                    "Stop": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' done" }
-                        ]
-                      }
-                    ],
-                    "PermissionRequest": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' blocked" }
-                        ]
-                      }
-                    ],
-                    "Notification": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' blocked" }
-                        ]
-                      }
-                    ],
                     "PreToolUse": [
                       {
                         "hooks": [
                           { "type": "command", "command": "echo user-hook" }
-                        ]
-                      },
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' working" }
-                        ]
-                      }
-                    ],
-                    "PostToolUse": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' working" }
                         ]
                       }
                     ],
@@ -962,27 +937,16 @@ class AgentStatusTrackerTest {
                 """.trimIndent(),
             )
             val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
-            installStatusSignals(AgentKind.ClaudeCode, cwd, artifacts)
+            installClaudeStatusHooks(cwd, artifacts)
 
-            val settingsText = File(settingsDir, "settings.json").readText()
             val hooks = kotlinx.serialization.json.Json
-                .parseToJsonElement(settingsText)
+                .parseToJsonElement(File(settingsDir, "settings.json").readText())
                 .jsonObject["hooks"]!!
                 .jsonObject
             assertTrue(hooks.containsKey("PreToolUse"), "user PreToolUse must be preserved")
             assertTrue("echo user-hook" in hooks.toString())
-            assertFalse("andy-status-hook" in settingsText, "legacy Andy status hooks must be stripped")
-            for (event in listOf(
-                "UserPromptSubmit",
-                "Stop",
-                "PermissionRequest",
-                "Notification",
-                "PostToolUse",
-                "SubagentStop",
-            )) {
-                assertFalse(hooks.containsKey(event), "Andy-only $event entry must be removed")
-            }
-            assertEquals("task-hooks", File(cwd, ".andy/active-task").readText().trim())
+            assertFalse(hooks.containsKey("SubagentStop"), "legacy Andy SubagentStop entry removed")
+            assertTrue(hooks.containsKey("Stop"))
         } finally {
             System.setProperty("user.home", previousHome)
             home.deleteRecursively()
@@ -990,7 +954,7 @@ class AgentStatusTrackerTest {
     }
 
     @Test
-    fun installCursorStatusSignalsDoesNotWriteWorkingDoneHooks() {
+    fun installCursorStatusHooksWritesBeforeSubmitAndStop() {
         val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
         val previousHome = System.getProperty("user.home")
         try {
@@ -999,8 +963,19 @@ class AgentStatusTrackerTest {
             val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
             installStatusSignals(AgentKind.Cursor, cwd, artifacts)
 
+            val hooksFile = File(cwd, ".cursor/hooks.json")
+            assertTrue(hooksFile.isFile)
+            val root = kotlinx.serialization.json.Json.parseToJsonElement(hooksFile.readText()).jsonObject
+            val hooks = root["hooks"]!!.jsonObject
+            assertTrue(hooks.containsKey("sessionStart"))
+            assertTrue(hooks.containsKey("beforeSubmitPrompt"))
+            assertTrue(hooks.containsKey("stop"))
+            val text = hooksFile.readText()
+            assertTrue("working" in text)
+            assertTrue("done" in text)
+            assertTrue(" completed" in text, "Cursor stop must gate done on status completed|aborted")
+            assertTrue("\$HOME/.andy/bin/andy-status-hook.sh" in text)
             assertEquals("task-hooks", File(cwd, ".andy/active-task").readText().trim())
-            assertFalse(File(cwd, ".cursor/hooks.json").exists())
         } finally {
             System.setProperty("user.home", previousHome)
             home.deleteRecursively()
@@ -1008,7 +983,7 @@ class AgentStatusTrackerTest {
     }
 
     @Test
-    fun installCursorStatusSignalsStripsAndyHooks() {
+    fun installCursorStatusHooksMergesWithoutClobberingUserHooks() {
         val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
         val previousHome = System.getProperty("user.home")
         try {
@@ -1037,11 +1012,12 @@ class AgentStatusTrackerTest {
 
             val text = File(hooksDir, "hooks.json").readText()
             val hooks = kotlinx.serialization.json.Json.parseToJsonElement(text).jsonObject["hooks"]!!.jsonObject
-            assertFalse("andy-status-hook" in text)
-            assertFalse(hooks.containsKey("beforeSubmitPrompt"))
-            assertFalse(hooks.containsKey("stop"))
+            assertTrue(hooks.containsKey("beforeSubmitPrompt"))
+            assertTrue(hooks.containsKey("stop"))
             assertTrue(hooks.containsKey("sessionStart"))
             assertTrue("echo user-cursor-hook" in text)
+            assertTrue("\$HOME/.andy/bin/andy-status-hook.sh" in text)
+            assertFalse("/tmp/andy-status-hook.sh" in text, "stale /tmp Andy hooks must be replaced")
         } finally {
             System.setProperty("user.home", previousHome)
             home.deleteRecursively()
@@ -1049,7 +1025,7 @@ class AgentStatusTrackerTest {
     }
 
     @Test
-    fun installCodexStatusSignalsDoesNotWriteWorkingDoneBlockedHooks() {
+    fun installCodexStatusHooksWritesWorkingDoneBlocked() {
         val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
         val previousHome = System.getProperty("user.home")
         try {
@@ -1058,113 +1034,57 @@ class AgentStatusTrackerTest {
             val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
             installStatusSignals(AgentKind.Codex, cwd, artifacts)
 
-            assertEquals("task-hooks", File(cwd, ".andy/active-task").readText().trim())
-            assertFalse(File(cwd, ".codex/hooks.json").exists())
-        } finally {
-            System.setProperty("user.home", previousHome)
-            home.deleteRecursively()
-        }
-    }
-
-    @Test
-    fun installCodexStatusSignalsStripsAndyHooks() {
-        val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
-        val previousHome = System.getProperty("user.home")
-        try {
-            System.setProperty("user.home", home.absolutePath)
-            val cwd = File(home, "project").also { it.mkdirs() }
-            val hooksDir = File(cwd, ".codex").also { it.mkdirs() }
-            File(hooksDir, "hooks.json").writeText(
-                """
-                {
-                  "hooks": {
-                    "UserPromptSubmit": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' working empty" }
-                        ]
-                      }
-                    ],
-                    "Stop": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' done empty" }
-                        ]
-                      }
-                    ],
-                    "PermissionRequest": [
-                      {
-                        "hooks": [
-                          { "type": "command", "command": "'/tmp/andy-status-hook.sh' blocked empty" }
-                        ]
-                      }
-                    ]
-                  }
-                }
-                """.trimIndent(),
-            )
-            val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
-            installStatusSignals(AgentKind.Codex, cwd, artifacts)
-
-            val text = File(hooksDir, "hooks.json").readText()
-            assertFalse("andy-status-hook" in text)
+            val hooksFile = File(cwd, ".codex/hooks.json")
+            assertTrue(hooksFile.isFile)
+            val text = hooksFile.readText()
             val hooks = kotlinx.serialization.json.Json.parseToJsonElement(text).jsonObject["hooks"]!!.jsonObject
-            assertTrue(hooks.isEmpty())
-        } finally {
-            System.setProperty("user.home", previousHome)
-            home.deleteRecursively()
-        }
-    }
-
-    @Test
-    fun installAntigravityStatusSignalsDoesNotWriteNamedAndyStatusHook() {
-        val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
-        val previousHome = System.getProperty("user.home")
-        try {
-            System.setProperty("user.home", home.absolutePath)
-            val cwd = File(home, "project").also { it.mkdirs() }
-            val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
-            installStatusSignals(AgentKind.Antigravity, cwd, artifacts)
-
-            assertEquals("task-hooks", File(cwd, ".andy/active-task").readText().trim())
-            assertFalse(File(cwd, ".agents/hooks.json").exists())
-        } finally {
-            System.setProperty("user.home", previousHome)
-            home.deleteRecursively()
-        }
-    }
-
-    @Test
-    fun installAntigravityStatusSignalsStripsNamedAndyStatusHook() {
-        val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
-        val previousHome = System.getProperty("user.home")
-        try {
-            System.setProperty("user.home", home.absolutePath)
-            val cwd = File(home, "project").also { it.mkdirs() }
-            val hooksDir = File(cwd, ".agents").also { it.mkdirs() }
-            File(hooksDir, "hooks.json").writeText(
-                """
-                {
-                  "andy-status": {
-                    "PreInvocation": [{ "command": "andy-status-hook.sh working" }],
-                    "Stop": [{ "command": "andy-status-hook.sh done empty fully-idle" }],
-                    "PreToolUse": [{ "command": "andy-status-hook.sh blocked" }]
-                  },
-                  "user-hook": {
-                    "Stop": [{ "command": "echo keep-me" }]
-                  }
-                }
-                """.trimIndent(),
+            assertTrue(hooks.containsKey("UserPromptSubmit"))
+            assertTrue(hooks.containsKey("Stop"))
+            assertTrue(hooks.containsKey("PermissionRequest"))
+            assertTrue(
+                Regex("""andy-status-hook\.sh\\?" (working|done|blocked) empty""")
+                    .containsMatchIn(text) ||
+                    Regex("""andy-status-hook\.sh" (working|done|blocked) empty""")
+                        .containsMatchIn(text),
+                "Codex hooks must use empty respond mode for JSON stdout",
             )
+            assertTrue("\$HOME/.andy/bin/andy-status-hook.sh" in text)
+            assertTrue(" empty" in text)
+        } finally {
+            System.setProperty("user.home", previousHome)
+            home.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun installAntigravityStatusHooksWritesNamedAndyStatusHook() {
+        val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
+        val previousHome = System.getProperty("user.home")
+        try {
+            System.setProperty("user.home", home.absolutePath)
+            val cwd = File(home, "project").also { it.mkdirs() }
             val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
             installStatusSignals(AgentKind.Antigravity, cwd, artifacts)
 
-            val root = kotlinx.serialization.json.Json
-                .parseToJsonElement(File(hooksDir, "hooks.json").readText())
-                .jsonObject
-            assertFalse(root.containsKey("andy-status"))
-            assertTrue(root.containsKey("user-hook"))
-            assertTrue("echo keep-me" in root.toString())
+            val hooksFile = File(cwd, ".agents/hooks.json")
+            assertTrue(hooksFile.isFile)
+            val root = kotlinx.serialization.json.Json.parseToJsonElement(hooksFile.readText()).jsonObject
+            assertTrue(root.containsKey("andy-status"))
+            val andy = root["andy-status"]!!.jsonObject
+            assertTrue(andy.containsKey("PreInvocation"))
+            assertTrue(andy.containsKey("Stop"))
+            assertTrue(andy.containsKey("PreToolUse"))
+            val text = hooksFile.readText()
+            assertTrue("ask_question|ask_permission" in text)
+            assertTrue(" fully-idle" in text, "Antigravity Stop must gate done on fullyIdle")
+            assertTrue(
+                Regex("""andy-status-hook\.sh" done empty fully-idle""")
+                    .containsMatchIn(text) ||
+                    Regex("""andy-status-hook\.sh\\" done empty fully-idle""")
+                        .containsMatchIn(text),
+                "Antigravity Stop must use empty respond (not decision:stop)",
+            )
+            assertFalse(" done stop" in text)
         } finally {
             System.setProperty("user.home", previousHome)
             home.deleteRecursively()
@@ -1318,7 +1238,7 @@ class AgentStatusTrackerTest {
     }
 
     @Test
-    fun installStatusSignalsUpdatesActiveTaskWithoutCreatingHooks() {
+    fun installCursorStatusHooksSkipsRewriteWhenUnchanged() {
         val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
         val previousHome = System.getProperty("user.home")
         try {
@@ -1326,13 +1246,16 @@ class AgentStatusTrackerTest {
             val cwd = File(home, "project").also { it.mkdirs() }
             val artifacts = File(cwd, ".andy/task-a").also { it.mkdirs() }
             installStatusSignals(AgentKind.Cursor, cwd, artifacts)
-            assertEquals("task-a", File(cwd, ".andy/active-task").readText().trim())
-            assertFalse(File(cwd, ".cursor/hooks.json").exists())
-
+            val hooksFile = File(cwd, ".cursor/hooks.json")
+            val first = hooksFile.readText()
+            val firstModified = hooksFile.lastModified()
+            Thread.sleep(20)
             val artifactsB = File(cwd, ".andy/task-b").also { it.mkdirs() }
             installStatusSignals(AgentKind.Cursor, cwd, artifactsB)
+            assertEquals(first, hooksFile.readText(), "stable hooks must not rewrite per task")
             assertEquals("task-b", File(cwd, ".andy/active-task").readText().trim())
-            assertFalse(File(cwd, ".cursor/hooks.json").exists())
+            // File content identical; mtime may or may not change — content is the contract.
+            assertTrue(firstModified > 0)
         } finally {
             System.setProperty("user.home", previousHome)
             home.deleteRecursively()

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentTerminalSessionLifecycleTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentTerminalSessionLifecycleTest.kt
@@ -134,6 +134,58 @@ class AgentTerminalSessionLifecycleTest {
     }
 
     /**
+     * Regression for orphaned `andy-task-*` tmux sessions: a session reattached after
+     * losing its handle (app/daemon restart, or any other drop from [handles]) is built
+     * with `killTmuxOnClose = false` so background release doesn't tear down a chat the
+     * user isn't actively stopping. But [AgentTerminalManager.stop] always means
+     * "terminate" - if it trusted that same flag, stopping (or deleting, which routes
+     * through stop) a chat that had been reattached would silently leave its tmux
+     * session and CLI process running forever with no handle referencing it.
+     */
+    @Test
+    fun stoppingAReattachedSessionStillKillsTmux() = runBlocking {
+        if (!TmuxAndy.isAvailable()) {
+            println("SKIP: tmux not installed")
+            return@runBlocking
+        }
+        AndyKetraTermConfig.ensureInitialized()
+        val dir = tempDir()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val taskId = "reattach-then-stop-task"
+        try {
+            val manager = AgentTerminalManager(
+                scope = scope,
+                scrollbackFile = { id -> File(dir, "$id/scrollback.ansi") },
+                mode = AgentTerminalMode.TmuxWithAttach,
+            )
+            manager.start(task(taskId, dir), longRunningArgv(), emptyMap())
+            assertTrue(TmuxAndy.hasSession(taskId))
+
+            // Simulate a dropped handle (e.g. app/daemon restart) followed by a GUI
+            // reattach: this is the only path that constructs a fresh TmuxAttachBackend
+            // pinned to killTmuxOnClose = false.
+            manager.stop(taskId)
+            assertFalse(TmuxAndy.hasSession(taskId), "sanity: stop on a live handle kills tmux")
+
+            TmuxAndy.newSession(taskId = taskId, cwd = dir.absolutePath, argv = longRunningArgv())
+            assertTrue(TmuxAndy.hasSession(taskId))
+            val reattached = manager.attachExisting(taskId, cwd = dir.absolutePath)
+            assertNotNull(reattached, "reattach should succeed")
+            assertTrue(TmuxAndy.hasSession(taskId))
+
+            manager.stop(taskId)
+            assertFalse(
+                TmuxAndy.hasSession(taskId),
+                "stopping a reattached chat must kill its tmux session, not just drop the handle",
+            )
+        } finally {
+            runCatching { TmuxAndy.killSession(taskId) }
+            scope.cancel()
+            dir.deleteRecursively()
+        }
+    }
+
+    /**
      * Product-path regression: AgentTerminalManager → TerminalSessions → tmux must
      * recover a deleted task cwd into scratch instead of a getcwd / uv_cwd broken pane.
      */


### PR DESCRIPTION
## Summary
- **Status hooks**: `installStatusSignals` now installs merged `working`/`done`/`blocked` lifecycle hooks per vendor (Claude Code, Cursor, Codex, Antigravity) instead of only stripping legacy Andy entries. Badge state in the UI stays screen-scrape authoritative (Herdr parity); the hooks write optional `status.json` artifacts for MCP/debug and merge non-destructively with user-authored hooks.
- **Tmux launch fix**: `TmuxAndy.createDetachedSession` now writes the launch command to a script file under `~/.andy/tmux-launch/` and invokes that instead of inlining the command on the `tmux new-session` command line. tmux's client/server IPC caps a single command message at roughly 16-20KB ("command too long"), which a long build/review prompt (e.g. a full frozen plan or diff) could exceed.
- **Reattach/stop bug fix**: `AgentTerminalManager.stop()` previously delegated tmux teardown to `session.close()`, which a reattached `TmuxAttachBackend` (`killTmuxOnClose = false`) honors by leaving the tmux session alive. Since `stop()` always means "terminate," it now force-kills the tmux session directly, so stopping (or deleting, which routes through stop) a chat that had been reattached after a dropped handle no longer leaks its tmux session and CLI process.

## Test plan
- [x] `./gradlew :desktopTest --tests "app.andy.desktop.service.agents.AgentStatusTrackerTest" --tests "app.andy.desktop.service.agents.AgentTerminalSessionLifecycleTest"` — all pass, including the new `stoppingAReattachedSessionStillKillsTmux` regression test
- [x] `./gradlew compileKotlinDesktop compileTestKotlinDesktop` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViQjJ91HG3SbQgrzZgtZHC