### PR TITLE
Add inline find bar and FSEvents-backed host file watching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -146,6 +146,8 @@ kotlin {
                 // Win32 / shared native bindings for DHU window capture and input forwarding.
                 implementation("net.java.dev.jna:jna:5.18.1")
                 implementation("net.java.dev.jna:jna-platform:5.18.1")
+                // Recursive FSEvents-backed directory watching on macOS (replaces JDK polling WatchService).
+                implementation("io.methvin:directory-watcher:0.19.1")
 
                 // SQLDelight agent store (JVM-only module — avoids wasmJs)
                 implementation(project(":agent-store"))

--- a/src/desktopMain/kotlin/app/andy/HostCodeEditor.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/HostCodeEditor.desktop.kt
@@ -11,16 +11,31 @@ import org.fife.ui.rtextarea.RTextScrollPane
 import org.fife.ui.rtextarea.SearchContext
 import org.fife.ui.rtextarea.SearchEngine
 import java.awt.BorderLayout
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.FlowLayout
 import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.awt.event.FocusAdapter
+import java.awt.event.FocusEvent
 import java.awt.event.InputEvent
+import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
-import javax.swing.JOptionPane
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JScrollPane
+import javax.swing.JTextField
 import javax.swing.KeyStroke
 import javax.swing.SwingUtilities
+import javax.swing.border.EmptyBorder
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
+import javax.swing.plaf.basic.BasicButtonUI
 
 @Composable
 actual fun HostCodeEditor(
@@ -95,16 +110,29 @@ private class HostCodeEditorPanel(
         verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
         horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED
     }
+    private val findBar = FindBar(
+        onFind = { forward -> findInFile(forward) },
+        onClose = { hideFindBar() },
+        onQueryChanged = { findInFile(forward = true, fromTyping = true) },
+    )
 
     init {
         applyEditorSyntaxTheme(editor, scrollPane, currentSyntaxThemeId)
+        findBar.applyTheme(editorFindBarColors(currentSyntaxThemeId, editor))
+        findBar.isVisible = false
+        add(findBar, BorderLayout.NORTH)
         add(scrollPane, BorderLayout.CENTER)
-        bindShortcut("save", KeyEvent.VK_S) { onSave(currentPath, editor.text) }
-        bindShortcut("close", KeyEvent.VK_W, action = onClose)
-        bindShortcut("find", KeyEvent.VK_F) { findInFile() }
-        bindShortcut("searchAll", KeyEvent.VK_A, shift = true) { onSearchAll() }
-        bindShortcut("searchNames", KeyEvent.VK_N, shift = true) { onSearchNames() }
-        bindShortcut("searchContents", KeyEvent.VK_F, shift = true) { onSearchContents() }
+        bindShortcut(editor, "save", KeyEvent.VK_S) { onSave(currentPath, editor.text) }
+        bindShortcut(editor, "close", KeyEvent.VK_W, action = onClose)
+        bindShortcut(editor, "find", KeyEvent.VK_F) { showFindBar() }
+        bindShortcut(editor, "findNext", KeyEvent.VK_G) { findInFile(forward = true) }
+        bindShortcut(editor, "findPrev", KeyEvent.VK_G, shift = true) { findInFile(forward = false) }
+        bindShortcut(editor, "searchAll", KeyEvent.VK_A, shift = true) { onSearchAll() }
+        bindShortcut(editor, "searchNames", KeyEvent.VK_N, shift = true) { onSearchNames() }
+        bindShortcut(editor, "searchContents", KeyEvent.VK_F, shift = true) { onSearchContents() }
+        bindShortcut(findBar.queryField, "find", KeyEvent.VK_F) { showFindBar() }
+        bindShortcut(findBar.queryField, "findNext", KeyEvent.VK_G) { findInFile(forward = true) }
+        bindShortcut(findBar.queryField, "findPrev", KeyEvent.VK_G, shift = true) { findInFile(forward = false) }
     }
 
     fun updateDocument(path: String, value: String) {
@@ -116,6 +144,9 @@ private class HostCodeEditorPanel(
         editor.text = value
         editor.caretPosition = if (pathChanged) 0 else caret.coerceAtMost(value.length)
         programmaticUpdate = false
+        if (findBar.isVisible && findBar.query.isNotBlank()) {
+            findInFile(forward = true, fromTyping = true)
+        }
     }
 
     /** Moves the caret to [line] (1-based) once per (path, line) pair, so recomposition doesn't fight manual scrolling. */
@@ -167,28 +198,305 @@ private class HostCodeEditorPanel(
         if (currentSyntaxThemeId == themeId) return
         currentSyntaxThemeId = themeId
         applyEditorSyntaxTheme(editor, scrollPane, themeId)
+        findBar.applyTheme(editorFindBarColors(themeId, editor))
     }
 
-    private fun bindShortcut(name: String, keyCode: Int, shift: Boolean = false, action: () -> Unit) {
-        val baseMask = if (System.getProperty("os.name").contains("mac", ignoreCase = true)) InputEvent.META_DOWN_MASK else InputEvent.CTRL_DOWN_MASK
-        val mask = if (shift) baseMask or InputEvent.SHIFT_DOWN_MASK else baseMask
-        editor.inputMap.put(KeyStroke.getKeyStroke(keyCode, mask), name)
-        editor.actionMap.put(name, object : javax.swing.AbstractAction() {
-            override fun actionPerformed(e: java.awt.event.ActionEvent?) {
-                SwingUtilities.invokeLater(action)
-            }
-        })
+    private fun showFindBar() {
+        val selection = editor.selectedText.orEmpty()
+        if (selection.isNotBlank() && !selection.contains('\n')) {
+            findBar.query = selection
+        }
+        findBar.isVisible = true
+        revalidate()
+        SwingUtilities.invokeLater {
+            findBar.focusField()
+            if (findBar.query.isNotBlank()) findInFile(forward = true, fromTyping = true)
+        }
     }
 
-    private fun findInFile() {
-        val query = JOptionPane.showInputDialog(this, "Find", editor.selectedText.orEmpty())?.takeIf { it.isNotBlank() } ?: return
-        val context = SearchContext().apply {
-            searchFor = query
+    private fun hideFindBar() {
+        clearMarks()
+        findBar.setStatus("")
+        findBar.isVisible = false
+        revalidate()
+        SwingUtilities.invokeLater { editor.requestFocusInWindow() }
+    }
+
+    private fun findInFile(forward: Boolean, fromTyping: Boolean = false) {
+        val query = findBar.query
+        if (query.isBlank()) {
+            clearMarks()
+            findBar.setStatus("")
+            return
+        }
+        if (fromTyping) {
+            // Restart from the top so live typing always lands on the first match.
+            editor.caretPosition = 0
+        }
+        val context = SearchContext(query).apply {
             matchCase = false
             isRegularExpression = false
-            searchForward = true
+            searchForward = forward
+            searchWrap = true
             wholeWord = false
+            markAll = true
         }
-        SearchEngine.find(editor, context)
+        val result = SearchEngine.find(editor, context)
+        val marked = result.markedCount
+        findBar.setStatus(
+            when {
+                !result.wasFound() && marked == 0 -> "No results"
+                marked > 0 -> "$marked match${if (marked == 1) "" else "es"}"
+                result.wasFound() -> "1 match"
+                else -> ""
+            },
+        )
+    }
+
+    private fun clearMarks() {
+        SearchEngine.markAll(editor, SearchContext(""))
+    }
+
+    private fun bindShortcut(component: JComponent, name: String, keyCode: Int, shift: Boolean = false, action: () -> Unit) {
+        val baseMask = if (System.getProperty("os.name").contains("mac", ignoreCase = true)) {
+            InputEvent.META_DOWN_MASK
+        } else {
+            InputEvent.CTRL_DOWN_MASK
+        }
+        val mask = if (shift) baseMask or InputEvent.SHIFT_DOWN_MASK else baseMask
+        component.inputMap.put(KeyStroke.getKeyStroke(keyCode, mask), name)
+        component.actionMap.put(
+            name,
+            object : javax.swing.AbstractAction() {
+                override fun actionPerformed(e: java.awt.event.ActionEvent?) {
+                    SwingUtilities.invokeLater(action)
+                }
+            },
+        )
+    }
+}
+
+private data class FindBarColors(
+    val background: java.awt.Color,
+    val foreground: java.awt.Color,
+    val secondary: java.awt.Color,
+    val fieldBackground: java.awt.Color,
+    val fieldBorder: java.awt.Color,
+    val fieldBorderFocused: java.awt.Color,
+    val buttonHover: java.awt.Color,
+)
+
+private fun editorFindBarColors(syntaxThemeId: String, editor: RSyntaxTextArea): FindBarColors {
+    return when (EditorSyntaxTheme.fromId(syntaxThemeId)) {
+        EditorSyntaxTheme.Andy, EditorSyntaxTheme.Dark, EditorSyntaxTheme.Monokai, EditorSyntaxTheme.Druid -> FindBarColors(
+            background = java.awt.Color(0x171511),
+            foreground = java.awt.Color(0xE4DED0),
+            secondary = java.awt.Color(0x8E8779),
+            fieldBackground = java.awt.Color(0x11100D),
+            fieldBorder = java.awt.Color(0x302D27),
+            fieldBorderFocused = java.awt.Color(0xD18A4B),
+            buttonHover = java.awt.Color(0x2C2117),
+        )
+        EditorSyntaxTheme.Idea -> FindBarColors(
+            background = java.awt.Color(0x313335),
+            foreground = java.awt.Color(0xA9B7C6),
+            secondary = java.awt.Color(0x808080),
+            fieldBackground = java.awt.Color(0x2B2B2B),
+            fieldBorder = java.awt.Color(0x555555),
+            fieldBorderFocused = java.awt.Color(0x6897BB),
+            buttonHover = java.awt.Color(0x3C3F41),
+        )
+        else -> {
+            val bg = editor.background ?: java.awt.Color.WHITE
+            val fg = editor.foreground ?: java.awt.Color.BLACK
+            val border = java.awt.Color(
+                (bg.red * 0.85 + fg.red * 0.15).toInt().coerceIn(0, 255),
+                (bg.green * 0.85 + fg.green * 0.15).toInt().coerceIn(0, 255),
+                (bg.blue * 0.85 + fg.blue * 0.15).toInt().coerceIn(0, 255),
+            )
+            FindBarColors(
+                background = blend(bg, fg, 0.06f),
+                foreground = fg,
+                secondary = blend(fg, bg, 0.35f),
+                fieldBackground = bg,
+                fieldBorder = border,
+                fieldBorderFocused = editor.caretColor ?: java.awt.Color(0x3875D7),
+                buttonHover = blend(bg, fg, 0.12f),
+            )
+        }
+    }
+}
+
+private fun blend(a: java.awt.Color, b: java.awt.Color, amount: Float): java.awt.Color {
+    val t = amount.coerceIn(0f, 1f)
+    return java.awt.Color(
+        (a.red + (b.red - a.red) * t).toInt().coerceIn(0, 255),
+        (a.green + (b.green - a.green) * t).toInt().coerceIn(0, 255),
+        (a.blue + (b.blue - a.blue) * t).toInt().coerceIn(0, 255),
+    )
+}
+
+private class FindBar(
+    private val onFind: (forward: Boolean) -> Unit,
+    private val onClose: () -> Unit,
+    private val onQueryChanged: () -> Unit,
+) : JPanel(BorderLayout()) {
+    private val label = JLabel("Find")
+    val queryField = JTextField()
+    private val status = JLabel(" ")
+    private val prevButton = flatButton("↑") { onFind(false) }
+    private val nextButton = flatButton("↓") { onFind(true) }
+    private val closeButton = flatButton("✕") { onClose() }
+    private var colors = FindBarColors(
+        background = java.awt.Color(0x171511),
+        foreground = java.awt.Color(0xE4DED0),
+        secondary = java.awt.Color(0x8E8779),
+        fieldBackground = java.awt.Color(0x11100D),
+        fieldBorder = java.awt.Color(0x302D27),
+        fieldBorderFocused = java.awt.Color(0xD18A4B),
+        buttonHover = java.awt.Color(0x2C2117),
+    )
+    private var suppressQueryCallback = false
+
+    var query: String
+        get() = queryField.text.orEmpty()
+        set(value) {
+            suppressQueryCallback = true
+            queryField.text = value
+            suppressQueryCallback = false
+        }
+
+    init {
+        border = EmptyBorder(6, 10, 6, 8)
+        isOpaque = true
+        label.border = EmptyBorder(0, 0, 0, 8)
+        status.border = EmptyBorder(0, 8, 0, 4)
+        queryField.preferredSize = Dimension(220, 26)
+        queryField.minimumSize = Dimension(120, 26)
+        queryField.columns = 18
+        queryField.border = fieldBorder(focused = false)
+        queryField.addFocusListener(object : FocusAdapter() {
+            override fun focusGained(e: FocusEvent?) {
+                queryField.border = fieldBorder(focused = true)
+            }
+
+            override fun focusLost(e: FocusEvent?) {
+                queryField.border = fieldBorder(focused = false)
+            }
+        })
+        queryField.document.addDocumentListener(object : DocumentListener {
+            override fun insertUpdate(e: DocumentEvent) = changed()
+            override fun removeUpdate(e: DocumentEvent) = changed()
+            override fun changedUpdate(e: DocumentEvent) = changed()
+            private fun changed() {
+                if (!suppressQueryCallback) onQueryChanged()
+            }
+        })
+        queryField.addKeyListener(object : KeyAdapter() {
+            override fun keyPressed(e: KeyEvent) {
+                when {
+                    e.keyCode == KeyEvent.VK_ESCAPE -> {
+                        onClose()
+                        e.consume()
+                    }
+                    e.keyCode == KeyEvent.VK_ENTER && e.isShiftDown -> {
+                        onFind(false)
+                        e.consume()
+                    }
+                    e.keyCode == KeyEvent.VK_ENTER -> {
+                        onFind(true)
+                        e.consume()
+                    }
+                }
+            }
+        })
+        val controls = JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply {
+            isOpaque = false
+            add(label)
+            add(queryField)
+            add(prevButton)
+            add(nextButton)
+            add(status)
+        }
+        add(controls, BorderLayout.CENTER)
+        add(closeButton, BorderLayout.EAST)
+        preferredSize = Dimension(0, 40)
+    }
+
+    fun focusField() {
+        queryField.requestFocusInWindow()
+        queryField.selectAll()
+    }
+
+    fun setStatus(text: String) {
+        status.text = text.ifBlank { " " }
+    }
+
+    fun applyTheme(next: FindBarColors) {
+        colors = next
+        background = next.background
+        label.foreground = next.secondary
+        status.foreground = next.secondary
+        queryField.background = next.fieldBackground
+        queryField.foreground = next.foreground
+        queryField.caretColor = next.fieldBorderFocused
+        queryField.selectionColor = blend(next.fieldBorderFocused, next.fieldBackground, 0.55f)
+        queryField.selectedTextColor = next.foreground
+        queryField.border = fieldBorder(focused = queryField.hasFocus())
+        listOf(prevButton, nextButton, closeButton).forEach { button ->
+            button.foreground = next.foreground
+            button.background = next.background
+        }
+        repaint()
+    }
+
+    private fun fieldBorder(focused: Boolean) = BorderFactory.createCompoundBorder(
+        BorderFactory.createLineBorder(if (focused) colors.fieldBorderFocused else colors.fieldBorder, 1),
+        EmptyBorder(3, 8, 3, 8),
+    )
+
+    private fun flatButton(label: String, action: () -> Unit): JButton {
+        return object : JButton(label) {
+            private var hovered = false
+
+            init {
+                isOpaque = false
+                isContentAreaFilled = false
+                isBorderPainted = false
+                isFocusPainted = false
+                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                preferredSize = Dimension(28, 26)
+                font = font.deriveFont(Font.PLAIN, 12f)
+                toolTipText = when (label) {
+                    "↑" -> "Previous match"
+                    "↓" -> "Next match"
+                    else -> "Close"
+                }
+                ui = object : BasicButtonUI() {}
+                addActionListener { action() }
+                addMouseListener(object : java.awt.event.MouseAdapter() {
+                    override fun mouseEntered(e: java.awt.event.MouseEvent?) {
+                        hovered = true
+                        repaint()
+                    }
+
+                    override fun mouseExited(e: java.awt.event.MouseEvent?) {
+                        hovered = false
+                        repaint()
+                    }
+                })
+            }
+
+            override fun paintComponent(g: Graphics) {
+                val g2 = g.create() as Graphics2D
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                if (hovered || model.isArmed) {
+                    g2.color = colors.buttonHover
+                    g2.fillRoundRect(1, 1, width - 2, height - 2, 6, 6)
+                }
+                g2.dispose()
+                super.paintComponent(g)
+            }
+        }
     }
 }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopHostFileService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopHostFileService.kt
@@ -133,9 +133,10 @@ class DesktopHostFileService(
         val entries = mutableMapOf<String, IndexedFile>()
         var bytes = 0L
         rootFile.toPath().walkIndexedFiles { path ->
-            val file = path.toFile()
+            val file = path.toStableAbsolutePath().toFile()
             bytes += file.length()
-            entries[file.absolutePath] = indexFile(root, file)
+            val indexed = indexFile(root, file)
+            entries[indexed.path] = indexed
             if (entries.size % 250 == 0) {
                 status.value = HostIndexStatus(root, entries.size, bytes, indexing = true, message = "Indexing ${entries.size} files", updatedAtMillis = System.currentTimeMillis())
             }
@@ -169,9 +170,10 @@ class DesktopHostFileService(
     }
 
     private fun indexFile(root: String, file: File): IndexedFile {
-        val relative = file.toPath().let { path ->
-            runCatching { File(root).toPath().relativize(path).toString() }.getOrDefault(file.name)
-        }
+        val stablePath = file.toPath().toStableAbsolutePath()
+        val relative = runCatching {
+            File(root).toPath().toStableAbsolutePath().relativize(stablePath).toString()
+        }.getOrDefault(file.name)
         val textLines = runCatching {
             val bytes = file.readBytes()
             if (bytes.size > MaxIndexedBytes || looksBinary(bytes)) emptyList() else bytes.toString(detectCharset(bytes)).lineSequence()
@@ -182,7 +184,7 @@ class DesktopHostFileService(
         }.getOrDefault(emptyList())
         val name = file.name
         return IndexedFile(
-            path = file.absolutePath,
+            path = stablePath.toString(),
             relativePath = relative,
             name = name,
             modifiedMillis = file.lastModified(),
@@ -244,11 +246,12 @@ class DesktopHostFileService(
         // FSEvents (via directory-watcher) often yields /private/var/... while File.absolutePath is /var/...
         val normalized = path.toStableAbsolutePath()
         val file = normalized.toFile()
+        val key = normalized.toString()
         if (!file.exists() || shouldExclude(normalized)) {
-            index.files.remove(file.absolutePath)
+            index.files.remove(key)
             removeIndexedDescendants(index, normalized)
         } else if (file.isFile) {
-            index.files[file.absolutePath] = indexFile(root, file)
+            index.files[key] = indexFile(root, file)
         }
         saveIndex(index)
         rootStatus(root).value = HostIndexStatus(root, index.files.size, index.files.values.sumOf { it.sizeBytes }, indexing = false, message = "Updated ${file.name}", updatedAtMillis = System.currentTimeMillis())
@@ -433,12 +436,25 @@ private object ExcludingFileTreeVisitor : FileTreeVisitor {
     }
 }
 
-/** Collapse macOS /private/var (FSEvents) to /var so watcher paths match File.absolutePath index keys. */
+private val isMacOs: Boolean =
+    System.getProperty("os.name").orEmpty().contains("mac", ignoreCase = true)
+
+/** macOS keeps /tmp, /var, and /etc as symlinks into /private; FSEvents reports the /private form. */
+private val MacOsPrivateAliasPrefixes = listOf("/private/tmp", "/private/var", "/private/etc")
+
+/**
+ * Collapse macOS FSEvents `/private/{tmp,var,etc}` paths to the symlink form so watcher events
+ * match indexed keys. Leaves real `/private/...` paths alone on Linux and for non-alias macOS paths.
+ */
 private fun Path.toStableAbsolutePath(): Path {
     val absolute = toAbsolutePath().normalize().toString()
-    return Path.of(
-        if (absolute.startsWith("/private/")) absolute.removePrefix("/private") else absolute,
-    )
+    if (!isMacOs) return Path.of(absolute)
+    for (prefix in MacOsPrivateAliasPrefixes) {
+        if (absolute == prefix || absolute.startsWith("$prefix/")) {
+            return Path.of(absolute.removePrefix("/private"))
+        }
+    }
+    return Path.of(absolute)
 }
 
 private fun moveReplacing(source: Path, target: Path) {
@@ -469,7 +485,13 @@ private fun languageHintForFile(file: File): String {
     }
 }
 
-private fun normalizeRoot(root: String): String = File(root.ifBlank { System.getProperty("user.home") }).absoluteFile.normalize().absolutePath
+private fun normalizeRoot(root: String): String =
+    File(root.ifBlank { System.getProperty("user.home") })
+        .absoluteFile
+        .normalize()
+        .toPath()
+        .toStableAbsolutePath()
+        .toString()
 
 private fun tokenize(value: String): Set<String> = value.lowercase()
     .split(Regex("[^a-z0-9_.$-]+|(?=[A-Z])"))

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopHostFileService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopHostFileService.kt
@@ -8,31 +8,33 @@ import app.andy.model.HostSearchMatchKind
 import app.andy.model.HostSearchMode
 import app.andy.model.HostSearchResult
 import app.andy.service.HostFileService
+import io.methvin.watcher.DirectoryChangeEvent
+import io.methvin.watcher.DirectoryWatcher
+import io.methvin.watcher.visitor.FileTreeVisitor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.IOException
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
-import java.nio.file.FileSystems
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
-import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
-import java.nio.file.StandardWatchEventKinds.ENTRY_DELETE
-import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
-import java.nio.file.WatchKey
-import java.nio.file.WatchService
 import java.nio.file.attribute.BasicFileAttributes
 import java.security.MessageDigest
 import java.util.Base64
@@ -40,7 +42,6 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.io.path.isDirectory
-import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
 
 class DesktopHostFileService(
@@ -108,7 +109,7 @@ class DesktopHostFileService(
             indexer.cancel()
             watchers.remove(normalized)?.close()
         }
-    }
+    }.flowOn(Dispatchers.IO)
 
     override suspend fun search(query: String, mode: HostSearchMode, roots: List<String>, limit: Int): List<HostSearchResult> = withContext(Dispatchers.IO) {
         val terms = query.trim().lowercase().split(Regex("\\s+")).filter { it.isNotBlank() }
@@ -198,36 +199,54 @@ class DesktopHostFileService(
         watchers[root]?.close()
         val rootPath = File(root).toPath()
         if (!rootPath.isDirectory()) return
-        val watchService = FileSystems.getDefault().newWatchService()
-        val keys = ConcurrentHashMap<WatchKey, Path>()
-        fun register(dir: Path) {
-            runCatching {
-                keys[dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE)] = dir
-            }
-        }
-        rootPath.walkDirectories { register(it) }
-        val job = scope.launch {
-            while (true) {
-                val key = runCatching { watchService.take() }.getOrNull() ?: break
-                val dir = keys[key]
-                val changed = key.pollEvents().mapNotNull { event -> dir?.resolve(event.context() as Path) }
-                key.reset()
-                delay(350)
-                changed.forEach { path ->
-                    if (path.isDirectory() && !shouldExclude(path)) path.walkDirectories { register(it) }
-                    refreshPath(root, path)
+        val events = Channel<Path>(Channel.UNLIMITED)
+        val watcher = runCatching {
+            DirectoryWatcher.builder()
+                .paths(listOf(rootPath))
+                // Skip hashing: init otherwise reads every file under the root on the caller thread.
+                .fileHashing(false)
+                // Prune excluded trees during registration (library has no include/exclude API).
+                .fileTreeVisitor(ExcludingFileTreeVisitor)
+                .listener { event ->
+                    if (event.eventType() == DirectoryChangeEvent.EventType.OVERFLOW) return@listener
+                    val path = event.path() ?: return@listener
+                    if (shouldExclude(path)) return@listener
+                    events.trySend(path)
                 }
+                .build()
+        }.getOrNull() ?: return
+        // watchAsync() blocks until registration finishes — keep that off the UI collector thread.
+        val job = scope.launch {
+            val watchFuture = runCatching { watcher.watchAsync() }.getOrElse {
+                runCatching { watcher.close() }
+                return@launch
+            }
+            try {
+                while (isActive) {
+                    val batch = linkedSetOf(events.receive())
+                    delay(350)
+                    while (true) {
+                        val next = events.tryReceive().getOrNull() ?: break
+                        batch.add(next)
+                    }
+                    batch.forEach { refreshPath(root, it) }
+                }
+            } finally {
+                events.close()
+                watchFuture.cancel(true)
             }
         }
-        watchers[root] = WatchHandle(watchService, job)
+        watchers[root] = WatchHandle(watcher, job)
     }
 
     private fun refreshPath(root: String, path: Path) {
         val index = roots[root] ?: loadIndex(root)
-        val file = path.toFile()
-        if (!file.exists() || shouldExclude(path)) {
+        // FSEvents (via directory-watcher) often yields /private/var/... while File.absolutePath is /var/...
+        val normalized = path.toStableAbsolutePath()
+        val file = normalized.toFile()
+        if (!file.exists() || shouldExclude(normalized)) {
             index.files.remove(file.absolutePath)
-            removeIndexedDescendants(index, path)
+            removeIndexedDescendants(index, normalized)
         } else if (file.isFile) {
             index.files[file.absolutePath] = indexFile(root, file)
         }
@@ -236,9 +255,10 @@ class DesktopHostFileService(
     }
 
     private fun refreshFileInIndexes(path: Path) {
+        val normalized = path.toStableAbsolutePath()
         roots.keys.forEach { root ->
-            if (path.toAbsolutePath().normalize().startsWith(File(root).toPath().toAbsolutePath().normalize())) {
-                refreshPath(root, path)
+            if (normalized.startsWith(File(root).toPath().toStableAbsolutePath())) {
+                refreshPath(root, normalized)
             }
         }
     }
@@ -270,9 +290,9 @@ class DesktopHostFileService(
     }
 
     private fun removeIndexedDescendants(index: RootIndex, path: Path) {
-        val normalized = path.toAbsolutePath().normalize()
+        val normalized = path.toStableAbsolutePath()
         index.files.keys.removeIf { indexedPath ->
-            Path.of(indexedPath).toAbsolutePath().normalize().startsWith(normalized)
+            Path.of(indexedPath).toStableAbsolutePath().startsWith(normalized)
         }
     }
 
@@ -342,10 +362,10 @@ class DesktopHostFileService(
 
     private data class IndexedLine(val lineNumber: Int, val text: String, val textLower: String)
 
-    private data class WatchHandle(val watchService: WatchService, val job: kotlinx.coroutines.Job) {
+    private data class WatchHandle(val watcher: DirectoryWatcher, val job: Job) {
         fun close() {
             job.cancel()
-            runCatching { watchService.close() }
+            runCatching { watcher.close() }
         }
     }
 
@@ -379,21 +399,47 @@ private fun Path.walkIndexedFiles(onFile: (Path) -> Unit) {
     })
 }
 
-private fun Path.walkDirectories(onDirectory: (Path) -> Unit) {
-    if (!exists()) return
-    Files.walkFileTree(this, object : SimpleFileVisitor<Path>() {
-        override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
-            return if (dir != this@walkDirectories && dir.name in ExcludedNames) {
-                FileVisitResult.SKIP_SUBTREE
-            } else {
-                onDirectory(dir)
-                FileVisitResult.CONTINUE
+private fun shouldExclude(path: Path): Boolean = path.asSequence().any { it.name in ExcludedNames }
+
+/**
+ * DirectoryWatcher registration visitor that skips the same excluded directory names as indexing.
+ * Without this, watchAsync() walks (and previously hashed) node_modules/.git/build/etc.
+ */
+private object ExcludingFileTreeVisitor : FileTreeVisitor {
+    override fun recursiveVisitFiles(
+        file: Path,
+        onDirectory: FileTreeVisitor.Callback,
+        onFile: FileTreeVisitor.Callback,
+    ) {
+        if (!file.exists()) return
+        Files.walkFileTree(file, object : SimpleFileVisitor<Path>() {
+            override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
+                return if (dir != file && dir.name in ExcludedNames) {
+                    FileVisitResult.SKIP_SUBTREE
+                } else {
+                    onDirectory.call(dir)
+                    FileVisitResult.CONTINUE
+                }
             }
-        }
-    })
+
+            override fun visitFile(visited: Path, attrs: BasicFileAttributes): FileVisitResult {
+                if (visited.name !in ExcludedNames) onFile.call(visited)
+                return FileVisitResult.CONTINUE
+            }
+
+            override fun visitFileFailed(visited: Path, exc: IOException): FileVisitResult =
+                FileVisitResult.CONTINUE
+        })
+    }
 }
 
-private fun shouldExclude(path: Path): Boolean = path.asSequence().any { it.name in ExcludedNames }
+/** Collapse macOS /private/var (FSEvents) to /var so watcher paths match File.absolutePath index keys. */
+private fun Path.toStableAbsolutePath(): Path {
+    val absolute = toAbsolutePath().normalize().toString()
+    return Path.of(
+        if (absolute.startsWith("/private/")) absolute.removePrefix("/private") else absolute,
+    )
+}
 
 private fun moveReplacing(source: Path, target: Path) {
     try {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopHostFileServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopHostFileServiceTest.kt
@@ -103,14 +103,59 @@ class DesktopHostFileServiceTest {
                     delay(50)
                 }
             }
+            // Allow async watchAsync() registration to finish before deleting.
+            delay(500)
 
             deletedDir.deleteRecursively()
 
-            withTimeout(5_000) {
+            withTimeout(8_000) {
                 while (service.search("stale", HostSearchMode.Content, listOf(root.absolutePath), 10).isNotEmpty()) {
                     delay(50)
                 }
             }
+        } finally {
+            collector.cancel()
+        }
+    }
+
+    @Test
+    fun watcherIndexesCreatesModifiesAndSkipsExcludedTrees() = runBlocking {
+        val root = createTempDirectory("andy-host-watch-root").toFile()
+        val indexDir = createTempDirectory("andy-host-watch-index").toFile()
+        root.resolve("seed.txt").writeText("seed")
+        val service = DesktopHostFileService(indexDir = indexDir)
+        val collector = launch { service.indexRoot(root.absolutePath).collect {} }
+        try {
+            withTimeout(5_000) {
+                while (service.search("seed", HostSearchMode.Content, listOf(root.absolutePath), 10).isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            val nested = root.resolve("nested/deep").apply { mkdirs() }
+            nested.resolve("fresh.kt").writeText("fun helloFresh() {}\n")
+            withTimeout(8_000) {
+                while (service.search("helloFresh", HostSearchMode.Content, listOf(root.absolutePath), 10).isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            nested.resolve("fresh.kt").writeText("fun helloFresh() { println(\"updatedNeedle\") }\n")
+            withTimeout(8_000) {
+                while (service.search("updatedNeedle", HostSearchMode.Content, listOf(root.absolutePath), 10).isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            listOf(".git", "node_modules", "build").forEach { excluded ->
+                root.resolve(excluded).apply { mkdirs() }
+                    .resolve("ignored.txt")
+                    .writeText("excludedNeedle should not index")
+            }
+            delay(1_200)
+            assertTrue(
+                service.search("excludedNeedle", HostSearchMode.Content, listOf(root.absolutePath), 10).isEmpty(),
+            )
         } finally {
             collector.cancel()
         }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/NestedWorktreeServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/NestedWorktreeServiceTest.kt
@@ -257,7 +257,11 @@ class NestedWorktreeServiceTest {
             val parent = harness.startWorktreeTask(title = "parent")
             val parentPath = assertNotNull(parent.worktreePath)
             // Remove the on-disk worktree while leaving the Andy task record (and branch) intact.
-            git(harness.repo, "worktree", "remove", "--force", parentPath)
+            // Linux CI occasionally leaves residue after `git worktree remove --force` ("Directory not
+            // empty" or a surviving directory); force-delete + prune keeps the setup deterministic.
+            runCatching { git(harness.repo, "worktree", "remove", "--force", parentPath) }
+            File(parentPath).deleteRecursively()
+            git(harness.repo, "worktree", "prune")
             assertFalse(File(parentPath).exists())
             assertTrue(harness.service.tasks.value.any { it.id == parent.id && it.branchName != null })
 


### PR DESCRIPTION
## Summary
- Replace the host code editor's find dialog with an inline find bar (Cmd/Ctrl+F, G / Shift+G next/prev, themed to the editor).
- Switch host file indexing from JDK `WatchService` polling to `directory-watcher` (FSEvents on macOS), with excluded-tree skipping and `/private` path normalization so creates/modifies refresh the index reliably.
- Extend desktop tests for create/modify indexing and excluded directories.

## Test plan
- [x] `./gradlew desktopTest --tests 'app.andy.desktop.service.DesktopHostFileServiceTest'`
- [ ] Open a host file, Cmd/Ctrl+F, confirm find bar appears, matches mark, and next/prev wrap
- [ ] Create/modify a file under a watched root and confirm search picks it up without restart
- [ ] Confirm `.git` / `node_modules` / `build` content is not indexed via the watcher


Made with [Cursor](https://cursor.com)