### PR TITLE
Badge chats left open behind other apps, and harden status-hook install

### DIFF
--- a/scripts/andy-status-hook.sh
+++ b/scripts/andy-status-hook.sh
@@ -5,8 +5,9 @@
 # respond: none (default) | empty | allow | stop
 # gate: none (default) | fully-idle | completed
 #
-# Resolves the active task via $ANDY_PROJECT_ROOT/.andy/active-task (default: $PWD).
-# No-ops when the pointer is missing so user-level / shared hooks are safe.
+# Resolves the active task via $ANDY_TASK_ID when set (per-session), else
+# $ANDY_PROJECT_ROOT/.andy/active-task (default: $PWD/.andy/active-task).
+# No-ops when neither is available so user-level / shared hooks are safe.
 # Always consumes stdin (vendor hooks send JSON payloads).
 status="${1:-done}"
 respond="${2:-none}"
@@ -34,11 +35,15 @@ case "$gate" in
 esac
 
 ROOT="${ANDY_PROJECT_ROOT:-$PWD}"
-ACTIVE="$ROOT/.andy/active-task"
-if [ ! -f "$ACTIVE" ]; then
-  respond_and_exit
+task_id=""
+if [ -n "${ANDY_TASK_ID:-}" ]; then
+  task_id=$(printf '%s' "$ANDY_TASK_ID" | tr -d '[:space:]')
+else
+  ACTIVE="$ROOT/.andy/active-task"
+  if [ -f "$ACTIVE" ]; then
+    task_id=$(tr -d '[:space:]' < "$ACTIVE")
+  fi
 fi
-task_id=$(tr -d '[:space:]' < "$ACTIVE")
 if [ -z "$task_id" ]; then
   respond_and_exit
 fi

--- a/scripts/install-andy.sh
+++ b/scripts/install-andy.sh
@@ -217,11 +217,15 @@ case "$gate" in
 esac
 
 ROOT="${ANDY_PROJECT_ROOT:-$PWD}"
-ACTIVE="$ROOT/.andy/active-task"
-if [ ! -f "$ACTIVE" ]; then
-  respond_and_exit
+task_id=""
+if [ -n "${ANDY_TASK_ID:-}" ]; then
+  task_id=$(printf '%s' "$ANDY_TASK_ID" | tr -d '[:space:]')
+else
+  ACTIVE="$ROOT/.andy/active-task"
+  if [ -f "$ACTIVE" ]; then
+    task_id=$(tr -d '[:space:]' < "$ACTIVE")
+  fi
 fi
-task_id=$(tr -d '[:space:]' < "$ACTIVE")
 if [ -z "$task_id" ]; then
   respond_and_exit
 fi

