### PR TITLE
Add remove button for host file roots

### DIFF
--- a/src/commonMain/kotlin/app/andy/ui/hostfiles/HostFilesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/hostfiles/HostFilesScreen.kt
@@ -261,6 +261,32 @@ internal fun HostFilesScreen(
         loadPath(path)
     }
 
+    fun removeRoot(root: String) {
+        val remaining = workspaceState.hostFileRoots.filterNot { it == root }
+        onUpdateWorkspace { ws ->
+            ws.copy(
+                hostFileRoots = remaining,
+                lastHostFilePath = ws.lastHostFilePath?.takeIf { path -> resolveHostRootForPath(path, remaining) != null },
+                recentHostFiles = ws.recentHostFiles.filter { path -> resolveHostRootForPath(path, remaining) != null },
+            )
+        }
+        state.statuses.remove(root)
+        (state.expandedPaths.keys + state.treeChildren.keys)
+            .filter { hostPathStartsWith(it, root) }
+            .forEach { path ->
+                state.expandedPaths.remove(path)
+                state.treeChildren.remove(path)
+            }
+        state.tabs = state.tabs.filterNot { hostPathStartsWith(it.path, root) }
+        if (state.activePath != null && hostPathStartsWith(state.activePath!!, root)) {
+            state.activePath = state.tabs.lastOrNull()?.path
+        }
+        if (selectedRoot == root) {
+            selectedRoot = remaining.firstOrNull()
+            selectedPath = selectedRoot.orEmpty()
+        }
+    }
+
     LaunchedEffect(workspaceState.hostFileRoots) {
         workspaceState.hostFileRoots.forEach { root ->
             state.expandedPaths[root] = true
@@ -356,20 +382,34 @@ internal fun HostFilesScreen(
                 }
                 workspaceState.hostFileRoots.forEach { root ->
                     val status = state.statuses[root]
-                    Column(
+                    Row(
                         Modifier.fillMaxWidth()
                             .background(if (root == selectedRoot) AndyColors.OrangeSubtle else PanelSoft, RoundedCornerShape(AndyRadius.Control))
                             .border(1.dp, if (root == selectedRoot) AndyColors.OrangeBorder.copy(alpha = 0.52f) else Border, RoundedCornerShape(AndyRadius.Control))
-                            .clickable {
+                            .padding(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(
+                            Modifier.weight(1f).clickable {
                                 selectedRoot = root
                                 selectedPath = root
                                 state.expandedPaths[root] = true
                                 loadPath(root)
-                            }
-                            .padding(8.dp),
-                    ) {
-                        Text(hostFileName(root).ifBlank { root }, color = if (root == selectedRoot) Rust else TextPrimary, fontFamily = MonoFont, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        Text(status?.message ?: "Queued", color = TextSecondary, fontFamily = MonoFont, fontSize = 10.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            },
+                        ) {
+                            Text(hostFileName(root).ifBlank { root }, color = if (root == selectedRoot) Rust else TextPrimary, fontFamily = MonoFont, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            Text(status?.message ?: "Queued", color = TextSecondary, fontFamily = MonoFont, fontSize = 10.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        }
+                        Text(
+                            "×",
+                            color = TextSecondary,
+                            fontFamily = MonoFont,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 14.sp,
+                            modifier = Modifier
+                                .clickable(onClick = { removeRoot(root) })
+                                .padding(start = 4.dp),
+                        )
                     }
                 }
                 AndyHorizontalDivider(color = Border)

--- a/src/commonMain/kotlin/app/andy/ui/hostfiles/HostFilesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/hostfiles/HostFilesScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -120,6 +121,7 @@ internal fun HostFilesScreen(
 ) {
     val scope = rememberCoroutineScope()
     val state = remember(service) { HostFilesScreenState(service) }
+    val hostFileRoots by rememberUpdatedState(workspaceState.hostFileRoots)
     var selectedRoot by remember(workspaceState.hostFileRoots, workspaceState.lastHostFilePath) {
         mutableStateOf(resolveHostRootForPath(workspaceState.lastHostFilePath, workspaceState.hostFileRoots) ?: workspaceState.hostFileRoots.firstOrNull())
     }
@@ -155,6 +157,7 @@ internal fun HostFilesScreen(
         scope.launch {
             runCatching { state.service.list(path) }
                 .onSuccess {
+                    if (resolveHostRootForPath(path, hostFileRoots) == null) return@onSuccess
                     selectedPath = path
                     state.treeChildren[path] = it
                     if (state.message.endsWith("entries")) state.message = ""
@@ -168,6 +171,7 @@ internal fun HostFilesScreen(
         scope.launch {
             runCatching { state.service.read(path) }
                 .onSuccess { doc ->
+                    if (resolveHostRootForPath(doc.path, hostFileRoots) == null) return@onSuccess
                     val next = HostEditorTab(doc.path, doc.content, doc.content, doc.modifiedMillis, doc.sizeBytes, doc.languageHint)
                     state.tabs = (state.tabs.filterNot { it.path == doc.path } + next)
                     state.activePath = doc.path
@@ -272,13 +276,13 @@ internal fun HostFilesScreen(
         }
         state.statuses.remove(root)
         (state.expandedPaths.keys + state.treeChildren.keys)
-            .filter { hostPathStartsWith(it, root) }
+            .filter { resolveHostRootForPath(it, remaining) == null }
             .forEach { path ->
                 state.expandedPaths.remove(path)
                 state.treeChildren.remove(path)
             }
-        state.tabs = state.tabs.filterNot { hostPathStartsWith(it.path, root) }
-        if (state.activePath != null && hostPathStartsWith(state.activePath!!, root)) {
+        state.tabs = state.tabs.filter { resolveHostRootForPath(it.path, remaining) != null }
+        if (state.activePath != null && resolveHostRootForPath(state.activePath, remaining) == null) {
             state.activePath = state.tabs.lastOrNull()?.path
         }
         if (selectedRoot == root) {


### PR DESCRIPTION
## Summary
- Add an × control on each host file root in the sidebar to remove it from the workspace
- Clean up related tabs, expanded paths, tree state, and persisted workspace fields when a root is removed

## Test plan
- [ ] Add a host file root and confirm the × button removes it from the sidebar
- [ ] Verify open tabs under the removed root are closed
- [ ] Verify selecting another root works after removal
- [ ] Confirm workspace state persists correctly after restart


Made with [Cursor](https://cursor.com)