### PR TITLE
Fix scrollback replay paint and tmux copy-mode lifecycle

### DIFF
--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
@@ -213,7 +213,7 @@ class AgentTerminalManager(
             is TmuxAttachBackend -> runCatching { handle.session.releaseViewer() }
             else -> Unit
         }
-        if (!isViewerAlive(taskId)) {
+        if (!isAlive(taskId)) {
             pauseBackgroundPolling(handle)
         }
         bumpSessionsRevision()
@@ -231,7 +231,7 @@ class AgentTerminalManager(
                 releaseViewerOnly(id)
             } else {
                 handle.foreground.set(false)
-                if (!isViewerAlive(id)) {
+                if (!isAlive(id)) {
                     pauseBackgroundPolling(handle)
                 }
             }
@@ -249,7 +249,7 @@ class AgentTerminalManager(
                 releaseViewerOnly(taskId)
             } else {
                 handle.foreground.set(false)
-                if (!isViewerAlive(taskId)) {
+                if (!isAlive(taskId)) {
                     pauseBackgroundPolling(handle)
                 }
             }
@@ -262,7 +262,7 @@ class AgentTerminalManager(
                 releaseViewerOnly(id)
             } else {
                 handle.foreground.set(false)
-                if (!isViewerAlive(id)) {
+                if (!isAlive(id)) {
                     pauseBackgroundPolling(handle)
                 }
             }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/AgentTerminalManager.kt
@@ -222,32 +222,49 @@ class AgentTerminalManager(
     /** Mark [taskId] as the only chat receiving foreground scrape cadence. */
     fun setOnlyForeground(taskId: String) {
         handles.forEach { (id, handle) ->
-            val foreground = id == taskId
-            handle.foreground.set(foreground)
-            if (foreground && isViewerAlive(id)) {
-                resumeBackgroundPolling(handle)
-            } else if (!isViewerAlive(id)) {
-                pauseBackgroundPolling(handle)
+            if (id == taskId) {
+                handle.foreground.set(true)
+                if (isViewerAlive(id)) {
+                    resumeBackgroundPolling(handle)
+                }
+            } else if (isViewerAlive(id) && handle.session is TmuxAttachBackend) {
+                releaseViewerOnly(id)
+            } else {
+                handle.foreground.set(false)
+                if (!isViewerAlive(id)) {
+                    pauseBackgroundPolling(handle)
+                }
             }
         }
     }
 
     fun setForeground(taskId: String, foreground: Boolean) {
         handles[taskId]?.let { handle ->
-            handle.foreground.set(foreground)
-            if (foreground && isViewerAlive(taskId)) {
-                resumeBackgroundPolling(handle)
-            } else if (!isViewerAlive(taskId)) {
-                pauseBackgroundPolling(handle)
+            if (foreground) {
+                handle.foreground.set(true)
+                if (isViewerAlive(taskId)) {
+                    resumeBackgroundPolling(handle)
+                }
+            } else if (isViewerAlive(taskId) && handle.session is TmuxAttachBackend) {
+                releaseViewerOnly(taskId)
+            } else {
+                handle.foreground.set(false)
+                if (!isViewerAlive(taskId)) {
+                    pauseBackgroundPolling(handle)
+                }
             }
         }
     }
 
     fun clearForeground() {
-        handles.values.forEach { handle ->
-            handle.foreground.set(false)
-            if (!isViewerAlive(handle.taskId)) {
-                pauseBackgroundPolling(handle)
+        handles.forEach { (id, handle) ->
+            if (isViewerAlive(id) && handle.session is TmuxAttachBackend) {
+                releaseViewerOnly(id)
+            } else {
+                handle.foreground.set(false)
+                if (!isViewerAlive(id)) {
+                    pauseBackgroundPolling(handle)
+                }
             }
         }
     }
@@ -878,7 +895,13 @@ class AgentTerminalManager(
      */
     private fun liveOrReattachHandle(taskId: String): Handle? {
         val existing = get(taskId) ?: return null
-        if (isViewerAlive(taskId)) return existing
+        if (isViewerAlive(taskId)) {
+            existing.foreground.set(true)
+            if (existing.session is TmuxAttachBackend) {
+                TmuxAndy.exitCopyModeIfActive(taskId)
+            }
+            return existing
+        }
         val session = existing.session
         if (session is TmuxAttachBackend && TmuxAndy.hasSession(taskId)) {
             existing.foreground.set(true)

--- a/src/desktopMain/kotlin/app/andy/terminal/AndyTerminalView.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/AndyTerminalView.kt
@@ -5,6 +5,17 @@ import ai.rever.bossterm.compose.PlatformServices
 import ai.rever.bossterm.compose.getPlatformServices
 import ai.rever.bossterm.compose.settings.TerminalSettingsOverride
 import app.andy.model.TerminalAppearanceSnapshot
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 /**
  * Opaque handle the Compose UI mounts via [EmbeddableTerminal].
@@ -30,6 +41,9 @@ data class AndyTerminalView(
      * state, not view identity.
      */
     internal var frameLimiter: TerminalFrameLimiter? = null
+
+    /** Settles the replay frame gate / paint kicks; cancelled by [disposeScrollbackReplayView]. */
+    internal var replaySettleJob: Job? = null
 }
 
 fun BossTermBackend.toTerminalView(): AndyTerminalView = AndyTerminalView(
@@ -52,13 +66,23 @@ fun createScrollbackReplayView(
 ): AndyTerminalView {
     val display = content.trimEnd().ifBlank { "(no readable history for this chat)" }
     val columns = if (cols > 0) cols else scrollbackReplayColumns(display)
+    val replayRows = rows.coerceAtLeast(1)
     val payload = (display.replace("\r\n", "\n").replace("\n", "\r\n") + "\u001b[0m\u001b[?25l")
     val state = EmbeddableTerminalState()
     val settings = appearance.toBossTermSettings(
         scrollbackLines = BossTermBackend.DEFAULT_MAX_HISTORY,
         agentCliMode = true,
     )
-    val services = ReplayPlatformServices(payload)
+    // Hold the one-shot feed until the emulator is resized to [columns]. Feeding at BossTerm's
+    // default grid hard-wraps every boxed TUI line and is what makes history look shattered.
+    val feedGate = CompletableDeferred<Unit>()
+    val payloadDelivered = AtomicBoolean(false)
+    val replaySettled = AtomicBoolean(false)
+    val services = ReplayPlatformServices(
+        payload = payload,
+        feedGate = feedGate,
+        onPayloadDelivered = { payloadDelivered.set(true) },
+    )
     BossTermAccess.initialize(
         state = state,
         settings = settings,
@@ -69,6 +93,12 @@ fun createScrollbackReplayView(
         onExit = null,
         platformServices = services,
     )
+    // initializeSession spawns on a BossTerm coroutine; wait briefly so resize/display exist.
+    awaitReplayTab(state, timeoutMs = 5_000)
+    BossTermAccess.resizeTerminal(state, columns, replayRows)
+    feedGate.complete(Unit)
+
+    val settleScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     return AndyTerminalView(
         state = state,
         settingsOverride = appearance.toBossTermSettingsOverride(
@@ -84,15 +114,94 @@ fun createScrollbackReplayView(
     ).also { view ->
         // The whole transcript is replayed as one payload and parsed character by character,
         // so an ungated replay asks for thousands of full-grid renders to reach a screen that
-        // never changes again. Cap it like a live session.
-        BossTermAccess.display(state)?.let { display ->
-            view.frameLimiter = TerminalFrameLimiter(display).also { it.start() }
+        // never changes again. Cap it while feeding, then leave the gate open and force a paint —
+        // cursor is hidden for replay, so caret-blink cannot recover a stuck blank frame.
+        val termDisplay = BossTermAccess.display(state)
+        if (termDisplay != null) {
+            val limiter = TerminalFrameLimiter(
+                display = termDisplay,
+                churningProvider = { !replaySettled.get() },
+            ).also { it.start() }
+            view.frameLimiter = limiter
+            view.replaySettleJob = settleScope.launch {
+                settleScrollbackReplayPaint(
+                    state = state,
+                    payloadDelivered = payloadDelivered,
+                    replaySettled = replaySettled,
+                    limiter = limiter,
+                    payloadChars = payload.length,
+                )
+            }.also { job ->
+                job.invokeOnCompletion { settleScope.cancel() }
+            }
+        } else {
+            settleScope.cancel()
         }
     }
 }
 
 fun disposeScrollbackReplayView(view: AndyTerminalView) {
+    runCatching { view.replaySettleJob?.cancel() }
+    view.replaySettleJob = null
     runCatching { view.frameLimiter?.close() }
     view.frameLimiter = null
     runCatching { view.state.dispose() }
+}
+
+/**
+ * Kick the history surface until a committed frame can capture real buffer content.
+ * Safe to call repeatedly; no-op when the session has already been disposed.
+ */
+internal fun kickScrollbackReplayPaint(view: AndyTerminalView) {
+    if (view.state.isDisposed) return
+    view.frameLimiter?.flushNow()
+    BossTermAccess.requestRedraw(view.state)
+}
+
+private suspend fun settleScrollbackReplayPaint(
+    state: EmbeddableTerminalState,
+    payloadDelivered: AtomicBoolean,
+    replaySettled: AtomicBoolean,
+    limiter: TerminalFrameLimiter,
+    payloadChars: Int,
+) {
+    val deliverDeadline = System.currentTimeMillis() + 10_000L
+    while (!payloadDelivered.get() && System.currentTimeMillis() < deliverDeadline) {
+        if (!coroutineContext.isActive) return
+        delay(10)
+    }
+    // Emulation of the one-shot chunk is async; budget scales with transcript size.
+    val parseBudgetMs = ((payloadChars / 40_000L) * 100L + 150L).coerceIn(150L, 8_000L)
+    var last = ""
+    var stableHits = 0
+    val parseDeadline = System.currentTimeMillis() + parseBudgetMs
+    while (System.currentTimeMillis() < parseDeadline) {
+        if (!coroutineContext.isActive) return
+        delay(40)
+        val text = BossTermAccess.screenText(state)
+        if (text.isNotBlank() && text == last) {
+            stableHits++
+            if (stableHits >= 2) break
+        } else {
+            stableHits = 0
+            last = text
+        }
+    }
+    replaySettled.set(true)
+    limiter.flushNow()
+    BossTermAccess.requestRedraw(state)
+    // Compose may mount after settle; a few ungated kicks cover the blank-until-resize race.
+    repeat(4) {
+        if (!coroutineContext.isActive) return
+        delay(120)
+        limiter.flushNow()
+        BossTermAccess.requestRedraw(state)
+    }
+}
+
+private fun awaitReplayTab(state: EmbeddableTerminalState, timeoutMs: Long) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (BossTermAccess.tab(state) == null && System.currentTimeMillis() < deadline) {
+        Thread.sleep(25)
+    }
 }

--- a/src/desktopMain/kotlin/app/andy/terminal/BossTermAccess.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/BossTermAccess.kt
@@ -79,14 +79,25 @@ internal object BossTermAccess {
     }
 
     fun resize(state: EmbeddableTerminalState, cols: Int, rows: Int, scope: CoroutineScope) {
-        val tab = tab(state) ?: return
-        runCatching {
-            tab.terminal.resize(TermSize(cols, rows), RequestOrigin.User)
-        }
-        val handle = tab.processHandle.value ?: return
+        resizeTerminal(state, cols, rows)
+        val handle = tab(state)?.processHandle?.value ?: return
         scope.launch(Dispatchers.IO) {
             runCatching { handle.resize(cols, rows) }
         }
+    }
+
+    /** Resize the emulator grid only (no PTY notify). Used before scrollback replay feed. */
+    fun resizeTerminal(state: EmbeddableTerminalState, cols: Int, rows: Int) {
+        val tab = tab(state) ?: return
+        if (cols <= 0 || rows <= 0) return
+        runCatching {
+            tab.terminal.resize(TermSize(cols, rows), RequestOrigin.User)
+        }
+    }
+
+    /** Force a Compose invalidation; used after history replay settles under the frame gate. */
+    fun requestRedraw(state: EmbeddableTerminalState) {
+        runCatching { display(state)?.requestRedraw() }
     }
 
     fun isProcessAlive(state: EmbeddableTerminalState): Boolean {

--- a/src/desktopMain/kotlin/app/andy/terminal/BossTermAppearance.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/BossTermAppearance.kt
@@ -40,9 +40,6 @@ fun TerminalAppearanceSnapshot.toBossTermSettingsOverride(
         aiAssistantsEnabled = false,
         disableLineSpacingInAlternateBuffer = true,
         performanceMode = if (agentCliMode) "latency" else "balanced",
-        // A tmux attach client owns the alternate screen and its pane scrollback. Let it
-        // receive wheel events directly instead of asking BossTerm to scroll an empty outer
-        // alternate buffer or translating the wheel into cursor keys.
         enableMouseReporting = forwardMouseToApplication || !agentCliMode,
         forceActionOnMouseReporting = agentCliMode && !forwardMouseToApplication,
         // BossTerm 1.2.143 accumulates fractional deltas only on its local-history path.

--- a/src/desktopMain/kotlin/app/andy/terminal/BossTermBackend.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/BossTermBackend.kt
@@ -275,6 +275,7 @@ class BossTermBackend(
         frameLimiter = TerminalFrameLimiter(
             display = display,
             foregroundProvider = { foregroundProvider() },
+            churningProvider = { scrollbackTee.isOutputChurning(OUTPUT_CHURN_WINDOW_MS) },
         ).also { it.start() }
     }
 
@@ -297,5 +298,7 @@ class BossTermBackend(
         const val DEFAULT_MAX_HISTORY: Int = 10_000
         const val SCROLLBACK_CAPTURE_ROWS: Int = 500
         const val SCROLLBACK_BACKGROUND_CAPTURE_ROWS: Int = 80
+        /** Hold the redraw gate only while PTY output is actively arriving. */
+        private const val OUTPUT_CHURN_WINDOW_MS = 500L
     }
 }

--- a/src/desktopMain/kotlin/app/andy/terminal/BossTermPlatformServices.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/BossTermPlatformServices.kt
@@ -5,6 +5,7 @@ import ai.rever.bossterm.compose.PlatformServices
 import ai.rever.bossterm.compose.getPlatformServices
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CompletableDeferred
 
 /**
  * BossTerm [PlatformServices] that spawn Andy's exact argv (tmux attach / DirectPty),
@@ -102,17 +103,26 @@ private class TeeingProcessHandle(
 /**
  * Read-only process handle that feeds [payload] once, then stays alive until [kill]
  * so BossTerm can render scrollback replay without a real shell.
+ *
+ * [feedGate] delays the one-shot payload until the emulator has been resized to the
+ * transcript width — feeding at BossTerm's default grid hard-wraps boxed TUI lines and
+ * is the main source of "shattered" historical formatting.
  */
 internal class ReplayProcessService(
     private val payload: String,
+    private val feedGate: CompletableDeferred<Unit>? = null,
+    private val onPayloadDelivered: (() -> Unit)? = null,
 ) : PlatformServices.ProcessService {
     override suspend fun spawnProcess(
         config: PlatformServices.ProcessService.ProcessConfig,
-    ): PlatformServices.ProcessService.ProcessHandle = ReplayProcessHandle(payload)
+    ): PlatformServices.ProcessService.ProcessHandle =
+        ReplayProcessHandle(payload, feedGate, onPayloadDelivered)
 }
 
 private class ReplayProcessHandle(
     payload: String,
+    private val feedGate: CompletableDeferred<Unit>? = null,
+    private val onPayloadDelivered: (() -> Unit)? = null,
 ) : PlatformServices.ProcessService.ProcessHandle {
     private val remaining = AtomicReference(payload)
     @Volatile private var alive = true
@@ -122,8 +132,13 @@ private class ReplayProcessHandle(
 
     override suspend fun read(): String? {
         if (!alive) return null
+        feedGate?.await()
+        if (!alive) return null
         val next = remaining.getAndSet(null)
-        if (next != null) return next
+        if (next != null) {
+            onPayloadDelivered?.invoke()
+            return next
+        }
         // Park until killed so the emulator session stays Connected.
         while (alive) {
             kotlinx.coroutines.delay(250)
@@ -135,6 +150,8 @@ private class ReplayProcessHandle(
 
     override suspend fun kill() {
         alive = false
+        // Unblock a parked reader without CancellationException noise on dispose.
+        feedGate?.complete(Unit)
     }
 
     override suspend fun waitFor(): Int {
@@ -150,7 +167,9 @@ private class ReplayProcessHandle(
 
 internal class ReplayPlatformServices(
     payload: String,
+    feedGate: CompletableDeferred<Unit>? = null,
+    onPayloadDelivered: (() -> Unit)? = null,
 ) : PlatformServices by getPlatformServices() {
-    private val processService = ReplayProcessService(payload)
+    private val processService = ReplayProcessService(payload, feedGate, onPayloadDelivered)
     override fun getProcessService(): PlatformServices.ProcessService = processService
 }

--- a/src/desktopMain/kotlin/app/andy/terminal/TerminalFrameLimiter.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/TerminalFrameLimiter.kt
@@ -74,6 +74,14 @@ fun interface SynchronizedUpdateGate {
  * the gate immediately, preserving the old throttle's "sparse updates are never delayed"
  * property. The gate re-arms on the loop's next tick.
  *
+ * ### Cursor blink
+ *
+ * BossTerm's caret blink toggles a Compose `MutableState` on a timer — it does **not** call
+ * `requestRedraw()`. While the gate is closed with no pending damage, `captureStableRenderFrame`
+ * hands back the last committed bitmap and the caret appears frozen. The gate therefore stays
+ * open whenever [churningProvider] reports no recent PTY output; streaming sessions still
+ * engage the cap for the per-character storm.
+ *
  * ### Interaction with applications that drive DEC 2026 themselves
  *
  * The flag is a single boolean with no nesting count, so a CLI emitting BSU/ESU interleaves
@@ -84,6 +92,8 @@ class TerminalFrameLimiter(
     private val gate: SynchronizedUpdateGate,
     /** Backgrounded sessions render to nothing; they only need the request churn suppressed. */
     private val foregroundProvider: () -> Boolean = { true },
+    /** When false the gate stays open so BossTerm's caret-blink Compose state can repaint. */
+    private val churningProvider: () -> Boolean = { true },
     private val foregroundIntervalMillis: Long = defaultForegroundIntervalMillis(),
     private val backgroundIntervalMillis: Long = DEFAULT_BACKGROUND_INTERVAL_MS,
     /** How long the gate stays open so the flushed frame can actually compose. */
@@ -92,7 +102,12 @@ class TerminalFrameLimiter(
     constructor(
         display: ComposeTerminalDisplay,
         foregroundProvider: () -> Boolean = { true },
-    ) : this(SynchronizedUpdateGate(display::setSynchronizedUpdate), foregroundProvider)
+        churningProvider: () -> Boolean = { true },
+    ) : this(
+        SynchronizedUpdateGate(display::setSynchronizedUpdate),
+        foregroundProvider,
+        churningProvider,
+    )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -111,6 +126,12 @@ class TerminalFrameLimiter(
     internal suspend fun gateLoop() {
         while (coroutineContext.isActive) {
             val interval = if (foregroundProvider()) foregroundIntervalMillis else backgroundIntervalMillis
+            if (!churningProvider()) {
+                // Idle: caret blink is Compose-driven and never sets the pending-redraw flag.
+                gate.setSynchronizedUpdate(false)
+                delay(interval)
+                continue
+            }
             gate.setSynchronizedUpdate(true)
             // Absorb the per-character storm. Nothing invalidates Compose for this whole span.
             delay((interval - renderWindowMillis).coerceAtLeast(1L))

--- a/src/desktopMain/kotlin/app/andy/terminal/TerminalScrollback.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/TerminalScrollback.kt
@@ -61,6 +61,10 @@ class ScrollbackAnsiTee(
     @Volatile
     private var bytesSeen: Long = 0L
 
+    /** Wall clock of the most recent [append]; `0` until the first PTY chunk arrives. */
+    @Volatile
+    private var lastOutputAtMillis: Long = 0L
+
     /** Absolute character offsets of the retained raw-PTY window. */
     private var retainedStartOffset: Long = 0L
 
@@ -79,6 +83,14 @@ class ScrollbackAnsiTee(
     /** Monotonic counter of bytes read from the host. See [bytesSeen]. */
     fun outputGeneration(): Long = bytesSeen
 
+    fun lastOutputAtMillis(): Long = lastOutputAtMillis
+
+    /** True when a PTY chunk arrived within [windowMillis] (never true before the first byte). */
+    fun isOutputChurning(windowMillis: Long): Boolean {
+        val last = lastOutputAtMillis
+        return last != 0L && System.currentTimeMillis() - last < windowMillis
+    }
+
     fun append(bytes: ByteArray, offset: Int, length: Int) {
         if (length <= 0) return
         synchronized(lock) {
@@ -89,6 +101,7 @@ class ScrollbackAnsiTee(
                 trimToCap()
             }
             bytesSeen += length
+            lastOutputAtMillis = System.currentTimeMillis()
         }
     }
 

--- a/src/desktopMain/kotlin/app/andy/terminal/TmuxAndy.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/TmuxAndy.kt
@@ -53,15 +53,14 @@ object TmuxAndy {
         "set-option", "-g", "exit-empty", "off", ";",
         // Interactive agent TUIs need a real terminal type (Cursor hosts often use TERM=dumb).
         "set-option", "-g", "default-terminal", "xterm-256color", ";",
-        // tmux owns durable pane history while the attached client occupies BossTerm's
-        // alternate buffer. Mouse wheel events enter copy mode and scroll that history.
+        // Agent TUIs use the alternate screen — BossTerm has no line scrollback for them.
+        // Wheel-up enters tmux copy mode so the user can browse pane history. Andy exits
+        // copy mode when the viewer detaches so chat switches always reopen on the live screen.
         "set-option", "-g", "mouse", "on", ";",
         "set-option", "-g", "history-limit", "10000", ";",
         "set-option", "-g", "status", "off", ";",
         // tmux's default binding forwards WheelUpPane whenever alternate_on is true,
         // which hands the gesture to agent TUIs instead of revealing pane history.
-        // Enter copy mode on the first upward wheel; copy-mode's native wheel bindings
-        // preserve position as output arrives and `-e` exits when scrolling to the bottom.
         "bind-key", "-n", "WheelUpPane", "if-shell", "-F", "#{pane_in_mode}",
         "send-keys -M", "copy-mode -e", ";",
         // CLI attach has no chrome — prefix-free ways back to `andy tui`.
@@ -396,6 +395,30 @@ object TmuxAndy {
 
     /** Liveness + title + pane text from a single tmux invocation. See [probePane]. */
     data class PaneProbe(val alive: Boolean, val title: String, val content: String)
+
+    /** True when the pane is in copy mode (user scrolled into tmux history). */
+    fun isPaneInCopyMode(taskId: String): Boolean {
+        val result = run(
+            listOf(
+                tmuxBinary(), "-L", SERVER,
+                "display-message", "-p", "-t", sessionName(taskId), "#{pane_in_mode}",
+            ),
+            checkExit = false,
+        )
+        return result.exitCode == 0 && result.stdout.trim() == "1"
+    }
+
+    /** Return the live alternate-screen view after wheel scroll or a detached reattach. */
+    fun exitCopyModeIfActive(taskId: String) {
+        if (!isPaneInCopyMode(taskId)) return
+        run(
+            listOf(
+                tmuxBinary(), "-L", SERVER,
+                "copy-mode", "-q", "-t", sessionName(taskId),
+            ),
+            checkExit = false,
+        )
+    }
 
     /**
      * One-process pane probe: session liveness, pane title and pane text together.

--- a/src/desktopMain/kotlin/app/andy/terminal/TmuxAttachBackend.kt
+++ b/src/desktopMain/kotlin/app/andy/terminal/TmuxAttachBackend.kt
@@ -99,6 +99,7 @@ class TmuxAttachBackend(
             "tmux session ${TmuxAndy.sessionName(sessionId)} does not exist; create it before attaching"
         }
         TmuxAndy.ensureServerConfigured()
+        TmuxAndy.exitCopyModeIfActive(sessionId)
         val attachCwd = resolveTerminalWorkingDirectory(cwd)
         inner.start(TmuxAndy.attachArgv(sessionId), cwd = attachCwd, env = emptyMap())
         observeViewer(inner)
@@ -117,6 +118,11 @@ class TmuxAttachBackend(
 
     override fun bufferSnapshot(): String {
         if (inner.isAlive) {
+            if (TmuxAndy.isPaneInCopyMode(sessionId)) {
+                val probe = TmuxAndy.probePane(sessionId, historyLines = 0)
+                markAlive(probe.alive)
+                if (probe.alive) return probe.content.trimEnd()
+            }
             val snap = inner.bufferSnapshot().trimEnd()
             if (snap.isNotBlank()) {
                 markAlive(true)
@@ -133,6 +139,7 @@ class TmuxAttachBackend(
     fun releaseViewer() {
         viewerJob?.cancel()
         viewerJob = null
+        TmuxAndy.exitCopyModeIfActive(sessionId)
         inner.close()
     }
 
@@ -143,6 +150,7 @@ class TmuxAttachBackend(
             "tmux session ${TmuxAndy.sessionName(sessionId)} does not exist; create it before reattaching"
         }
         TmuxAndy.ensureServerConfigured()
+        TmuxAndy.exitCopyModeIfActive(sessionId)
         runCatching { inner.close() }
         inner = newInner(appearance)
         inner.start(TmuxAndy.attachArgv(sessionId), cwd = resolveTerminalWorkingDirectory(null), env = emptyMap())
@@ -179,7 +187,11 @@ class TmuxAttachBackend(
             launch {
                 viewer.bufferSnapshots.collect { snap ->
                     markAlive(true)
-                    val trimmed = snap.trimEnd()
+                    val trimmed = if (TmuxAndy.isPaneInCopyMode(sessionId)) {
+                        TmuxAndy.probePane(sessionId, historyLines = 0).content.trimEnd()
+                    } else {
+                        snap.trimEnd()
+                    }
                     if (trimmed != lastSnapshot) {
                         lastSnapshot = trimmed
                         _bufferSnapshots.emit(trimmed)

--- a/src/desktopMain/kotlin/app/andy/ui/agents/AgentTerminalSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ui/agents/AgentTerminalSurface.desktop.kt
@@ -103,8 +103,15 @@ actual fun AgentTerminalSurface(
             if (agentRuns?.hasScrollback(taskId) != true) return
             // Replay init waits briefly for the BossTerm tab and resizes before feeding;
             // keep that off Main so the UI thread is not parked on Thread.sleep.
-            historyTerminal = withContext(Dispatchers.Default) {
-                agentRuns.openScrollbackReplay(taskId)
+            var created: AndyTerminalView? = null
+            try {
+                val replay = withContext(Dispatchers.Default) {
+                    agentRuns.openScrollbackReplay(taskId).also { created = it }
+                }
+                historyTerminal = replay
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                created?.let(::disposeScrollbackReplayView)
+                throw e
             }
         }
 

--- a/src/desktopMain/kotlin/app/andy/ui/agents/AgentTerminalSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ui/agents/AgentTerminalSurface.desktop.kt
@@ -42,13 +42,16 @@ import app.andy.terminal.AndyTerminalView
 import app.andy.terminal.BossTermAccess
 import app.andy.terminal.TmuxWheelInput
 import app.andy.terminal.disposeScrollbackReplayView
+import app.andy.terminal.kickScrollbackReplayPaint
 import app.andy.terminal.panelBackgroundArgb
 import app.andy.ui.theme.AndyRadius
 import app.andy.ui.theme.Cyan
 import app.andy.ui.theme.MonoFont
 import app.andy.ui.theme.TextSecondary
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
 
 private val NoSessionsRevision = MutableStateFlow(0L)
 private val NoWorkspace = MutableStateFlow(WorkspaceState())
@@ -98,7 +101,11 @@ actual fun AgentTerminalSurface(
         suspend fun openHistoryIfAvailable() {
             if (historyTerminal != null) return
             if (agentRuns?.hasScrollback(taskId) != true) return
-            historyTerminal = agentRuns.openScrollbackReplay(taskId)
+            // Replay init waits briefly for the BossTerm tab and resizes before feeding;
+            // keep that off Main so the UI thread is not parked on Thread.sleep.
+            historyTerminal = withContext(Dispatchers.Default) {
+                agentRuns.openScrollbackReplay(taskId)
+            }
         }
 
         if (!effectiveSessionActive) {
@@ -143,9 +150,11 @@ actual fun AgentTerminalSurface(
     }
 
     val historyToDispose = rememberUpdatedState(historyTerminal)
+    val releaseViewerOnDispose = rememberUpdatedState(releaseViewer)
     DisposableEffect(taskId) {
         onDispose {
             historyToDispose.value?.let(::disposeScrollbackReplayView)
+            releaseViewerOnDispose.value?.invoke(taskId)
         }
     }
     val displayTerminal = liveTerminal ?: historyTerminal
@@ -156,6 +165,17 @@ actual fun AgentTerminalSurface(
         }
     }
     var imageDragActive by remember(taskId) { mutableStateOf(false) }
+
+    // History feeds before EmbeddableTerminal mounts; without an ungated redraw after layout
+    // ProperTerminal can keep the blank first committed bitmap until the window is resized.
+    LaunchedEffect(historyTerminal?.state, liveTerminal?.state) {
+        val history = historyTerminal ?: return@LaunchedEffect
+        if (liveTerminal != null) return@LaunchedEffect
+        repeat(8) {
+            kickScrollbackReplayPaint(history)
+            delay(100)
+        }
+    }
 
     LaunchedEffect(taskId, effectiveSessionActive) {
         if (!effectiveSessionActive) imageDragActive = false

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentTerminalSessionLifecycleTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentTerminalSessionLifecycleTest.kt
@@ -469,6 +469,50 @@ class AgentTerminalSessionLifecycleTest {
         }
     }
 
+    @Test
+    fun setOnlyForegroundReleasesBackgroundViewerAndExitsCopyMode() = runBlocking {
+        if (!TmuxAndy.isAvailable()) {
+            println("SKIP: tmux not installed")
+            return@runBlocking
+        }
+        val dir = tempDir()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val foregroundId = "foreground-chat"
+        val backgroundId = "background-chat"
+        try {
+            val manager = AgentTerminalManager(
+                scope = scope,
+                scrollbackFile = { id -> File(dir, "$id/scrollback.ansi") },
+                mode = AgentTerminalMode.TmuxWithAttach,
+            )
+            manager.start(task(foregroundId, dir), longRunningArgv(), emptyMap())
+            manager.start(task(backgroundId, dir), longRunningArgv(), emptyMap())
+            manager.attachExisting(foregroundId, cwd = dir.absolutePath)
+            manager.attachExisting(backgroundId, cwd = dir.absolutePath)
+            assertTrue(manager.isViewerAlive(foregroundId))
+            assertTrue(manager.isViewerAlive(backgroundId))
+
+            val enterCopyMode = ProcessBuilder(
+                TmuxAndy.tmuxBinary(), "-L", TmuxAndy.SERVER,
+                "copy-mode", "-e", "-t", TmuxAndy.sessionName(backgroundId),
+            ).redirectErrorStream(true).start()
+            assertTrue(enterCopyMode.waitFor(5, java.util.concurrent.TimeUnit.SECONDS))
+            assertEquals(0, enterCopyMode.exitValue())
+            assertTrue(TmuxAndy.isPaneInCopyMode(backgroundId))
+
+            manager.setOnlyForeground(foregroundId)
+
+            assertTrue(manager.isViewerAlive(foregroundId), "foreground viewer should stay mounted")
+            assertFalse(manager.isViewerAlive(backgroundId), "background viewer should detach")
+            assertFalse(TmuxAndy.isPaneInCopyMode(backgroundId), "background copy mode should exit on detach")
+        } finally {
+            runCatching { TmuxAndy.killSession(foregroundId) }
+            runCatching { TmuxAndy.killSession(backgroundId) }
+            scope.cancel()
+            dir.deleteRecursively()
+        }
+    }
+
     /** Clients tmux itself reports for the session — orphaned viewers show up here. */
     private fun tmuxClientCount(taskId: String): Int {
         val process = ProcessBuilder(

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentTerminalSessionLifecycleTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentTerminalSessionLifecycleTest.kt
@@ -505,9 +505,40 @@ class AgentTerminalSessionLifecycleTest {
             assertTrue(manager.isViewerAlive(foregroundId), "foreground viewer should stay mounted")
             assertFalse(manager.isViewerAlive(backgroundId), "background viewer should detach")
             assertFalse(TmuxAndy.isPaneInCopyMode(backgroundId), "background copy mode should exit on detach")
+            assertTrue(manager.isAlive(backgroundId), "background tmux session should keep running")
         } finally {
             runCatching { TmuxAndy.killSession(foregroundId) }
             runCatching { TmuxAndy.killSession(backgroundId) }
+            scope.cancel()
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun releaseViewerOnlyKeepsBackgroundPollingForLiveSession() = runBlocking {
+        if (!TmuxAndy.isAvailable()) {
+            println("SKIP: tmux not installed")
+            return@runBlocking
+        }
+        val dir = tempDir()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val taskId = "release-polling"
+        try {
+            val manager = AgentTerminalManager(
+                scope = scope,
+                scrollbackFile = { id -> File(dir, "$id/scrollback.ansi") },
+                mode = AgentTerminalMode.TmuxWithAttach,
+            )
+            manager.start(task(taskId, dir), longRunningArgv(), emptyMap())
+            manager.attachExisting(taskId, cwd = dir.absolutePath)
+            assertTrue(manager.isViewerAlive(taskId))
+
+            manager.releaseViewerOnly(taskId)
+
+            assertFalse(manager.isViewerAlive(taskId), "viewer should detach")
+            assertTrue(manager.isAlive(taskId), "live tmux session must keep background polling")
+        } finally {
+            runCatching { TmuxAndy.killSession(taskId) }
             scope.cancel()
             dir.deleteRecursively()
         }

--- a/src/desktopTest/kotlin/app/andy/terminal/BossTermScrollbackTest.kt
+++ b/src/desktopTest/kotlin/app/andy/terminal/BossTermScrollbackTest.kt
@@ -776,6 +776,35 @@ class BossTermScrollbackTest {
     }
 
     @Test
+    fun createScrollbackReplayViewResizesToTranscriptWidth() {
+        val wide = "\u001b[32m" + "x".repeat(180) + "\u001b[0m\nboxed TUI line\n"
+        val expectedCols = scrollbackReplayColumns(wide)
+        val view = createScrollbackReplayView(wide, cols = expectedCols, rows = 40)
+        try {
+            assertTrue(view.readOnly)
+            val display = BossTermAccess.display(view.state)
+            assertNotNull(display, "replay session must expose a display for paint kicks")
+            val size = display.termSize.value
+            assertEquals(expectedCols, size.columns, "replay must feed at transcript width, not default grid")
+            assertEquals(40, size.rows)
+            // Frame gate must settle open — a stuck blank committed frame is what made history
+            // stay empty until the window was resized.
+            var ungated = false
+            repeat(50) {
+                kickScrollbackReplayPaint(view)
+                Thread.sleep(40)
+                // After settle, churningProvider is false so the limiter leaves the gate open.
+                // We can't read the private gate; asserting the limiter still exists and kicks
+                // are safe is the contract the UI relies on.
+                ungated = view.frameLimiter != null
+            }
+            assertTrue(ungated)
+        } finally {
+            disposeScrollbackReplayView(view)
+        }
+    }
+
+    @Test
     fun inferScrollbackGridSizePrefersCupEnvelopeOverStaleSmallMarker() {
         val raw = buildString {
             append(scrollbackLayoutMarker(columns = 120, rows = 32))

--- a/src/desktopTest/kotlin/app/andy/terminal/TerminalFrameLimiterTest.kt
+++ b/src/desktopTest/kotlin/app/andy/terminal/TerminalFrameLimiterTest.kt
@@ -91,10 +91,12 @@ class TerminalFrameLimiterTest {
         gate: SynchronizedUpdateGate,
         intervalMs: Long = 25L,
         foreground: () -> Boolean = { true },
+        churning: () -> Boolean = { true },
         renderWindowMs: Long = 5L,
     ) = TerminalFrameLimiter(
         gate = gate,
         foregroundProvider = foreground,
+        churningProvider = churning,
         foregroundIntervalMillis = intervalMs,
         backgroundIntervalMillis = intervalMs * 10,
         renderWindowMillis = renderWindowMs,
@@ -231,6 +233,18 @@ class TerminalFrameLimiterTest {
         assertFalse(gate.isGated)
         gate.requestRedraw()
         assertEquals(1, gate.redraws.get(), "an uncapped terminal renders every request")
+    }
+
+    @Test
+    fun `the gate stays open while output is idle so caret blink can repaint`() = runBlocking {
+        val gate = FakeRedrawGate()
+        val loop = driveLoop(limiter(gate, intervalMs = 20L, churning = { false }))
+
+        Thread.sleep(150)
+        assertFalse(gate.isGated, "idle sessions must not hold the redraw gate closed")
+        assertEquals(0, gate.redraws.get(), "idle bypass should not force redraws")
+
+        loop.cancel()
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/terminal/TmuxAndyTest.kt
+++ b/src/desktopTest/kotlin/app/andy/terminal/TmuxAndyTest.kt
@@ -170,16 +170,38 @@ class TmuxAndyTest {
             val wheel = TmuxWheelInput { bytes -> BossTermAccess.writeBytes(view.state, bytes) }
             assertTrue(wheel.onScroll(-1f))
             Thread.sleep(200)
-            val paneModeAfterRawSgr = ProcessBuilder(
+            assertTrue(TmuxAndy.isPaneInCopyMode(taskId), "wheel-up should enter tmux copy mode")
+        } finally {
+            backend.close()
+            TmuxAndy.killSession(taskId)
+        }
+    }
+
+    @Test
+    fun releaseViewerExitsCopyMode() {
+        if (!TmuxAndy.isAvailable()) {
+            println("SKIP: tmux not installed")
+            return
+        }
+        val taskId = "release-copy-mode-" + UUID.randomUUID().toString().take(8)
+        val backend = TmuxAttachBackend(sessionId = taskId)
+        try {
+            TmuxAndy.newSession(
+                taskId = taskId,
+                cwd = System.getProperty("user.dir"),
+                argv = listOf("/bin/sh", "-c", "printf 'live\\n'; sleep 30"),
+            )
+            backend.attach()
+            val enterCopyMode = ProcessBuilder(
                 TmuxAndy.tmuxBinary(), "-L", TmuxAndy.SERVER,
-                "display-message", "-p", "-t", TmuxAndy.sessionName(taskId), "#{pane_in_mode}",
-            ).redirectErrorStream(true).start().let { process ->
-                val output = process.inputStream.bufferedReader().readText().trim()
-                assertTrue(process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS))
-                assertEquals(0, process.exitValue(), output)
-                output
-            }
-            assertEquals("1", paneModeAfterRawSgr, "raw SGR wheel event did not enter tmux copy mode")
+                "copy-mode", "-e", "-t", TmuxAndy.sessionName(taskId),
+            ).redirectErrorStream(true).start()
+            assertTrue(enterCopyMode.waitFor(5, java.util.concurrent.TimeUnit.SECONDS))
+            assertEquals(0, enterCopyMode.exitValue())
+            assertTrue(TmuxAndy.isPaneInCopyMode(taskId))
+
+            backend.releaseViewer()
+            assertFalse(TmuxAndy.isPaneInCopyMode(taskId), "leaving chat should exit copy mode")
         } finally {
             backend.close()
             TmuxAndy.killSession(taskId)
@@ -199,6 +221,34 @@ class TmuxAndyTest {
         writes.clear()
         assertTrue(wheel.onScroll(1f))
         assertTrue(writes.joinToString("").contains("\u001B[<65;1;1M"))
+    }
+
+    @Test
+    fun exitCopyModeIfActiveReturnsPaneToLiveView() {
+        if (!TmuxAndy.isAvailable()) {
+            println("SKIP: tmux not installed")
+            return
+        }
+        val taskId = "copy-mode-exit-" + UUID.randomUUID().toString().take(8)
+        try {
+            TmuxAndy.newSession(
+                taskId = taskId,
+                cwd = System.getProperty("user.dir"),
+                argv = listOf("/bin/sh", "-c", "printf 'live-line\\n'; sleep 30"),
+            )
+            val enterCopyMode = ProcessBuilder(
+                TmuxAndy.tmuxBinary(), "-L", TmuxAndy.SERVER,
+                "copy-mode", "-e", "-t", TmuxAndy.sessionName(taskId),
+            ).redirectErrorStream(true).start()
+            assertTrue(enterCopyMode.waitFor(5, java.util.concurrent.TimeUnit.SECONDS))
+            assertEquals(0, enterCopyMode.exitValue())
+            assertTrue(TmuxAndy.isPaneInCopyMode(taskId))
+
+            TmuxAndy.exitCopyModeIfActive(taskId)
+            assertFalse(TmuxAndy.isPaneInCopyMode(taskId))
+        } finally {
+            TmuxAndy.killSession(taskId)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Resize scrollback replay to transcript width before feeding the one-shot payload so boxed TUI history no longer hard-wraps at BossTerm's default grid.
- Keep the terminal frame gate open when PTY output is idle so caret blink and post-replay paints are not stuck on a blank committed frame.
- Exit tmux copy mode when viewers detach, chats switch foreground, or sessions reattach so chat switches always reopen on the live alternate screen.

## Test plan
- [x] `./gradlew desktopTest --tests "app.andy.terminal.TerminalFrameLimiterTest"`
- [x] `./gradlew desktopTest --tests "app.andy.terminal.BossTermScrollbackTest.createScrollbackReplayViewResizesToTranscriptWidth"`
- [x] `./gradlew desktopTest --tests "app.andy.terminal.TmuxAndyTest.exitCopyModeIfActiveReturnsPaneToLiveView"`
- [x] `./gradlew desktopTest --tests "app.andy.terminal.TmuxAndyTest.releaseViewerExitsCopyMode"`
- [ ] CI desktop tests (including tmux lifecycle integration)


Made with [Cursor](https://cursor.com)