--- a/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -380,8 +380,18 @@ interface AgentRunService {
     val interactiveTerminalTaskIds: StateFlow<Set<String>> get() = NoInteractiveTerminals
     /** Chats whose embedded terminal widget is currently mounted in the UI. */
     val attachedTerminalTaskIds: StateFlow<Set<String>> get() = NoInteractiveTerminals
-    /** True while the embedded chat for [taskId] is currently on screen. */
+    /**
+     * True while the embedded chat for [taskId] is on screen *and* the app window is
+     * foreground. A chat left open behind another app is not being watched, so it still
+     * earns an unread badge and an OS banner when its turn ends.
+     */
     fun isViewing(taskId: String): Boolean = false
+
+    /**
+     * Publishes window visibility/focus. Losing focus makes the open chat behave like a
+     * background one for attention purposes; regaining it marks that chat read again.
+     */
+    fun setAppForeground(foreground: Boolean) = Unit
     /** Supplies an answer to an agent-issued decision checkpoint and continues the task. */
     fun respondToUserInput(taskId: String, requestId: String, answers: Map<String, String>)
     /** Holds a follow-up until the active run completes successfully. */

--- a/src/desktopMain/kotlin/app/andy/desktop/Main.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/Main.kt
@@ -323,17 +323,21 @@ fun main() {
             }
             LaunchedEffect(visible) {
                 appFocus.visible = visible
+                // Hidden to the tray counts as background: chats keep badging and notifying.
+                services.agentRuns.setAppForeground(appFocus.isForeground())
                 if (visible) consumePendingOpen()
             }
             DisposableEffect(window) {
                 val listener = object : java.awt.event.WindowAdapter() {
                     override fun windowActivated(event: java.awt.event.WindowEvent) {
                         appFocus.focused = true
+                        services.agentRuns.setAppForeground(appFocus.isForeground())
                         consumePendingOpen()
                     }
 
                     override fun windowDeactivated(event: java.awt.event.WindowEvent) {
                         appFocus.focused = false
+                        services.agentRuns.setAppForeground(false)
                     }
                 }
                 window.addWindowListener(listener)

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
@@ -85,6 +85,10 @@ class McpAgentRunClient(
     private val clientReadTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val clientViewingTaskId = java.util.concurrent.atomic.AtomicReference<String?>(null)
 
+    /** Window visibility/focus. An open chat only counts as watched while the window is up. */
+    @Volatile
+    private var appForeground: Boolean = true
+
     private val _cliStatuses = MutableStateFlow<List<AgentCliStatus>>(emptyList())
     override val cliStatuses: StateFlow<List<AgentCliStatus>> = _cliStatuses.asStateFlow()
 
@@ -146,7 +150,8 @@ class McpAgentRunClient(
     fun terminalHost(): DesktopAgentRunService? = localBridge
 
     internal fun reconcileStaleActiveTaskIfNeeded(taskId: String) {
-        if (!isViewing(taskId)) return
+        // Repair is tied to the chat being mounted, not to window focus.
+        if (clientViewingTaskId.get() != taskId && localBridge?.isChatOpen(taskId) != true) return
         scope.launch {
             runCatching {
                 callTool("chat.reconcile", mapOf("taskId" to JsonPrimitive(taskId)))
@@ -160,8 +165,10 @@ class McpAgentRunClient(
         patchTask(taskId) { it.copy(unread = false) }
     }
 
+    // While the window is away the open chat must keep whatever unread the daemon reports;
+    // merging it as "viewing" would wipe the badge the user is meant to come back to.
     private fun viewingTaskIdsForMerge(): Set<String> =
-        clientViewingTaskId.get()?.let(::setOf).orEmpty()
+        if (appForeground) clientViewingTaskId.get()?.let(::setOf).orEmpty() else emptySet()
 
     private suspend fun refreshTasks() {
         refreshComposerOptions()
@@ -448,7 +455,21 @@ class McpAgentRunClient(
         localBridge?.isTerminalLive(taskId) == true
 
     override fun isViewing(taskId: String): Boolean =
-        clientViewingTaskId.get() == taskId || localBridge?.isViewing(taskId) == true
+        appForeground && (clientViewingTaskId.get() == taskId || localBridge?.isChatOpen(taskId) == true)
+
+    override fun setAppForeground(foreground: Boolean) {
+        if (appForeground == foreground) return
+        appForeground = foreground
+        localBridge?.setAppForeground(foreground)
+        // The daemon owns unread, so it needs the same signal; older andyd builds without
+        // the tool simply keep the previous (always-foreground) behaviour.
+        scope.launch {
+            runCatching {
+                callTool("chat.set_app_focus", mapOf("focused" to JsonPrimitive(foreground)))
+            }
+        }
+        if (foreground) clientViewingTaskId.get()?.let(::markRead)
+    }
 
     override fun respondToUserInput(taskId: String, requestId: String, answers: Map<String, String>) {
         scope.launch {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -83,11 +85,25 @@ class McpAgentRunClient(
      * [AgentTask.unread] = false. Prevents periodic refresh from re-badging them.
      */
     private val clientReadTaskIds = ConcurrentHashMap.newKeySet<String>()
+
+    /** Ids whose `chat.mark_read` RPC the daemon has acknowledged; see [dropSettledClientReads]. */
+    private val daemonAckedReadTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val clientViewingTaskId = java.util.concurrent.atomic.AtomicReference<String?>(null)
 
     /** Window visibility/focus. An open chat only counts as watched while the window is up. */
     @Volatile
     private var appForeground: Boolean = true
+
+    /**
+     * Serializes `chat.set_app_focus` RPCs. Each [callTool] opens its own Unix connection and
+     * the daemon handles connections concurrently, so unsynchronized sends can land out of
+     * order and leave the daemon believing the window is foreground after it went away —
+     * exactly the state that suppresses the badge this focus tracking exists to produce.
+     */
+    private val appFocusRpcMutex = Mutex()
+
+    /** Last value the daemon accepted, so redundant transitions do not re-send. */
+    private var lastSentAppForeground: Boolean? = null
 
     private val _cliStatuses = MutableStateFlow<List<AgentCliStatus>>(emptyList())
     override val cliStatuses: StateFlow<List<AgentCliStatus>> = _cliStatuses.asStateFlow()
@@ -162,6 +178,9 @@ class McpAgentRunClient(
 
     private fun acknowledgeRead(taskId: String) {
         clientReadTaskIds += taskId
+        // This ack is pending again until its own RPC lands; an earlier settle marker would
+        // otherwise retire it on the next refresh and flash the badge back.
+        daemonAckedReadTaskIds -= taskId
         patchTask(taskId) { it.copy(unread = false) }
     }
 
@@ -172,11 +191,15 @@ class McpAgentRunClient(
 
     private suspend fun refreshTasks() {
         refreshComposerOptions()
+        // Snapshot before the fetch: the list we are about to request is produced after the
+        // daemon acknowledged these reads, so it already reflects them.
+        val settledReads = daemonAckedReadTaskIds.toSet()
         val raw = callTool("chat.list", emptyMap())
         val arr = runCatching { json.parseToJsonElement(raw).jsonArray }.getOrNull() ?: return
         // Keep a lightweight task list for the GUI; lifecycle fields must round-trip so
         // badges/labels match the daemon (startedAtMillis drives isQueued).
         val refreshedTasks = arr.mapNotNull { el -> parseListedTask(el.jsonObject) }
+        dropSettledClientReads(clientReadTaskIds, daemonAckedReadTaskIds, settledReads)
         dropConfirmedClientReads(clientReadTaskIds, refreshedTasks)
         _tasks.value = mergeRefreshedAgentTasks(
             refreshed = refreshedTasks,
@@ -230,10 +253,12 @@ class McpAgentRunClient(
         _tasks.value = _tasks.value.map { if (it.id == taskId) transform(it) else it }
     }
 
-    private fun callTaskMutation(tool: String, taskId: String) {
+    private fun callTaskMutation(tool: String, taskId: String, onApplied: (() -> Unit)? = null) {
         scope.launch {
             runCatching {
                 callTool(tool, mapOf("taskId" to JsonPrimitive(taskId)))
+            }.onSuccess {
+                onApplied?.invoke()
             }.onFailure { error ->
                 // Local clientReadTaskIds clear the badge for this session only;
                 // if the daemon RPC fails (e.g. stale andyd without chat.mark_read),
@@ -461,14 +486,27 @@ class McpAgentRunClient(
         if (appForeground == foreground) return
         appForeground = foreground
         localBridge?.setAppForeground(foreground)
-        // The daemon owns unread, so it needs the same signal; older andyd builds without
-        // the tool simply keep the previous (always-foreground) behaviour.
+        publishAppForeground()
+        if (foreground) clientViewingTaskId.get()?.let(::markRead)
+    }
+
+    /**
+     * Pushes window focus to the daemon, which owns unread. Sends are serialized and always
+     * carry the *current* state rather than the value captured at call time, so a burst of
+     * transitions converges on the latest one instead of racing. Older andyd builds without
+     * the tool simply keep the previous (always-foreground) behaviour.
+     */
+    private fun publishAppForeground() {
         scope.launch {
-            runCatching {
-                callTool("chat.set_app_focus", mapOf("focused" to JsonPrimitive(foreground)))
+            appFocusRpcMutex.withLock {
+                val desired = appForeground
+                if (lastSentAppForeground == desired) return@withLock
+                val sent = runCatching {
+                    callTool("chat.set_app_focus", mapOf("focused" to JsonPrimitive(desired)))
+                }.isSuccess
+                if (sent) lastSentAppForeground = desired
             }
         }
-        if (foreground) clientViewingTaskId.get()?.let(::markRead)
     }
 
     override fun respondToUserInput(taskId: String, requestId: String, answers: Map<String, String>) {
@@ -515,12 +553,15 @@ class McpAgentRunClient(
         // reloads unread=true from andyd.
         if (!task.unread && taskId !in clientReadTaskIds) return
         acknowledgeRead(taskId)
-        callTaskMutation("chat.mark_read", taskId)
+        callTaskMutation("chat.mark_read", taskId) { daemonAckedReadTaskIds += taskId }
     }
 
     override fun markUnread(taskId: String) {
         val task = _tasks.value.firstOrNull { it.id == taskId } ?: return
         if (task.unread) return
+        // A deliberate unread supersedes any in-flight read ack for the same chat.
+        clientReadTaskIds -= taskId
+        daemonAckedReadTaskIds -= taskId
         patchTask(taskId) { it.copy(unread = true) }
         callTaskMutation("chat.mark_unread", taskId)
     }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTaskListSync.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTaskListSync.kt
@@ -28,3 +28,22 @@ internal fun dropConfirmedClientReads(
 ) {
     clientReadTaskIds.removeIf { id -> refreshed.any { it.id == id && !it.unread } }
 }
+
+/**
+ * Retire local read acks the daemon has already applied.
+ *
+ * [settled] holds ids whose `chat.mark_read` RPC completed before the list currently being
+ * merged was requested, so that list already reflects the read. Any `unread = true` it still
+ * reports is therefore a *newer* transition — a turn that finished after the user opened the
+ * chat — and must not be masked by the ack. Without this, an ack placed moments before the
+ * turn completes is never confirmed (the daemon never reports the chat read again) and the
+ * badge stays suppressed for the rest of the session.
+ */
+internal fun dropSettledClientReads(
+    clientReadTaskIds: MutableSet<String>,
+    daemonAckedReadTaskIds: MutableSet<String>,
+    settled: Set<String>,
+) {
+    clientReadTaskIds.removeAll(settled)
+    daemonAckedReadTaskIds.removeAll(settled)
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
@@ -309,6 +309,20 @@ fun Server.registerAgentProjectTools(
     }
 
     register(
+        name = "chat.set_app_focus",
+        description = "Track whether the Andy window is foreground; a chat open behind another " +
+            "app still earns unread badges and notifications",
+        properties = mapOf(
+            "focused" to buildJsonObject { put("type", "boolean") },
+        ),
+        required = listOf("focused"),
+    ) { args ->
+        val focused = args["focused"]?.jsonPrimitive?.booleanOrNull ?: error("focused required")
+        agentRuns.setAppForeground(focused)
+        textResult("""{"ok":true,"focused":$focused}""")
+    }
+
+    register(
         name = "chat.mark_unread",
         description = "Mark a chat unread so list/dock badges show again",
         properties = mapOf(
@@ -677,6 +691,7 @@ fun agentProjectToolNames(): List<String> = listOf(
     "chat.stop",
     "chat.mark_read",
     "chat.set_viewing",
+    "chat.set_app_focus",
     "chat.mark_unread",
     "chat.archive",
     "chat.unarchive",

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentStatusHooks.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentStatusHooks.kt
@@ -19,7 +19,8 @@ private const val ANTIGRAVITY_HOOK_NAME = "andy-status"
 
 /**
  * Installs vendor lifecycle hooks that append state to `.andy/<taskId>/status.json`
- * via the user-global `~/.andy/bin/andy-status-hook.sh` and `.andy/active-task`.
+ * via the user-global `~/.andy/bin/andy-status-hook.sh`. Each launched agent session
+ * sets `ANDY_TASK_ID` in its environment; `.andy/active-task` remains a fallback.
  *
  * Preferred status mapping (when the vendor emits the event):
  * - working ← prompt submit / pre-invocation
@@ -78,7 +79,8 @@ private fun shouldSkipProjectHooks(worktreeOrCwd: File): Boolean {
     return cwd == home
 }
 
-private fun writeHooksIfChanged(file: File, merged: JsonObject) {
+private fun writeHooksIfChanged(file: File, merged: JsonObject?) {
+    if (merged == null) return
     val encoded = hooksJson.encodeToString(JsonObject.serializer(), merged) + "\n"
     val existing = file.takeIf { it.isFile }?.readText()
     if (existing == encoded) return
@@ -297,18 +299,21 @@ private fun cursorCommandEntry(command: String): JsonObject =
 /**
  * Merge Andy event hooks into a Claude/Codex-style `{ "hooks": { Event: [...] } }` file.
  * Preserves non-Andy entries; replaces prior Andy `andy-status-hook` entries per event.
+ * Returns null when [settingsFile] exists but cannot be parsed — caller must not overwrite.
  */
 internal fun mergeClaudeStyleEventHooks(
     settingsFile: File,
     andyEventHooks: JsonObject,
-): JsonObject {
-    val existingRoot = if (settingsFile.isFile) {
-        runCatching { hooksJson.parseToJsonElement(settingsFile.readText()).jsonObject }.getOrNull()
-    } else {
-        null
+): JsonObject? {
+    val existingRoot = when (val read = readExistingHooksRoot(settingsFile)) {
+        HooksFileRead.Missing -> null
+        HooksFileRead.Invalid -> return null
+        is HooksFileRead.Ok -> read.root
     }
     val root = mutableJsonMap(existingRoot)
     val existingEvents = mutableJsonMap(root["hooks"] as? JsonObject)
+
+    stripAndyHooksFromAllEvents(existingEvents)
 
     for ((event, andyMatchers) in andyEventHooks) {
         val current = (existingEvents[event] as? JsonArray)?.toList().orEmpty()
@@ -317,28 +322,22 @@ internal fun mergeClaudeStyleEventHooks(
         existingEvents[event] = JsonArray(preserved + andyList)
     }
 
-    // Drop legacy Andy SubagentStop→done wiring that falsely marks the parent Done.
-    val subagentStop = existingEvents["SubagentStop"] as? JsonArray
-    if (subagentStop != null) {
-        val preserved = subagentStop.filterNot(::jsonContainsAndyHook)
-        if (preserved.isEmpty()) existingEvents.remove("SubagentStop")
-        else existingEvents["SubagentStop"] = JsonArray(preserved)
-    }
-
     root["hooks"] = JsonObject(existingEvents)
     return JsonObject(root)
 }
 
-internal fun mergeCursorHooks(hooksFile: File, andyEventHooks: JsonObject): JsonObject {
-    val existingRoot = if (hooksFile.isFile) {
-        runCatching { hooksJson.parseToJsonElement(hooksFile.readText()).jsonObject }.getOrNull()
-    } else {
-        null
+internal fun mergeCursorHooks(hooksFile: File, andyEventHooks: JsonObject): JsonObject? {
+    val existingRoot = when (val read = readExistingHooksRoot(hooksFile)) {
+        HooksFileRead.Missing -> null
+        HooksFileRead.Invalid -> return null
+        is HooksFileRead.Ok -> read.root
     }
     val root = mutableJsonMap(existingRoot)
     if (!root.containsKey("version")) root["version"] = JsonPrimitive(1)
     val existingEvents = mutableJsonMap(root["hooks"] as? JsonObject)
 
+    stripAndyHooksFromAllEvents(existingEvents)
+
     for ((event, andyMatchers) in andyEventHooks) {
         val current = (existingEvents[event] as? JsonArray)?.toList().orEmpty()
         val preserved = current.filterNot(::jsonContainsAndyHook)
@@ -349,15 +348,39 @@ internal fun mergeCursorHooks(hooksFile: File, andyEventHooks: JsonObject): Json
     return JsonObject(root)
 }
 
-internal fun mergeAntigravityHooks(hooksFile: File, andyHook: JsonObject): JsonObject {
-    val existingRoot = if (hooksFile.isFile) {
-        runCatching { hooksJson.parseToJsonElement(hooksFile.readText()).jsonObject }.getOrNull()
-    } else {
-        null
+internal fun mergeAntigravityHooks(hooksFile: File, andyHook: JsonObject): JsonObject? {
+    val existingRoot = when (val read = readExistingHooksRoot(hooksFile)) {
+        HooksFileRead.Missing -> null
+        HooksFileRead.Invalid -> return null
+        is HooksFileRead.Ok -> read.root
     }
     val root = mutableJsonMap(existingRoot)
     root[ANTIGRAVITY_HOOK_NAME] = andyHook
     return JsonObject(root)
+}
+
+private sealed interface HooksFileRead {
+    data object Missing : HooksFileRead
+    data object Invalid : HooksFileRead
+    data class Ok(val root: JsonObject) : HooksFileRead
+}
+
+private fun readExistingHooksRoot(file: File): HooksFileRead {
+    if (!file.isFile) return HooksFileRead.Missing
+    return runCatching { hooksJson.parseToJsonElement(file.readText()).jsonObject }
+        .fold(
+            onSuccess = { HooksFileRead.Ok(it) },
+            onFailure = { HooksFileRead.Invalid },
+        )
+}
+
+private fun stripAndyHooksFromAllEvents(existingEvents: MutableMap<String, JsonElement>) {
+    for (event in existingEvents.keys.toList()) {
+        val current = existingEvents[event] as? JsonArray ?: continue
+        val preserved = current.filterNot(::jsonContainsAndyHook)
+        if (preserved.isEmpty()) existingEvents.remove(event)
+        else existingEvents[event] = JsonArray(preserved)
+    }
 }
 
 private fun mutableJsonMap(source: JsonObject?): MutableMap<String, JsonElement> =

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
@@ -371,6 +371,11 @@ class AgentTerminalManager(
             File(artifactDir, "status.json").delete()
             File(artifactDir, "question.json").delete()
 
+            val launchEnv = env + mapOf(
+                AndyStatusHookInstaller.TASK_ID_ENV to task.id,
+                AndyStatusHookInstaller.PROJECT_ROOT_ENV to cwdPath,
+            )
+
             val resolvedMode = resolveMode()
             val session = when (resolvedMode) {
                 AgentTerminalMode.TmuxHeadless -> {
@@ -379,7 +384,7 @@ class AgentTerminalManager(
                             sessionId = task.id,
                             argv = argv,
                             cwd = cwdPath,
-                            env = env,
+                            env = launchEnv,
                             appearance = terminalAppearance(),
                             mode = TerminalMode.TmuxAgent,
                             killTmuxOnClose = true,
@@ -392,7 +397,7 @@ class AgentTerminalManager(
                             sessionId = task.id,
                             argv = argv,
                             cwd = cwdPath,
-                            env = env,
+                            env = launchEnv,
                             appearance = terminalAppearance(),
                             mode = TerminalMode.TmuxAttach,
                             killTmuxOnClose = true,
@@ -405,7 +410,7 @@ class AgentTerminalManager(
                             sessionId = task.id,
                             argv = argv,
                             cwd = cwdPath,
-                            env = env,
+                            env = launchEnv,
                             appearance = terminalAppearance(),
                             mode = TerminalMode.DirectPty,
                             agentCli = true,

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AndyStatusHookInstaller.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AndyStatusHookInstaller.kt
@@ -12,6 +12,8 @@ import java.io.File
 object AndyStatusHookInstaller {
     const val SCRIPT_NAME = "andy-status-hook.sh"
     const val ACTIVE_TASK_FILE = "active-task"
+    const val TASK_ID_ENV = "ANDY_TASK_ID"
+    const val PROJECT_ROOT_ENV = "ANDY_PROJECT_ROOT"
 
     /** Stable shell command prefix used in vendor hook configs (expands `$HOME` at runtime). */
     const val STABLE_HOOK_COMMAND = "\"\$HOME/.andy/bin/$SCRIPT_NAME\""
@@ -29,8 +31,9 @@ object AndyStatusHookInstaller {
         # respond: none (default) | empty | allow | stop
         # gate: none (default) | fully-idle | completed
         #
-        # Resolves the active task via ${'$'}ANDY_PROJECT_ROOT/.andy/active-task (default: ${'$'}PWD).
-        # No-ops when the pointer is missing so user-level / shared hooks are safe.
+        # Resolves the active task via ${'$'}ANDY_TASK_ID when set (per-session), else
+        # ${'$'}ANDY_PROJECT_ROOT/.andy/active-task (default: ${'$'}PWD/.andy/active-task).
+        # No-ops when neither is available so user-level / shared hooks are safe.
         # Always consumes stdin (vendor hooks send JSON payloads).
         status="${'$'}{1:-done}"
         respond="${'$'}{2:-none}"
@@ -58,11 +61,15 @@ object AndyStatusHookInstaller {
         esac
 
         ROOT="${'$'}{ANDY_PROJECT_ROOT:-${'$'}PWD}"
-        ACTIVE="${'$'}ROOT/.andy/active-task"
-        if [ ! -f "${'$'}ACTIVE" ]; then
-          respond_and_exit
+        task_id=""
+        if [ -n "${'$'}{ANDY_TASK_ID:-}" ]; then
+          task_id=${'$'}(printf '%s' "${'$'}ANDY_TASK_ID" | tr -d '[:space:]')
+        else
+          ACTIVE="${'$'}ROOT/.andy/active-task"
+          if [ -f "${'$'}ACTIVE" ]; then
+            task_id=${'$'}(tr -d '[:space:]' < "${'$'}ACTIVE")
+          fi
         fi
-        task_id=${'$'}(tr -d '[:space:]' < "${'$'}ACTIVE")
         if [ -z "${'$'}task_id" ]; then
           respond_and_exit
         fi

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -152,6 +152,15 @@ class DesktopAgentRunService(
 
     private val handles = ConcurrentHashMap<String, TaskHandle>()
     private val viewingTaskIds = ConcurrentHashMap.newKeySet<String>()
+
+    /**
+     * Window visibility/focus, pushed by the GUI. Terminal foreground cadence deliberately
+     * ignores this — scraping must stay fast while the user is in another app, otherwise
+     * the finished turn we want to notify about is detected late.
+     */
+    @Volatile
+    private var appForeground: Boolean = true
+
     private val previousTaskStatuses = ConcurrentHashMap<String, AgentStatus?>()
     private val eventFlows = ConcurrentHashMap<String, MutableStateFlow<List<AgentEvent>>>()
     private val emptyEvents = MutableStateFlow<List<AgentEvent>>(emptyList())
@@ -237,7 +246,10 @@ class DesktopAgentRunService(
 
     override val interactiveTerminalTaskIds: StateFlow<Set<String>> get() = terminals.interactiveTaskIds
 
-    override fun isViewing(taskId: String): Boolean = taskId in viewingTaskIds
+    override fun isViewing(taskId: String): Boolean = appForeground && taskId in viewingTaskIds
+
+    /** True while the chat is mounted in the UI, focused or not. */
+    internal fun isChatOpen(taskId: String): Boolean = taskId in viewingTaskIds
 
     /** True while the local Swing/PTY viewer attached to tmux is still running. */
     internal fun isViewerAlive(taskId: String): Boolean = terminals.isViewerAlive(taskId)
@@ -3229,6 +3241,14 @@ class DesktopAgentRunService(
         }
     }
 
+    override fun setAppForeground(foreground: Boolean) {
+        if (appForeground == foreground) return
+        appForeground = foreground
+        // Coming back to the window is the moment the open chat is actually seen: clear the
+        // badge that accumulated while it sat behind another app.
+        if (foreground) viewingTaskIds.forEach(::markRead)
+    }
+
     private fun applyStatusSnapshot(taskId: String, snapshot: AgentStatusSnapshot) {
         val task = currentTask(taskId) ?: return
         val terminalLive = terminals.isAlive(taskId)
@@ -3265,7 +3285,7 @@ class DesktopAgentRunService(
                 task = task,
                 previous = previous,
                 next = snapshot.status,
-                viewing = taskId in viewingTaskIds,
+                viewing = isViewing(taskId),
                 terminalLive = terminalLive,
             )
         ) {
@@ -3323,7 +3343,7 @@ class DesktopAgentRunService(
                     exitCode = exitCode,
                     errorMessage = error,
                     finishedAtMillis = System.currentTimeMillis(),
-                    unread = taskId !in viewingTaskIds,
+                    unread = !isViewing(taskId),
                     completedChanges = completedChanges ?: task.completedChanges,
                 )
             } else {

--- a/src/desktopMain/kotlin/app/andy/terminal/OwnerOnlyFiles.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/OwnerOnlyFiles.kt
@@ -1,0 +1,29 @@
+package app.andy.terminal
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+
+/** Write [content] to [file] with owner-only permissions (0600 file, 0700 parent dirs). */
+internal fun writeOwnerOnlyText(file: File, content: String) {
+    val parent = file.parentFile
+    if (parent != null) {
+        parent.mkdirs()
+        restrictToOwner(parent, executable = true)
+    }
+    file.writeText(content, StandardCharsets.UTF_8)
+    restrictToOwner(file, executable = false)
+}
+
+internal fun restrictToOwner(file: File, executable: Boolean) {
+    if (!file.exists()) return
+    runCatching {
+        val perms = mutableSetOf(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+        )
+        if (executable || file.isDirectory) perms += PosixFilePermission.OWNER_EXECUTE
+        Files.setPosixFilePermissions(file.toPath(), perms)
+    }
+}

--- a/src/desktopMain/kotlin/app/andy/terminal/TmuxAndy.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/TmuxAndy.kt
@@ -242,8 +242,7 @@ object TmuxAndy {
         // script path instead — the command line stays tiny no matter how big the
         // agent prompt is.
         val scriptFile = launchScriptFile(name)
-        scriptFile.parentFile?.mkdirs()
-        scriptFile.writeText(launch)
+        writeOwnerOnlyText(scriptFile, launch)
         val cmd = listOf(
             tmuxBinary(), "-L", SERVER, "new-session", "-d", "-s", name,
             "-c", sessionCwd,
@@ -288,6 +287,7 @@ object TmuxAndy {
         run(listOf(tmuxBinary(), "-L", SERVER, "kill-server"), checkExit = false)
         invalidateSessionCache()
         serverConfigured.set(false)
+        launchScriptDir().listFiles()?.forEach { it.delete() }
     }
 
     /** Literal keystrokes into the session's active pane (no automatic Enter). */

--- a/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentTaskListSyncTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentTaskListSyncTest.kt
@@ -68,6 +68,40 @@ class McpAgentTaskListSyncTest {
     }
 
     @Test
+    fun settledClientReadStopsMaskingNewerDaemonUnread() {
+        // The user opened "a" (ack recorded), the daemon applied the read, and only then did
+        // the turn finish and re-badge it. The list below was fetched after that ack landed,
+        // so its unread=true is newer than the ack and must survive.
+        val clientReads = linkedSetOf("a")
+        val daemonAcked = linkedSetOf("a")
+        val refreshed = listOf(task("a", unread = true))
+
+        dropSettledClientReads(clientReads, daemonAcked, settled = setOf("a"))
+        dropConfirmedClientReads(clientReads, refreshed)
+        val merged = mergeRefreshedAgentTasks(refreshed, clientReads, viewingTaskIds = emptySet())
+
+        assertTrue(merged.single().unread)
+        assertTrue(clientReads.isEmpty())
+        assertTrue(daemonAcked.isEmpty())
+    }
+
+    @Test
+    fun unsettledClientReadStillMasksDaemonUnread() {
+        // Same shape, but the mark_read RPC has not been acknowledged yet, so the daemon's
+        // unread is stale rather than newer and the local ack must still win.
+        val clientReads = linkedSetOf("a")
+        val daemonAcked = linkedSetOf<String>()
+        val refreshed = listOf(task("a", unread = true))
+
+        dropSettledClientReads(clientReads, daemonAcked, settled = daemonAcked.toSet())
+        dropConfirmedClientReads(clientReads, refreshed)
+        val merged = mergeRefreshedAgentTasks(refreshed, clientReads, viewingTaskIds = emptySet())
+
+        assertFalse(merged.single().unread)
+        assertEquals(setOf("a"), clientReads)
+    }
+
+    @Test
     fun withoutClientReadAckDaemonUnreadReturnsAfterRestart() {
         // Documents why setChatViewing must call chat.mark_read: session-local
         // clientReadTaskIds alone cannot survive GUI restart.

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentChatReadStateTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentChatReadStateTest.kt
@@ -92,6 +92,34 @@ class AgentChatReadStateTest {
     }
 
     @Test
+    fun openChatStopsCountingAsViewedWhileWindowIsNotFocused() = withService { service, _, _ ->
+        service.setChatViewing("chat-read", viewing = true)
+        assertTrue(service.isViewing("chat-read"))
+
+        service.setAppForeground(false)
+        // Attention treats it as background, but the chat is still mounted.
+        assertFalse(service.isViewing("chat-read"))
+        assertTrue(service.isChatOpen("chat-read"))
+
+        service.setAppForeground(true)
+        assertTrue(service.isViewing("chat-read"))
+    }
+
+    @Test
+    fun badgeEarnedWhileUnfocusedSurvivesUntilTheWindowComesBack() = withService { service, _, _ ->
+        service.setChatViewing("chat-read", viewing = true)
+        assertFalse(task(service, "chat-read").unread)
+
+        service.setAppForeground(false)
+        // A turn finishing behind another app badges the chat even though it is on screen.
+        service.markUnread("chat-read")
+        assertTrue(task(service, "chat-read").unread)
+
+        service.setAppForeground(true)
+        assertFalse(task(service, "chat-read").unread)
+    }
+
+    @Test
     fun reconcileAppliesAttentionWhenDiscoveringCompletedTurn() {
         val working = AgentTask(
             id = "t",
@@ -172,6 +200,10 @@ class AgentChatReadStateTest {
                 AgentStoreState(
                     tasks = listOf(seededTask),
                     binaryOverrides = AgentKind.entries.associate { it.cliName to shell },
+                    // The one-time legacy-transcript migration runs off-thread during init and
+                    // archives + clears unread on scrollback-less chats. Marking it already done
+                    // keeps read state under the test's control instead of racing startup.
+                    legacyTranscriptChatsArchived = true,
                 ),
             )
         }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentStatusTrackerTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentStatusTrackerTest.kt
@@ -1263,6 +1263,101 @@ class AgentStatusTrackerTest {
     }
 
     @Test
+    fun installClaudeStatusHooksPreservesMalformedSettingsFile() {
+        val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
+        val previousHome = System.getProperty("user.home")
+        try {
+            System.setProperty("user.home", home.absolutePath)
+            val cwd = File(home, "project").also { it.mkdirs() }
+            val settingsDir = File(cwd, ".claude").also { it.mkdirs() }
+            val settings = File(settingsDir, "settings.json")
+            val malformed = """
+                {
+                  // user comment — not valid for strict JSON parsers
+                  "hooks": {
+                    "PreToolUse": [
+                      { "hooks": [ { "type": "command", "command": "echo user-hook" } ] }
+                    ]
+                  }
+                }
+            """.trimIndent()
+            settings.writeText(malformed)
+            val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
+            installClaudeStatusHooks(cwd, artifacts)
+
+            assertEquals(malformed, settings.readText(), "malformed settings must not be overwritten")
+        } finally {
+            System.setProperty("user.home", previousHome)
+            home.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun installClaudeStatusHooksRemovesLegacyAndyHookFromUntouchedEvents() {
+        val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
+        val previousHome = System.getProperty("user.home")
+        try {
+            System.setProperty("user.home", home.absolutePath)
+            val cwd = File(home, "project").also { it.mkdirs() }
+            val settingsDir = File(cwd, ".claude").also { it.mkdirs() }
+            File(settingsDir, "settings.json").writeText(
+                """
+                {
+                  "hooks": {
+                    "PostToolUse": [
+                      {
+                        "hooks": [
+                          { "type": "command", "command": "'${'$'}HOME/.andy/bin/andy-status-hook.sh' working" }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """.trimIndent(),
+            )
+            val artifacts = File(cwd, ".andy/task-hooks").also { it.mkdirs() }
+            installClaudeStatusHooks(cwd, artifacts)
+
+            val hooks = kotlinx.serialization.json.Json
+                .parseToJsonElement(File(settingsDir, "settings.json").readText())
+                .jsonObject["hooks"]!!
+                .jsonObject
+            assertFalse(hooks.containsKey("PostToolUse"), "legacy Andy PostToolUse hook must be removed")
+            assertTrue(hooks.containsKey("UserPromptSubmit"))
+        } finally {
+            System.setProperty("user.home", previousHome)
+            home.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun statusHookScriptPrefersAndyTaskIdEnvOverActiveTaskPointer() {
+        val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
+        val previousHome = System.getProperty("user.home")
+        val project = File(home, "project").also { it.mkdirs() }
+        val taskA = File(project, ".andy/task-a").also { it.mkdirs() }
+        val taskB = File(project, ".andy/task-b").also { it.mkdirs() }
+        try {
+            System.setProperty("user.home", home.absolutePath)
+            val script = AndyStatusHookInstaller.ensureInstalled(home)
+            File(project, ".andy/active-task").writeText("task-b\n")
+
+            runStatusHook(
+                script,
+                project,
+                "working",
+                "empty",
+                env = mapOf(AndyStatusHookInstaller.TASK_ID_ENV to "task-a"),
+            )
+            assertTrue(File(taskA, "status.json").readText().contains("\"status\":\"working\""))
+            assertFalse(File(taskB, "status.json").exists())
+        } finally {
+            System.setProperty("user.home", previousHome)
+            home.deleteRecursively()
+        }
+    }
+
+    @Test
     fun installStatusSignalsSkipsHomeDirectory() {
         val home = File.createTempFile("andy-home", null).also { it.delete(); it.mkdirs() }
         val previousHome = System.getProperty("user.home")
@@ -1309,9 +1404,11 @@ private fun runStatusHook(
     project: File,
     vararg args: String,
     stdin: String = "",
+    env: Map<String, String> = emptyMap(),
 ): Pair<Int, String> {
     val proc = ProcessBuilder("sh", script.absolutePath, *args)
         .directory(project)
+        .apply { environment().putAll(env) }
         .redirectErrorStream(true)
         .start()
     proc.outputStream.bufferedWriter().use { writer ->

--- a/src/desktopTest/kotlin/app/andy/terminal/OwnerOnlyFilesTest.kt
+++ b/src/desktopTest/kotlin/app/andy/terminal/OwnerOnlyFilesTest.kt
@@ -1,0 +1,42 @@
+package app.andy.terminal
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OwnerOnlyFilesTest {
+    @Test
+    fun writeOwnerOnlyTextRestrictsFileAndParent() {
+        if (!FileSystemsSupportsPosix()) return
+
+        val root = File.createTempFile("andy-owner-only", null).also { it.delete(); it.mkdirs() }
+        try {
+            val file = File(root, "nested/secret.sh")
+            writeOwnerOnlyText(file, "export SECRET=1\n")
+            assertTrue(file.isFile)
+            assertEquals(
+                setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+                Files.getPosixFilePermissions(file.toPath()),
+            )
+            assertEquals(
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE,
+                ),
+                Files.getPosixFilePermissions(file.parentFile.toPath()),
+            )
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    private fun FileSystemsSupportsPosix(): Boolean =
+        runCatching {
+            Files.getPosixFilePermissions(File.createTempFile("posix-probe", null).toPath())
+            true
+        }.getOrDefault(false)
+}

--- a/src/desktopTest/kotlin/app/andy/terminal/TmuxAndyTest.kt
+++ b/src/desktopTest/kotlin/app/andy/terminal/TmuxAndyTest.kt
@@ -383,4 +383,44 @@ class TmuxAndyTest {
             dir.deleteRecursively()
         }
     }
+
+    @Test
+    fun launchScriptIsOwnerOnlyWhileSessionRuns() {
+        if (!TmuxAndy.isAvailable()) {
+            println("SKIP: tmux not installed")
+            return
+        }
+        if (!supportsPosixPermissions()) {
+            println("SKIP: POSIX permissions unavailable")
+            return
+        }
+
+        val taskId = "launch-script-" + UUID.randomUUID().toString().take(8)
+        val script = File(System.getProperty("user.home"), ".andy/tmux-launch/${TmuxAndy.sessionName(taskId)}.sh")
+        try {
+            TmuxAndy.newSession(
+                taskId = taskId,
+                cwd = System.getProperty("user.dir"),
+                argv = listOf("/bin/sh", "-c", "sleep 30"),
+            )
+            assertTrue(script.isFile, "launch script must exist while session is running")
+            val perms = java.nio.file.Files.getPosixFilePermissions(script.toPath())
+            assertEquals(
+                setOf(
+                    java.nio.file.attribute.PosixFilePermission.OWNER_READ,
+                    java.nio.file.attribute.PosixFilePermission.OWNER_WRITE,
+                ),
+                perms,
+            )
+        } finally {
+            TmuxAndy.killSession(taskId)
+            assertFalse(script.isFile, "launch script must be deleted when session ends")
+        }
+    }
+
+    private fun supportsPosixPermissions(): Boolean =
+        runCatching {
+            java.nio.file.Files.getPosixFilePermissions(File.createTempFile("posix-probe", null).toPath())
+            true
+        }.getOrDefault(false)
 }


### PR DESCRIPTION
## Summary

Four related fixes around agent attention state and status-hook installation.

**Chats open behind another app now badge and notify.** An open chat previously counted as "being watched" purely because it was mounted, so a turn that finished while Andy sat behind another app (or hidden to the tray) silently cleared itself — no unread badge, no OS banner. Window focus is now published through a new `AgentRunService.setAppForeground` and mirrored to the daemon via a new `chat.set_app_focus` MCP tool. Coming back to the window is treated as the moment the chat is actually seen, so the accumulated badge clears then. Older `andyd` builds without the tool keep the previous always-foreground behaviour.

Chat *mount* state is kept separate from focus (`isChatOpen`) so two things deliberately do **not** change: stale-history repair still keys off the chat being on screen, and terminal scrape cadence stays fast while the user is in another app — otherwise the finished turn we want to notify about gets detected late.

**Status hooks resolve the task per session.** Each launched agent now gets `ANDY_TASK_ID` (and `ANDY_PROJECT_ROOT`) in its environment; `.andy/active-task` remains a fallback for user-level/shared hooks. Two concurrent agents in one project no longer both write status to whichever task the pointer named last.

**Hook installation is non-destructive.** A `settings.json` / `hooks.json` that fails to parse (comments, hand-edits) is now left untouched instead of being overwritten with a freshly generated file. Stale Andy entries are stripped from *every* event rather than only the events Andy is about to rewrite, which generalizes the old one-off `SubagentStop` cleanup.

**tmux launch scripts are owner-only and cleaned up.** The launch script carries the full agent prompt; it is now written `0600` under a `0700` directory and deleted when the tmux server is killed, so it is not readable by other local users or left on disk after the session ends.

## Tests

- `./gradlew desktopTest` (local, macOS)
- New: `OwnerOnlyFilesTest`, launch-script permission/cleanup coverage in `TmuxAndyTest`, focus-vs-mount coverage in `AgentChatReadStateTest`, and `AgentStatusTrackerTest` cases for malformed-settings preservation, legacy hook removal, and `ANDY_TASK_ID` precedence over the pointer file.
- Deflaked `AgentChatReadStateTest`: the one-time legacy-transcript migration runs off-thread during service init and archives + clears unread on scrollback-less chats, which raced the test body. The harness now seeds that migration as already done. Reproduced the flake (1 of 3 runs failing) and confirmed 5/5 clean after the fix.

## Risks

- `chat.set_app_focus` is a new MCP tool; the client tolerates its absence, but a mixed old-app / new-daemon pair falls back to the previous behaviour rather than erroring.
- The broader "strip Andy hooks from all events" pass will remove Andy entries from events Andy no longer writes. That is the intent, but it means a downgrade would need a reinstall to restore older wiring.
- The tmux launch-script directory is now wiped on `killServer`; anything that expected those scripts to persist past server shutdown would no longer find them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DBYvLrCHzJyCW27L2hiKh
