### PR TITLE
Fix ACP replay filtering, logcat package matching, and agent transcript follow-up scroll

### DIFF
--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -151,6 +151,7 @@ internal fun AgentTaskDetail(
     var copiedHint by remember(task.id) { mutableStateOf(false) }
     var followUpImagePaths by remember(task.id) { mutableStateOf<List<String>>(emptyList()) }
     var followUpImageDragActive by remember(task.id) { mutableStateOf(false) }
+    var scrollToLatestRequest by remember(task.id) { mutableStateOf(0) }
     var goalEditorOpen by remember(task.id) { mutableStateOf(false) }
     var goalEditorText by remember(task.id) { mutableStateOf(task.goal.orEmpty()) }
     LaunchedEffect(task.id, task.isActive, task.status) {
@@ -286,6 +287,7 @@ internal fun AgentTaskDetail(
         }
         followUp = ""
         followUpImagePaths = emptyList()
+        scrollToLatestRequest++
     }
 
     LaunchedEffect(task.goal) {
@@ -420,6 +422,7 @@ internal fun AgentTaskDetail(
                     originalImagePaths = task.imagePaths,
                     restoreScrollKey = task.id,
                     scrollMemory = transcriptScrollMemory,
+                    scrollToLatestRequest = scrollToLatestRequest,
                     autoExpandActivitySections = workspaceState.agentTranscriptAutoExpandActivity,
                     collapseActivityBetweenMessages = workspaceState.agentTranscriptCollapseActivityBlocks,
                     pendingContent = task.userInputRequest?.let { request ->

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -154,6 +154,8 @@ internal fun AgentTranscript(
     onSkillOpen: (AgentSkill) -> Unit = {},
     restoreScrollKey: String? = null,
     scrollMemory: TranscriptScrollMemory? = null,
+    /** Increment to jump to the live edge (e.g. after the user sends a follow-up). */
+    scrollToLatestRequest: Int = 0,
     autoExpandActivitySections: Boolean = false,
     collapseActivityBetweenMessages: Boolean = false,
     modifier: Modifier = Modifier,
@@ -308,6 +310,12 @@ internal fun AgentTranscript(
     fun jumpToLatest() {
         stickToBottom = true
         scope.launch { listState.scrollToItem(0) }
+    }
+
+    LaunchedEffect(scrollToLatestRequest, scrollInitialized) {
+        if (scrollToLatestRequest == 0 || !scrollInitialized) return@LaunchedEffect
+        stickToBottom = true
+        listState.scrollToItem(0)
     }
 
     Box(modifier) {
@@ -557,7 +565,7 @@ private fun AgentThinkingIndicator() {
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        ThinkingOrb(size = 14.dp, color = TextSecondary, contentDescription = "Thinking")
+        ThinkingOrb(size = 14.dp, color = Cyan, contentDescription = "Thinking")
         Text("Thinking", color = TextSecondary, fontSize = 12.sp)
     }
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
@@ -137,11 +137,18 @@ object AndroidParsers {
     fun parsePidList(output: String): Set<String> =
         output.split(Regex("\\s+")).filter { it.isNotBlank() && it.all(Char::isDigit) }.toSet()
 
+    private const val PS_PROCESS_NAME_MAX_LEN = 15
+
     /** Matches a process [name] column value to an Android package (handles 15-char truncation). */
     fun processNameMatchesPackage(processName: String, packageName: String): Boolean =
-        processName == packageName ||
-            packageName.startsWith(processName) ||
-            processName.startsWith(packageName)
+        when {
+            processName == packageName -> true
+            processName.startsWith("$packageName:") -> true
+            processName.length == PS_PROCESS_NAME_MAX_LEN &&
+                packageName.length > PS_PROCESS_NAME_MAX_LEN &&
+                processName == packageName.take(PS_PROCESS_NAME_MAX_LEN) -> true
+            else -> false
+        }
 
     fun packagePidsFromPs(output: String, packageName: String): Set<String> =
         output.lineSequence()
@@ -167,9 +174,18 @@ object AndroidParsers {
                 val pid = parts[0]
                 if (!pid.all(Char::isDigit)) return@mapNotNull null
                 val args = parts[1]
-                if (args.contains(packageName)) pid else null
+                if (argsMatchPackage(args, packageName)) pid else null
             }
             .toSet()
+
+    private fun argsMatchPackage(args: String, packageName: String): Boolean {
+        val head = args.trim().split(Regex("\\s+"), limit = 2).firstOrNull().orEmpty()
+        if (head.isEmpty()) return false
+        if (processNameMatchesPackage(head, packageName)) return true
+        return head.split('/').any { segment ->
+            segment == packageName || segment.startsWith("$packageName:")
+        }
+    }
 
     fun parseSystemImages(output: String): List<SystemImage> {
         return output.lineSequence()

--- a/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/parser/AndroidParsers.kt
@@ -134,6 +134,43 @@ object AndroidParsers {
         return packageName to cleaned
     }
 
+    fun parsePidList(output: String): Set<String> =
+        output.split(Regex("\\s+")).filter { it.isNotBlank() && it.all(Char::isDigit) }.toSet()
+
+    /** Matches a process [name] column value to an Android package (handles 15-char truncation). */
+    fun processNameMatchesPackage(processName: String, packageName: String): Boolean =
+        processName == packageName ||
+            packageName.startsWith(processName) ||
+            processName.startsWith(packageName)
+
+    fun packagePidsFromPs(output: String, packageName: String): Set<String> =
+        output.lineSequence()
+            .mapNotNull { line ->
+                val trimmed = line.trim()
+                if (trimmed.isBlank() || trimmed.startsWith("PID", ignoreCase = true)) return@mapNotNull null
+                val parts = trimmed.split(Regex("\\s+"), limit = 2)
+                if (parts.size < 2) return@mapNotNull null
+                val pid = parts[0]
+                if (!pid.all(Char::isDigit)) return@mapNotNull null
+                val name = parts[1]
+                if (processNameMatchesPackage(name, packageName)) pid else null
+            }
+            .toSet()
+
+    fun packagePidsFromPsArgs(output: String, packageName: String): Set<String> =
+        output.lineSequence()
+            .mapNotNull { line ->
+                val trimmed = line.trim()
+                if (trimmed.isBlank() || trimmed.startsWith("PID", ignoreCase = true)) return@mapNotNull null
+                val parts = trimmed.split(Regex("\\s+"), limit = 2)
+                if (parts.size < 2) return@mapNotNull null
+                val pid = parts[0]
+                if (!pid.all(Char::isDigit)) return@mapNotNull null
+                val args = parts[1]
+                if (args.contains(packageName)) pid else null
+            }
+            .toSet()
+
     fun parseSystemImages(output: String): List<SystemImage> {
         return output.lineSequence()
             .filter { it.contains("system-images;android-") }
@@ -464,7 +501,9 @@ object AndroidParsers {
                         !line.startsWith("Package:") && !line.startsWith("Foreground:") && !line.startsWith("Build:")
                 }
                 ?: tag
-            val id = "dropbox|$timestampText|$tag"
+            val baseId = "dropbox|$timestampText|$tag"
+            val duplicateIndex = records.count { it.id == baseId || it.id.startsWith("$baseId#") }
+            val id = if (duplicateIndex == 0) baseId else "$baseId#$duplicateIndex"
             records += CrashRecord(
                 id = id,
                 kind = classifyDropboxTag(tag),

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionConfigStore.kt
@@ -27,15 +27,27 @@ class DesktopActionConfigStore(
                 ActionsConfig()
             }
         }
-        val roots = runCatching { discoveryRootsProvider() }.getOrDefault(emptyList()).distinct()
-        val discoveredProjects = roots.mapNotNull { rootPath ->
-            val rootDir = File(rootPath)
-            val repoFile = File(rootDir, ".andy/actions.toml")
-            if (!repoFile.isFile) return@mapNotNull null
-            val decoded = decode(repoFile, ConfigSource.Repo).getOrNull() ?: return@mapNotNull null
-            decoded.resolveRelativeProjectPaths(rootDir).stripRepoEnv(repoFile)
+        val discoveredFromProjects = personal.projects.mapNotNull { project ->
+            loadRepoConfig(File(project.contextDir.normalizedContextDir()))
         }
-        personal.mergeDiscoveredProjects(discoveredProjects)
+        val discoveredFromWorkspace = runCatching { discoveryRootsProvider() }
+            .getOrDefault(emptyList())
+            .map { it.normalizedContextDir() }
+            .distinct()
+            .filter { rootPath ->
+                personal.projects.none { project ->
+                    project.contextDir.normalizedContextDir() == rootPath
+                }
+            }
+            .mapNotNull { rootPath -> loadRepoConfig(File(rootPath)) }
+        personal.mergeDiscoveredProjects(discoveredFromProjects + discoveredFromWorkspace)
+    }
+
+    private fun loadRepoConfig(rootDir: File): ActionsConfig? {
+        val repoFile = File(rootDir, ".andy/actions.toml")
+        if (!repoFile.isFile) return null
+        val decoded = decode(repoFile, ConfigSource.Repo).getOrNull() ?: return null
+        return decoded.resolveRelativeProjectPaths(rootDir).stripRepoEnv(repoFile)
     }
 
     override suspend fun save(config: ActionsConfig): Unit = withContext(Dispatchers.IO) {
@@ -197,14 +209,18 @@ private fun ActionsConfig.stripRepoEnv(sourceFile: File): ActionsConfig {
     return copy(projects = cleanedProjects)
 }
 
+private fun String.normalizedContextDir(): String =
+    File(this).toPath().normalize().toFile().absolutePath
+
 private fun ActionsConfig.mergeDiscoveredProjects(
     discoveredConfigs: List<ActionsConfig>,
 ): ActionsConfig {
     val merged = projects.toMutableList()
     discoveredConfigs.forEach { discoveredConfig ->
         discoveredConfig.projects.forEach { repoProject ->
+            val repoContextDir = repoProject.contextDir.normalizedContextDir()
             val existingIndex = merged.indexOfFirst { project ->
-                project.contextDir == repoProject.contextDir || project.id == repoProject.id
+                project.contextDir.normalizedContextDir() == repoContextDir || project.id == repoProject.id
             }
             if (existingIndex < 0) {
                 merged += repoProject

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopCrashInspectorService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopCrashInspectorService.kt
@@ -135,8 +135,9 @@ class DesktopCrashInspectorService(
     }
 
     private suspend fun loadDropboxEntry(serial: String, id: String): String? {
-        val parts = id.split('|', limit = 3)
-        if (parts.size != 3) return null
+        val canonicalId = id.substringBefore('#')
+        val parts = canonicalId.split('|', limit = 3)
+        if (parts.size != 3 || parts[0] != "dropbox") return null
         val timestampText = parts[1]
         val tag = parts[2]
         val dateParts = timestampText.split(' ', limit = 2)

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopLogcatService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopLogcatService.kt
@@ -35,7 +35,8 @@ class DesktopLogcatService(
                 add(buffer)
             }
         }
-        val normalizedFilter = resolveLogcatFilter(serial, filter)
+        var resolvedFilter = resolveLogcatFilter(serial, filter)
+        var lastPidRefreshNanos = System.nanoTime()
         var process: Process? = null
         val reader = launch(Dispatchers.IO) {
             process = ProcessBuilder(command).redirectErrorStream(true).start()
@@ -45,11 +46,15 @@ class DesktopLogcatService(
                 process?.inputStream?.bufferedReader()?.useLines { lines ->
                     for (line in lines) {
                         if (!isActive) break
+                        val now = System.nanoTime()
+                        if (resolvedFilter.packageName != null && now - lastPidRefreshNanos > 2_000_000_000L) {
+                            resolvedFilter = resolveLogcatFilter(serial, filter)
+                            lastPidRefreshNanos = now
+                        }
                         val entry = AndroidParsers.parseLogcatLine(line)
-                        if (entry != null && matchesLogcatFilter(entry, normalizedFilter)) {
+                        if (entry != null && matchesLogcatFilter(entry, resolvedFilter)) {
                             batch += entry
                         }
-                        val now = System.nanoTime()
                         if (batch.size >= 80 || (batch.isNotEmpty() && now - lastFlush > 80_000_000L)) {
                             send(batch.toList())
                             batch.clear()
@@ -88,21 +93,44 @@ class DesktopLogcatService(
         val (packageName, search) = AndroidParsers.extractPackageFilter(filter.search)
         val explicitPackage = filter.packageName ?: packageName
         val packagePids = explicitPackage?.takeIf { it.isNotBlank() }?.let { name ->
-            devices.shell(serial, listOf("pidof", name)).stdout
-                .split(Regex("\\s+"))
-                .filter { it.isNotBlank() }
-                .toSet()
+            resolvePackagePids(serial, name)
         }.orEmpty()
         return ResolvedLogcatFilter(search = search, levels = filter.levels, packageName = explicitPackage, packagePids = packagePids)
     }
 
+    private suspend fun resolvePackagePids(serial: String, packageName: String): Set<String> {
+        val fromPidof = AndroidParsers.parsePidList(
+            devices.shell(serial, listOf("pidof", packageName)).stdout,
+        )
+        if (fromPidof.isNotEmpty()) return fromPidof
+
+        val fromPs = AndroidParsers.packagePidsFromPs(
+            devices.shell(serial, listOf("ps", "-A", "-o", "PID,NAME")).stdout,
+            packageName,
+        )
+        if (fromPs.isNotEmpty()) return fromPs
+
+        return AndroidParsers.packagePidsFromPsArgs(
+            devices.shell(serial, listOf("ps", "-A", "-o", "PID,ARGS")).stdout,
+            packageName,
+        )
+    }
+
     private fun matchesLogcatFilter(entry: LogcatEntry, filter: ResolvedLogcatFilter): Boolean {
         if (entry.level !in filter.levels) return false
-        if (filter.packageName != null && entry.pid !in filter.packagePids) return false
+        if (filter.packageName != null) {
+            val pidMatch = entry.pid != null && entry.pid in filter.packagePids
+            val textMatch = logEntryMentionsPackage(entry, filter.packageName)
+            if (!pidMatch && !textMatch) return false
+        }
         return filter.search.isBlank() ||
             entry.message.contains(filter.search, true) ||
             entry.tag.contains(filter.search, true)
     }
+
+    private fun logEntryMentionsPackage(entry: LogcatEntry, packageName: String): Boolean =
+        entry.tag.contains(packageName, ignoreCase = true) ||
+            entry.message.contains(packageName, ignoreCase = true)
 
     private data class ResolvedLogcatFilter(
         val search: String,

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -62,7 +62,8 @@ import app.andy.desktop.service.agents.acp.AgentAcpManager
 import app.andy.desktop.service.agents.acp.AcpRegistry
 import app.andy.desktop.service.agents.acp.AcpEventMapper
 import app.andy.desktop.service.agents.acp.AcpTranscriptStore
-import app.andy.desktop.service.agents.acp.shouldIgnoreAcpProviderHistoryReplay
+import app.andy.desktop.service.agents.acp.AcpReplayFilterResult
+import app.andy.desktop.service.agents.acp.filterAcpProviderHistoryReplay
 import app.andy.desktop.service.agents.acp.NodeRuntimeLocator
 import app.andy.desktop.service.agents.acp.PendingAcpPermission
 import app.andy.model.TerminalAppearanceSnapshot
@@ -4052,11 +4053,17 @@ class DesktopAgentRunService(
             events
         } else {
             events.fold(emptyList<AgentEvent>() to flow.value) { (acceptedEvents, acc), event ->
-                if (shouldIgnoreAcpProviderHistoryReplay(acc, event, replayScratch!!)) {
-                    acceptedEvents to acc
-                } else {
-                    val nextAcc = mergeAcpTranscriptEvent(acc, event)
-                    (acceptedEvents + event) to nextAcc
+                when (val decision = filterAcpProviderHistoryReplay(acc, event, replayScratch!!)) {
+                    AcpReplayFilterResult.Ignore -> acceptedEvents to acc
+                    is AcpReplayFilterResult.Accept -> {
+                        val accepted = when (event) {
+                            is AgentEvent.AssistantText -> decision.text?.let { text -> event.copy(text = text) } ?: event
+                            is AgentEvent.Thinking -> decision.text?.let { text -> event.copy(text = text) } ?: event
+                            else -> event
+                        }
+                        val nextAcc = mergeAcpTranscriptEvent(acc, accepted)
+                        (acceptedEvents + accepted) to nextAcc
+                    }
                 }
             }.first
         }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpTranscriptReplayFilter.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpTranscriptReplayFilter.kt
@@ -2,50 +2,73 @@ package app.andy.desktop.service.agents.acp
 
 import app.andy.model.AgentEvent
 
+internal sealed class AcpReplayFilterResult {
+    data object Ignore : AcpReplayFilterResult()
+    /** [text] overrides stream chunk text when set; otherwise accept [event] unchanged. */
+    data class Accept(val text: String? = null) : AcpReplayFilterResult()
+}
+
 /**
  * Providers may replay prior turns when an ACP session is reloaded after Andy quit.
  * Andy already persisted those turns — drop echoed chunks until genuinely new text arrives.
  *
  * [scratch] accumulates ignored stream deltas so multi-chunk replays are recognized.
  */
-internal fun shouldIgnoreAcpProviderHistoryReplay(
+internal fun filterAcpProviderHistoryReplay(
     existing: List<AgentEvent>,
     event: AgentEvent,
     scratch: StringBuilder,
-): Boolean = when (event) {
-    is AgentEvent.AssistantText -> {
-        if (!event.isStreamDelta) {
-            scratch.clear()
-            return false
-        }
-        scratch.append(event.text)
-        val replaying = existingAssistantTexts(existing).any { prior ->
-            prior.startsWith(scratch.toString()) && scratch.length <= prior.length
-        }
-        if (replaying) true else {
-            scratch.clear()
-            false
-        }
-    }
-    is AgentEvent.Thinking -> {
-        if (!event.isStreamDelta) {
-            scratch.clear()
-            return false
-        }
-        scratch.append(event.text)
-        val replaying = existing.filterIsInstance<AgentEvent.Thinking>().map { it.text }.any { prior ->
-            prior.startsWith(scratch.toString()) && scratch.length <= prior.length
-        }
-        if (replaying) true else {
-            scratch.clear()
-            false
-        }
-    }
+): AcpReplayFilterResult = when (event) {
+    is AgentEvent.AssistantText -> streamReplayFilterResult(
+        priorTexts = existingAssistantTexts(existing),
+        text = event.text,
+        isStreamDelta = event.isStreamDelta,
+        scratch = scratch,
+    )
+    is AgentEvent.Thinking -> streamReplayFilterResult(
+        priorTexts = existing.filterIsInstance<AgentEvent.Thinking>().map { it.text },
+        text = event.text,
+        isStreamDelta = event.isStreamDelta,
+        scratch = scratch,
+    )
     is AgentEvent.ToolCall -> {
-        val id = event.toolCallId ?: return false
-        existing.any { (it as? AgentEvent.ToolCall)?.toolCallId == id }
+        val id = event.toolCallId
+        if (id != null && existing.any { (it as? AgentEvent.ToolCall)?.toolCallId == id }) {
+            AcpReplayFilterResult.Ignore
+        } else {
+            AcpReplayFilterResult.Accept()
+        }
     }
-    else -> false
+    else -> AcpReplayFilterResult.Accept()
+}
+
+private fun streamReplayFilterResult(
+    priorTexts: List<String>,
+    text: String,
+    isStreamDelta: Boolean,
+    scratch: StringBuilder,
+): AcpReplayFilterResult {
+    if (!isStreamDelta) {
+        scratch.clear()
+        return AcpReplayFilterResult.Accept()
+    }
+    scratch.append(text)
+    val scratchText = scratch.toString()
+    val replaying = priorTexts.any { prior ->
+        prior.startsWith(scratchText) && scratchText.length <= prior.length
+    }
+    if (replaying) return AcpReplayFilterResult.Ignore
+
+    val replayedPrefix = priorTexts
+        .filter { prior -> prior.isNotEmpty() && scratchText.startsWith(prior) }
+        .maxByOrNull { it.length }
+    val emit = replayedPrefix?.let(scratchText::removePrefix) ?: scratchText
+    scratch.clear()
+    return when {
+        emit.isEmpty() -> AcpReplayFilterResult.Ignore
+        emit == text -> AcpReplayFilterResult.Accept()
+        else -> AcpReplayFilterResult.Accept(text = emit)
+    }
 }
 
 private fun existingAssistantTexts(events: List<AgentEvent>): List<String> =

--- a/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
@@ -518,6 +518,50 @@ class AndroidParsersTest {
     }
 
     @Test
+    fun parseDropboxIndexAssignsUniqueIdsForDuplicateTimestampAndTag() {
+        val output = """
+            ========================================
+            2026-08-03 13:16:33 clockpackage (text, 100 bytes)
+            Process: com.example.clock
+            java.lang.RuntimeException: first
+            ========================================
+            ========================================
+            2026-08-03 13:16:33 clockpackage (text, 200 bytes)
+            Process: com.example.clock
+            java.lang.RuntimeException: second
+        """.trimIndent()
+
+        val parsed = AndroidParsers.parseDropboxIndex(output)
+        val ids = parsed.records.map { it.id }
+
+        assertEquals(2, parsed.records.size)
+        assertEquals(listOf("dropbox|2026-08-03 13:16:33|clockpackage", "dropbox|2026-08-03 13:16:33|clockpackage#1"), ids)
+        assertEquals(2, parsed.bodiesById.size)
+    }
+
+    @Test
+    fun packagePidsFromPsMatchesTruncatedProcessNames() {
+        val output = """
+            PID   NAME
+            1234  com.example.clo
+            5678  system_server
+        """.trimIndent()
+
+        assertEquals(setOf("1234"), AndroidParsers.packagePidsFromPs(output, "com.example.clockpackage"))
+    }
+
+    @Test
+    fun packagePidsFromPsArgsMatchesFullPackageInCommandLine() {
+        val output = """
+            PID   ARGS
+            9012  com.example.clockpackage
+            5678  system_server
+        """.trimIndent()
+
+        assertEquals(setOf("9012"), AndroidParsers.packagePidsFromPsArgs(output, "com.example.clockpackage"))
+    }
+
+    @Test
     fun parseDropboxEntryStripsChunkRuleAndTimestampHeader() {
         val output = """
             ========================================

--- a/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/parser/AndroidParsersTest.kt
@@ -562,6 +562,32 @@ class AndroidParsersTest {
     }
 
     @Test
+    fun processNameMatchingRejectsLongerSiblingPackageName() {
+        assertFalse(AndroidParsers.processNameMatchesPackage("com.example.app2", "com.example.app"))
+    }
+
+    @Test
+    fun packagePidsFromPsArgsRejectsSiblingPackageTokens() {
+        val output = """
+            PID   ARGS
+            1111  com.example.app2
+            2222  grep com.example.app
+        """.trimIndent()
+
+        assertEquals(emptySet(), AndroidParsers.packagePidsFromPsArgs(output, "com.example.app"))
+    }
+
+    @Test
+    fun packagePidsFromPsArgsMatchesPackageSubprocessToken() {
+        val output = """
+            PID   ARGS
+            3333  com.example.app:ui
+        """.trimIndent()
+
+        assertEquals(setOf("3333"), AndroidParsers.packagePidsFromPsArgs(output, "com.example.app"))
+    }
+
+    @Test
     fun parseDropboxEntryStripsChunkRuleAndTimestampHeader() {
         val output = """
             ========================================

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
@@ -294,6 +294,56 @@ class DesktopActionConfigStoreTest {
     }
 
     @Test
+    fun discoversRepoActionsFromGlobalProjectContextDir() = runBlocking {
+        val dir = createTempDirectory("andy-actions-global-context").toFile()
+        val workspace = dir.resolve("workspace").apply { mkdirs() }
+        val homeConfig = dir.resolve("home/actions.toml").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                version = 1
+                [[projects]]
+                id = "proj-basil"
+                name = "Basil"
+                contextDir = "${workspace.absolutePath}/"
+                env = { }
+                """.trimIndent() + "\n",
+            )
+        }
+        workspace.resolve(".andy/actions.toml").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                version = 1
+                [[projects]]
+                id = "basil"
+                name = "Basil"
+                contextDir = "."
+                env = { }
+                [[actions]]
+                id = "act-desktop"
+                projectId = "basil"
+                name = "Desktop"
+                icon = "run"
+                command = "./gradlew :composeApp:run"
+                cwd = ""
+                env = { }
+                """.trimIndent() + "\n",
+            )
+        }
+
+        val store = DesktopActionConfigStore(homeConfig, discoveryRootsProvider = { emptyList() })
+        val loaded = store.load()
+        val project = loaded.projects.single()
+
+        assertEquals("proj-basil", project.id)
+        assertEquals(ConfigSource.Global, project.source)
+        assertEquals(1, project.actions.size)
+        assertEquals("act-desktop", project.actions.single().id)
+        assertEquals(ConfigSource.Repo, project.actions.single().source)
+    }
+
+    @Test
     fun savesVirtualProjectWhenGlobalChildIsAdded() = runBlocking {
         val dir = createTempDirectory("andy-actions-global-child").toFile()
         val homeConfig = dir.resolve("home/actions.toml")

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionConfigStoreTest.kt
@@ -305,7 +305,7 @@ class DesktopActionConfigStoreTest {
                 [[projects]]
                 id = "proj-basil"
                 name = "Basil"
-                contextDir = "${workspace.absolutePath}/"
+                contextDir = "${workspace.absolutePath.replace("\\", "\\\\")}/"
                 env = { }
                 """.trimIndent() + "\n",
             )

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
@@ -144,32 +144,88 @@ class AcpLaneTest {
             AgentEvent.AssistantText(atMillis = 2, text = "first answer about the weather"),
         )
         val replayScratch = StringBuilder()
-        assertTrue(
-            shouldIgnoreAcpProviderHistoryReplay(
+        assertEquals(
+            AcpReplayFilterResult.Ignore,
+            filterAcpProviderHistoryReplay(
                 existing,
                 AgentEvent.AssistantText(atMillis = 3, text = "first answer", isStreamDelta = true),
                 replayScratch,
             ),
         )
-        assertTrue(
-            shouldIgnoreAcpProviderHistoryReplay(
+        assertEquals(
+            AcpReplayFilterResult.Ignore,
+            filterAcpProviderHistoryReplay(
                 existing,
                 AgentEvent.AssistantText(atMillis = 4, text = " about the weather", isStreamDelta = true),
                 replayScratch,
             ),
         )
-        assertFalse(
-            shouldIgnoreAcpProviderHistoryReplay(
+        assertEquals(
+            AcpReplayFilterResult.Accept(),
+            filterAcpProviderHistoryReplay(
                 existing,
                 AgentEvent.AssistantText(atMillis = 5, text = "brand new answer", isStreamDelta = true),
                 StringBuilder(),
             ),
         )
-        assertTrue(
-            shouldIgnoreAcpProviderHistoryReplay(
+        assertEquals(
+            AcpReplayFilterResult.Ignore,
+            filterAcpProviderHistoryReplay(
                 existing + AgentEvent.ToolCall(atMillis = 6, toolName = "read", summary = "x", toolCallId = "call-1"),
                 AgentEvent.ToolCall(atMillis = 7, toolName = "read", summary = "done", toolCallId = "call-1"),
                 StringBuilder(),
+            ),
+        )
+    }
+
+    @Test
+    fun replayFilterRecoversBufferedPrefixWhenNewThinkingDivergesFromPrior() {
+        val existing = listOf(
+            AgentEvent.Thinking(atMillis = 1, text = "reverting the old layout"),
+        )
+        val replayScratch = StringBuilder()
+        assertEquals(
+            AcpReplayFilterResult.Ignore,
+            filterAcpProviderHistoryReplay(
+                existing,
+                AgentEvent.Thinking(atMillis = 2, text = "re", isStreamDelta = true),
+                replayScratch,
+            ),
+        )
+        assertEquals(
+            AcpReplayFilterResult.Accept(text = "reverting the layout to the original"),
+            filterAcpProviderHistoryReplay(
+                existing,
+                AgentEvent.Thinking(atMillis = 3, text = "verting the layout to the original", isStreamDelta = true),
+                replayScratch,
+            ),
+        )
+    }
+
+    @Test
+    fun replayFilterEmitsOnlySuffixWhenNewAssistantTextExtendsPrior() {
+        val existing = listOf(
+            AgentEvent.AssistantText(atMillis = 1, text = "**Width** — nearly full width"),
+        )
+        val replayScratch = StringBuilder()
+        assertEquals(
+            AcpReplayFilterResult.Ignore,
+            filterAcpProviderHistoryReplay(
+                existing,
+                AgentEvent.AssistantText(atMillis = 2, text = "**Width** — nearly full width", isStreamDelta = true),
+                replayScratch,
+            ),
+        )
+        assertEquals(
+            AcpReplayFilterResult.Accept(),
+            filterAcpProviderHistoryReplay(
+                existing,
+                AgentEvent.AssistantText(
+                    atMillis = 3,
+                    text = " again (`fillMaxWidth` with 8dp padding)",
+                    isStreamDelta = true,
+                ),
+                replayScratch,
             ),
         )
     }

--- a/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
@@ -199,6 +199,51 @@ class AgentTranscriptUiTest {
         }
 
     @Test
+    fun scrollToLatestRequestJumpsToLiveEdgeAfterDetaching() =
+        runTranscriptUiTest {
+            val memory = TranscriptScrollMemory()
+            var events by mutableStateOf(
+                (0..40).map { index ->
+                    AgentEvent.UserMessage(atMillis = index.toLong(), text = "conversation row $index")
+                },
+            )
+            var scrollToLatestRequest by mutableStateOf(0)
+
+            setContent {
+                AndyTheme {
+                    AgentTranscript(
+                        events = events,
+                        isActive = true,
+                        restoreScrollKey = "follow-up",
+                        scrollMemory = memory,
+                        scrollToLatestRequest = scrollToLatestRequest,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+            waitForIdle()
+
+            onNodeWithTag("transcript-list").performMouseInput {
+                moveTo(center)
+                scroll(-12f)
+            }
+            waitForIdle()
+            assertFalse(assertNotNull(memory.get("follow-up")).stickToBottom)
+
+            runOnUiThread {
+                events = events + AgentEvent.UserMessage(atMillis = 41, text = "follow-up message")
+                scrollToLatestRequest++
+            }
+            waitForIdle()
+
+            val restored = assertNotNull(memory.get("follow-up"))
+            assertEquals(true, restored.stickToBottom)
+            assertEquals(0, restored.index)
+            assertEquals(0, restored.offset)
+            onNodeWithTag("transcript-row-UserMessage-41-41").assertIsDisplayed()
+        }
+
+    @Test
     fun pendingInputRendersOnLiveEdge() =
         runTranscriptUiTest {
             setContent {


### PR DESCRIPTION
## Summary
- Recover genuinely new ACP transcript text after replayed prefixes instead of dropping the whole stream chunk.
- Resolve logcat package filters via pidof, ps NAME, and ps ARGS fallbacks, with periodic PID refresh and text-based package matching.
- Discover repo actions from global project context dirs and normalize context paths when merging projects.
- Scroll the agent transcript to the live edge when the user sends a follow-up after scrolling away.
- Disambiguate duplicate Dropbox crash record IDs and match truncated process names in Android parsers.

## Test plan
- [x] `./gradlew desktopTest --tests AndroidParsersTest`
- [x] `./gradlew desktopTest --tests DesktopActionConfigStoreTest`
- [x] `./gradlew desktopTest --tests AcpLaneTest`
- [x] `./gradlew desktopTest --tests AgentTranscriptUiTest`


Made with [Cursor](https://cursor.com)