### PR TITLE
Add chat.subscribe and native ACP viewer to the CLI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -236,7 +236,7 @@ jobs:
         run: ./gradlew :web-launcher:test
 
   andy-cli:
-    name: Andy CLI build
+    name: Andy CLI build + test
     runs-on: macos-latest
     timeout-minutes: 15
 
@@ -244,10 +244,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build Andy Rust CLI
+      - name: Build and test Andy Rust CLI
         run: |
           rustup show || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "$HOME/.cargo/env" 2>/dev/null || true
+          cargo test --manifest-path cli/andy/Cargo.toml
           cargo build --manifest-path cli/andy/Cargo.toml
 
   web-preview-deploy:

--- a/cli/andy/Cargo.lock
+++ b/cli/andy/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,12 +30,16 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
- "crossterm",
+ "crossterm 0.28.1",
  "dirs",
  "ratatui",
  "serde",
  "serde_json",
+ "syntect",
+ "tempfile",
+ "termimad",
  "tokio",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -86,6 +105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +138,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -179,6 +217,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+dependencies = [
+ "crossterm 0.29.0",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crokey"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074bc31bff1084f74e5a145ad5f6ac74469fa312159faa5144f0b1c4506b8d80"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm 0.29.0",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88c4ff2d5717616c3bb4a31d06b0b241ed811c7c0c41d077d77631bee7caad0"
+dependencies = [
+ "crossterm 0.29.0",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,7 +335,25 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -238,6 +403,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +449,15 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -281,6 +483,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +548,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -319,6 +566,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "indoc"
@@ -364,6 +621,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,10 +659,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -405,7 +703,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -413,6 +711,25 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "minimad"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -427,10 +744,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "option-ext"
@@ -474,12 +825,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -492,6 +877,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,7 +891,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "indoc",
  "instability",
  "itertools",
@@ -527,9 +918,47 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -541,8 +970,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -558,10 +1000,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -607,6 +1064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +1101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +1127,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "strsim"
@@ -710,6 +1185,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termimad"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7301d9c2c4939c97f25376b70d3c13311f8fefdee44092fc361d2a98adc2cbb6"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +1252,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -798,6 +1353,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +1383,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -912,6 +1486,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zmij"

--- a/cli/andy/Cargo.toml
+++ b/cli/andy/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Andy CLI — MCP client for andyd over a Unix domain socket"
 license = "MIT"
 
+[lib]
+name = "andy_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "andy"
 path = "src/main.rs"
@@ -13,9 +17,17 @@ path = "src/main.rs"
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "net", "io-util", "process", "signal", "time"] }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "net", "io-util", "process", "signal", "time", "sync"] }
 ratatui = "0.29"
 crossterm = "0.28"
 anyhow = "1.0"
 dirs = "6.0"
 base64 = "0.22"
+termimad = "0.31"
+syntect = "5.2"
+unicode-width = "0.2"
+
+[dev-dependencies]
+tempfile = "3.19"
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync"] }
+serde_json = "1.0"

--- a/cli/andy/src/acp_view.rs
+++ b/cli/andy/src/acp_view.rs
@@ -1,0 +1,1439 @@
+use anyhow::{bail, Context, Result};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    KeyModifiers,
+};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::ExecutableCommand;
+use ratatui::prelude::*;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use serde_json::{json, Value};
+use std::io::{stdout, Stdout};
+use std::path::PathBuf;
+use std::time::Duration;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::ThemeSet;
+use syntect::parsing::SyntaxSet;
+use syntect::util::LinesWithEndings;
+use termimad::MadSkin;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::events::AgentEvent;
+use crate::file_picker;
+use crate::mcp::{McpClient, SubscribeMessage, SUBSCRIBE_MISSING_ERROR};
+use crate::viewer_chrome::{self, Lane};
+
+const DETAIL_TRUNCATE_LINES: usize = 40;
+
+#[derive(Debug, Clone)]
+struct ChatMeta {
+    id: String,
+    title: String,
+    status: String,
+    #[allow(dead_code)]
+    lane: String,
+    cwd: String,
+    origin_dir: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionIssue {
+    Gone,
+    Lost,
+}
+
+struct ViewState {
+    events: Vec<AgentEvent>,
+    status: String,
+    input: String,
+    image_paths: Vec<String>,
+    scroll: u16,
+    expanded_tools: std::collections::HashSet<usize>,
+    pending_permission: Option<AgentEvent>,
+    composer_enabled: bool,
+    /// False once `chat.subscribe` ends (terminal/done) so a later resume can reopen it.
+    subscribe_open: bool,
+    connection_issue: Option<ConnectionIssue>,
+    connection_error: Option<String>,
+    status_flash: Option<String>,
+    /// When false (default), hide tools/commands/raw/usage/thinking/etc. and show
+    /// only the conversation transcript. Toggle with `v`; default on via
+    /// `ANDY_ACP_VIEW_DETAILS=1`.
+    show_details: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopAction {
+    Continue,
+    Exit,
+    Retry,
+}
+
+/// Native ACP chat viewer for `andy attach` on ACP-lane tasks.
+pub async fn run_acp_viewer(client: &mut McpClient, task_id: &str) -> Result<()> {
+    client.requires_chat_subscribe().await.map_err(|err| {
+        if err.to_string().contains("chat.subscribe") {
+            anyhow::anyhow!("{SUBSCRIBE_MISSING_ERROR}")
+        } else {
+            err
+        }
+    })?;
+
+    let meta = load_meta(client, task_id).await?;
+
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    stdout().execute(EnableMouseCapture)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+
+    let skin = MadSkin::default();
+    let syntax_set = SyntaxSet::load_defaults_newlines();
+    let theme_set = ThemeSet::load_defaults();
+    let theme = theme_set
+        .themes
+        .get("base16-ocean.dark")
+        .or_else(|| theme_set.themes.values().next())
+        .expect("syntect theme");
+
+    let result = async {
+        // Persist viewer state across subscribe reconnects (lost socket, or continuing
+        // a completed chat). A fresh subscribe still delivers the full backlog; we only
+        // reset connection flags / subscribe_open when opening a new stream.
+        let mut state = ViewState {
+            events: Vec::new(),
+            status: meta.status.clone(),
+            input: String::new(),
+            image_paths: Vec::new(),
+            scroll: 0,
+            expanded_tools: std::collections::HashSet::new(),
+            pending_permission: None,
+            // Done/Idle chats remain continuable (resume); only hard failures lock the composer.
+            composer_enabled: !matches!(meta.status.as_str(), "Error" | "Failed" | "Stopped"),
+            subscribe_open: true,
+            connection_issue: None,
+            connection_error: None,
+            status_flash: None,
+            show_details: details_default_from_env(),
+        };
+
+        loop {
+            let (tx, mut rx) = mpsc::channel::<SubscribeMessage>(64);
+            let mut sub_client = McpClient::new(client.socket_path());
+            let sub_task = task_id.to_string();
+            // Each subscribe delivers the full backlog; reset transcript local state so
+            // reconnect / continue-after-Done does not duplicate events.
+            state.events.clear();
+            state.expanded_tools.clear();
+            state.pending_permission = None;
+            state.subscribe_open = true;
+            state.connection_issue = None;
+            state.connection_error = None;
+            // Re-enable after Lost disconnect; Done chats stay continuable, hard errors don't.
+            if !matches!(state.status.as_str(), "Error" | "Failed" | "Stopped") {
+                state.composer_enabled = true;
+            }
+            let subscribe_handle: JoinHandle<()> = tokio::spawn(async move {
+                if let Err(err) = sub_client
+                    .subscribe_chat_events(&sub_task, tx.clone())
+                    .await
+                {
+                    let msg = err.to_string();
+                    let _ = tx
+                        .send(SubscribeMessage::Disconnected(if msg.is_empty() {
+                            "lost connection to andyd".into()
+                        } else {
+                            msg
+                        }))
+                        .await;
+                }
+            });
+
+            let loop_result = run_loop(
+                client,
+                &mut terminal,
+                &meta,
+                &mut state,
+                &mut rx,
+                &skin,
+                &syntax_set,
+                theme,
+            )
+            .await;
+
+            subscribe_handle.abort();
+
+            match loop_result {
+                Ok(LoopAction::Retry) => continue,
+                Ok(LoopAction::Exit) | Ok(LoopAction::Continue) => return Ok(()),
+                Err(err) => return Err(err),
+            }
+        }
+    }
+    .await;
+
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    stdout().execute(DisableMouseCapture)?;
+    result
+}
+
+async fn run_loop(
+    client: &mut McpClient,
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    meta: &ChatMeta,
+    state: &mut ViewState,
+    rx: &mut mpsc::Receiver<SubscribeMessage>,
+    skin: &MadSkin,
+    syntax_set: &SyntaxSet,
+    theme: &syntect::highlighting::Theme,
+) -> Result<LoopAction> {
+    loop {
+        while let Ok(msg) = rx.try_recv() {
+            apply_subscribe_message(state, msg);
+        }
+
+        terminal.draw(|frame| draw(frame, meta, state, skin, syntax_set, theme))?;
+
+        if let Some(err) = &state.connection_error {
+            if err.contains("chat.subscribe") || err.contains(SUBSCRIBE_MISSING_ERROR) {
+                bail!("{SUBSCRIBE_MISSING_ERROR}");
+            }
+        }
+
+        // Deleted/missing chat: leave the viewer cleanly (same mental model as detach).
+        if state.connection_issue == Some(ConnectionIssue::Gone) {
+            eprintln!("chat no longer exists");
+            return Ok(LoopAction::Exit);
+        }
+
+        if event::poll(Duration::from_millis(120))? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    match handle_key(client, terminal, meta, state, key).await? {
+                        LoopAction::Continue => {}
+                        other => return Ok(other),
+                    }
+                }
+                Event::Resize(_, _) => {}
+                _ => {}
+            }
+        }
+    }
+}
+
+fn apply_subscribe_message(state: &mut ViewState, msg: SubscribeMessage) {
+    match msg {
+        SubscribeMessage::Batch(batch) => {
+            if let Some(from) = batch.replace_from {
+                if from <= state.events.len() {
+                    state.events.truncate(from);
+                }
+                // expanded_tools indexes the coalesced display list, not raw events.
+                let display_len = AgentEvent::coalesce_for_display(&state.events).len();
+                state.expanded_tools.retain(|idx| *idx < display_len);
+            }
+            for raw in batch.events {
+                let event = AgentEvent::from_wire(&raw);
+                if let AgentEvent::Permission { request_id, .. } = &event {
+                    state.pending_permission = Some(event.clone());
+                    let _ = request_id;
+                }
+                if let AgentEvent::PermissionResolved { request_id, .. } = &event {
+                    if let Some(AgentEvent::Permission {
+                        request_id: pending_id,
+                        ..
+                    }) = &state.pending_permission
+                    {
+                        if pending_id == request_id {
+                            state.pending_permission = None;
+                        }
+                    }
+                }
+                match &event {
+                    AgentEvent::Error { .. } => {
+                        state.composer_enabled = false;
+                        state.status = "Error".into();
+                    }
+                    AgentEvent::Result { success, .. } => {
+                        if *success {
+                            state.composer_enabled = true;
+                            state.status = "Done".into();
+                        } else {
+                            // Failed/crashed task: terminal, composer locked (matches GUI).
+                            state.composer_enabled = false;
+                            state.status = "Error".into();
+                        }
+                    }
+                    _ => {}
+                }
+                state.events.push(event);
+            }
+            if let Some(err) = batch.error {
+                if err.contains("chat no longer exists") {
+                    state.connection_issue = Some(ConnectionIssue::Gone);
+                } else {
+                    state.connection_issue = Some(ConnectionIssue::Lost);
+                }
+                state.connection_error = Some(err);
+                state.composer_enabled = false;
+            }
+            if batch.done && state.connection_error.is_none() {
+                state.subscribe_open = false;
+                state.status_flash = Some("subscription ended".into());
+                // Defer Done vs Error promotion to Finished { reason }. A done batch alone
+                // cannot tell AgentStatus.Error from Done (both close the subscribe).
+            }
+        }
+        SubscribeMessage::Finished { reason } => {
+            state.subscribe_open = false;
+            state.status_flash = Some(format!("subscribe finished ({reason})"));
+            if reason == "gone" {
+                state.connection_issue = Some(ConnectionIssue::Gone);
+                state.connection_error = Some("chat no longer exists".into());
+                state.composer_enabled = false;
+            } else if reason == "error" {
+                // Daemon closed subscribe on AgentStatus.Error — lock composer even when
+                // no TaskError/TaskResult event was appended.
+                state.status = "Error".into();
+                state.composer_enabled = false;
+            } else if reason == "terminal" || reason == "done" {
+                // Stop/finish may not emit TaskResult; treat subscribe terminal as Done.
+                mark_terminal_if_stopping(state);
+                // Leave composer enabled so resume can continue the chat.
+            }
+        }
+        SubscribeMessage::Disconnected(msg) => {
+            state.subscribe_open = false;
+            if msg.contains("chat no longer exists") {
+                state.connection_issue = Some(ConnectionIssue::Gone);
+            } else {
+                state.connection_issue = Some(ConnectionIssue::Lost);
+            }
+            state.connection_error = Some(msg);
+            state.composer_enabled = false;
+        }
+    }
+}
+
+async fn handle_key(
+    client: &mut McpClient,
+    terminal: &mut Terminal<impl Backend>,
+    meta: &ChatMeta,
+    state: &mut ViewState,
+    key: KeyEvent,
+) -> Result<LoopAction> {
+    match map_key_action(state, key) {
+        MappedKey::Exit => return Ok(LoopAction::Exit),
+        MappedKey::Retry => return Ok(LoopAction::Retry),
+        MappedKey::Stop => {
+            state.status = "Stopping".into();
+            match client
+                .call_tool("chat.stop", json!({ "taskId": meta.id }))
+                .await
+            {
+                Ok(_) => {
+                    // ACP stop calls finishTask(Done) without appending TaskResult.
+                    // Prefer the daemon's status; fall back to Done when unavailable.
+                    apply_stop_success(state, fetch_task_status(client, &meta.id).await);
+                }
+                Err(err) => {
+                    state.status_flash = Some(format!("stop failed: {err:#}"));
+                    // Leave Stopping only briefly — next subscribe terminal will promote.
+                }
+            }
+        }
+        MappedKey::PickImage => {
+            let start = if !meta.cwd.is_empty() {
+                PathBuf::from(&meta.cwd)
+            } else if !meta.origin_dir.is_empty() {
+                PathBuf::from(&meta.origin_dir)
+            } else {
+                std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+            };
+            if let Some(path) = file_picker::pick_image(terminal, start)? {
+                state.image_paths.push(path.display().to_string());
+            }
+        }
+        MappedKey::ToggleExpand => {
+            if state.show_details {
+                toggle_last_tool_expand(state);
+            }
+        }
+        MappedKey::ToggleDetails => {
+            state.show_details = !state.show_details;
+            state.status_flash = Some(if state.show_details {
+                "details on".into()
+            } else {
+                "conversation only".into()
+            });
+        }
+        MappedKey::ScrollUp => state.scroll = state.scroll.saturating_add(1),
+        MappedKey::ScrollDown => state.scroll = state.scroll.saturating_sub(1),
+        MappedKey::PageUp => state.scroll = state.scroll.saturating_add(10),
+        MappedKey::PageDown => state.scroll = state.scroll.saturating_sub(10),
+        MappedKey::Backspace => {
+            state.input.pop();
+        }
+        MappedKey::Submit => {
+            if state.composer_enabled {
+                let resubscribe = submit_follow_up(client, meta, state).await?;
+                if resubscribe {
+                    return Ok(LoopAction::Retry);
+                }
+            }
+        }
+        MappedKey::Insert(c) => {
+            if state.composer_enabled {
+                state.input.push(c);
+            }
+        }
+        MappedKey::Permission(choice) => {
+            if let Some(AgentEvent::Permission {
+                request_id,
+                options,
+                ..
+            }) = state.pending_permission.clone()
+            {
+                respond_permission(client, &meta.id, &request_id, &options, choice).await?;
+                state.pending_permission = None;
+            }
+        }
+        MappedKey::None => {}
+    }
+    Ok(LoopAction::Continue)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PermissionChoice {
+    Yes,
+    No,
+    Always,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MappedKey {
+    Exit,
+    Retry,
+    Stop,
+    PickImage,
+    ToggleExpand,
+    ToggleDetails,
+    ScrollUp,
+    ScrollDown,
+    PageUp,
+    PageDown,
+    Backspace,
+    Submit,
+    Insert(char),
+    Permission(PermissionChoice),
+    None,
+}
+
+fn modifiers_allow_typing(mods: KeyModifiers) -> bool {
+    !mods.contains(KeyModifiers::CONTROL)
+        && !mods.contains(KeyModifiers::ALT)
+        && !mods.contains(KeyModifiers::SUPER)
+}
+
+/// Toggle expand/collapse for the last tool bubble using coalesced display indexes
+/// (the same list `render_transcript` iterates).
+fn toggle_last_tool_expand(state: &mut ViewState) {
+    let display = AgentEvent::coalesce_for_display(&state.events);
+    if let Some(idx) = display
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, e)| matches!(e, AgentEvent::Tool { .. } | AgentEvent::ToolResult { .. }))
+        .map(|(i, _)| i)
+    {
+        if !state.expanded_tools.remove(&idx) {
+            state.expanded_tools.insert(idx);
+        }
+    }
+}
+
+fn follow_up_tool_for_status(status: &str) -> &'static str {
+    if matches!(status, "Working" | "Blocked" | "Stopping") {
+        "chat.queue_follow_up"
+    } else {
+        "chat.resume"
+    }
+}
+
+/// ACP user-stop finishes as Done without a TaskResult event.
+fn mark_terminal_if_stopping(state: &mut ViewState) {
+    if matches!(state.status.as_str(), "Stopping" | "Working" | "Blocked") {
+        state.status = "Done".into();
+    }
+}
+
+fn apply_stop_success(state: &mut ViewState, daemon_status: Option<String>) {
+    state.status = daemon_status.unwrap_or_else(|| "Done".into());
+    state.status_flash = Some("stopped".into());
+    state.composer_enabled = !matches!(state.status.as_str(), "Error" | "Failed" | "Stopped");
+}
+
+async fn fetch_task_status(client: &mut McpClient, task_id: &str) -> Option<String> {
+    let raw = client
+        .call_tool("chat.status", json!({ "taskId": task_id }))
+        .await
+        .ok()?;
+    let v: Value = serde_json::from_str(&raw).ok()?;
+    v.get("status")
+        .and_then(|s| s.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Pure key → action mapping for the ACP composer/viewer (unit-tested).
+fn map_key_action(state: &ViewState, key: KeyEvent) -> MappedKey {
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        return MappedKey::Exit;
+    }
+
+    if state.connection_issue == Some(ConnectionIssue::Lost) {
+        return match key.code {
+            KeyCode::Char('r') | KeyCode::Char('R') if modifiers_allow_typing(key.modifiers) => {
+                MappedKey::Retry
+            }
+            KeyCode::Esc | KeyCode::Char('q') if modifiers_allow_typing(key.modifiers) => {
+                MappedKey::Exit
+            }
+            _ => MappedKey::None,
+        };
+    }
+
+    if state.pending_permission.is_some() {
+        return match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') if modifiers_allow_typing(key.modifiers) => {
+                MappedKey::Permission(PermissionChoice::Yes)
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') if modifiers_allow_typing(key.modifiers) => {
+                MappedKey::Permission(PermissionChoice::No)
+            }
+            KeyCode::Char('a') | KeyCode::Char('A') if modifiers_allow_typing(key.modifiers) => {
+                MappedKey::Permission(PermissionChoice::Always)
+            }
+            KeyCode::Esc | KeyCode::Char('q') if modifiers_allow_typing(key.modifiers) => {
+                MappedKey::Exit
+            }
+            _ => MappedKey::None,
+        };
+    }
+
+    match key.code {
+        KeyCode::Esc => MappedKey::Exit,
+        KeyCode::Char('q') if state.input.is_empty() && modifiers_allow_typing(key.modifiers) => {
+            MappedKey::Exit
+        }
+        KeyCode::Char('s') if state.input.is_empty() && modifiers_allow_typing(key.modifiers) => {
+            MappedKey::Stop
+        }
+        KeyCode::Char('i')
+            if state.input.is_empty()
+                && state.composer_enabled
+                && modifiers_allow_typing(key.modifiers) =>
+        {
+            MappedKey::PickImage
+        }
+        KeyCode::Char('v') if state.input.is_empty() && modifiers_allow_typing(key.modifiers) => {
+            MappedKey::ToggleDetails
+        }
+        KeyCode::Char(' ') if state.input.is_empty() && modifiers_allow_typing(key.modifiers) => {
+            MappedKey::ToggleExpand
+        }
+        KeyCode::Up => MappedKey::ScrollUp,
+        KeyCode::Down => MappedKey::ScrollDown,
+        KeyCode::PageUp => MappedKey::PageUp,
+        KeyCode::PageDown => MappedKey::PageDown,
+        KeyCode::Backspace => MappedKey::Backspace,
+        KeyCode::Enter => MappedKey::Submit,
+        KeyCode::Char(c) if modifiers_allow_typing(key.modifiers) => MappedKey::Insert(c),
+        _ => MappedKey::None,
+    }
+}
+
+async fn respond_permission(
+    client: &mut McpClient,
+    task_id: &str,
+    request_id: &str,
+    options: &[(String, String)],
+    choice: PermissionChoice,
+) -> Result<()> {
+    let label = pick_permission_label(options, choice).unwrap_or_else(|| match choice {
+        PermissionChoice::Yes => "Allow".into(),
+        PermissionChoice::No => "Reject".into(),
+        PermissionChoice::Always => "Allow always".into(),
+    });
+    client
+        .call_tool(
+            "chat.respond",
+            json!({
+                "taskId": task_id,
+                "requestId": request_id,
+                "answers": { request_id: label }
+            }),
+        )
+        .await
+        .context("chat.respond")?;
+    Ok(())
+}
+
+fn pick_permission_label(options: &[(String, String)], choice: PermissionChoice) -> Option<String> {
+    let needle: &[&str] = match choice {
+        PermissionChoice::Yes => &["allow_once", "allow once", "allow"],
+        PermissionChoice::No => &["reject_once", "reject once", "reject", "deny"],
+        PermissionChoice::Always => &["allow_always", "allow always", "always"],
+    };
+    for (label, description) in options {
+        let blob = format!("{label} {description}").to_lowercase();
+        if needle.iter().any(|n| blob.contains(n)) {
+            return Some(label.clone());
+        }
+    }
+    match choice {
+        PermissionChoice::Yes => options.first().map(|(l, _)| l.clone()),
+        PermissionChoice::No => options.last().map(|(l, _)| l.clone()),
+        PermissionChoice::Always => options
+            .iter()
+            .find(|(_, d)| d.to_lowercase().contains("always"))
+            .map(|(l, _)| l.clone())
+            .or_else(|| options.first().map(|(l, _)| l.clone())),
+    }
+}
+
+/// Returns true when the caller must reopen `chat.subscribe` (e.g. after continuing
+/// a completed chat whose prior subscription already finished).
+async fn submit_follow_up(
+    client: &mut McpClient,
+    meta: &ChatMeta,
+    state: &mut ViewState,
+) -> Result<bool> {
+    let text = state.input.trim().to_string();
+    if text.is_empty() && state.image_paths.is_empty() {
+        return Ok(false);
+    }
+    // Subscribe carries transcript events, not status transitions. Another client
+    // (GUI) may have started a turn while this viewer still shows Done — refresh
+    // authoritative status before choosing resume vs queue.
+    if let Some(daemon_status) = fetch_task_status(client, &meta.id).await {
+        state.status = daemon_status;
+    }
+    let tool = follow_up_tool_for_status(&state.status);
+    let mut args = json!({
+        "taskId": meta.id,
+        "followUp": if text.is_empty() { "(image)" } else { text.as_str() },
+    });
+    if !state.image_paths.is_empty() {
+        args["imagePaths"] = json!(state.image_paths);
+    }
+    client
+        .call_tool(tool, args)
+        .await
+        .with_context(|| tool.to_string())?;
+    state.input.clear();
+    state.image_paths.clear();
+    state.status = "Working".into();
+    state.status_flash = Some(format!("sent via {tool}"));
+    // Daemon closes subscribe on terminal status; continuing the chat needs a new stream
+    // or the viewer stays stale until the user exits and reattaches.
+    Ok(!state.subscribe_open)
+}
+
+fn draw(
+    frame: &mut Frame<'_>,
+    meta: &ChatMeta,
+    state: &ViewState,
+    skin: &MadSkin,
+    syntax_set: &SyntaxSet,
+    theme: &syntect::highlighting::Theme,
+) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+            Constraint::Length(
+                if state.pending_permission.is_some()
+                    || state.connection_issue == Some(ConnectionIssue::Lost)
+                {
+                    4
+                } else {
+                    2
+                },
+            ),
+        ])
+        .split(area);
+
+    let header = viewer_chrome::format_header(&meta.id, &meta.title, &state.status, Lane::Acp);
+    frame.render_widget(
+        Paragraph::new(header).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Lane::Acp.frame_title()),
+        ),
+        chunks[0],
+    );
+
+    let body = render_transcript(state, skin, syntax_set, theme, chunks[1].width);
+    let transcript_title = if state.show_details {
+        " Transcript · details "
+    } else {
+        " Transcript "
+    };
+    frame.render_widget(
+        Paragraph::new(body)
+            .wrap(Wrap { trim: false })
+            .scroll((state.scroll, 0))
+            .block(Block::default().borders(Borders::ALL).title(transcript_title)),
+        chunks[1],
+    );
+
+    let chips = if state.image_paths.is_empty() {
+        String::new()
+    } else {
+        state
+            .image_paths
+            .iter()
+            .map(|p| {
+                PathBuf::from(p)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| p.clone())
+            })
+            .map(|n| format!("[image: {n}]"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    let composer = if let Some(err) = &state.connection_error {
+        format!(" {err} ")
+    } else if !state.composer_enabled {
+        " (composer disabled) ".to_string()
+    } else {
+        format!(" {chips}{} ", state.input)
+    };
+    frame.render_widget(
+        Paragraph::new(composer).block(Block::default().borders(Borders::ALL).title(" Follow-up ")),
+        chunks[2],
+    );
+
+    let footer = if state.connection_issue == Some(ConnectionIssue::Lost) {
+        " Lost connection to andyd — press r to retry, q/Esc to quit ".to_string()
+    } else if let Some(AgentEvent::Permission {
+        tool_name,
+        question,
+        ..
+    }) = &state.pending_permission
+    {
+        format!(" Permission: {tool_name} — {question}  [y]es [n]o [a]lways-allow ")
+    } else {
+        viewer_chrome::format_status_line(Lane::Acp, state.status_flash.as_deref())
+    };
+    frame.render_widget(Paragraph::new(footer), chunks[3]);
+}
+
+/// Conversation-only visibility (default). Mirrors the GUI hiding AvailableCommands /
+/// Raw / ContextUsage, and also drops tools/thinking/plan/mode noise for the TUI.
+fn event_visible_in_conversation(event: &AgentEvent) -> bool {
+    match event {
+        AgentEvent::User { .. } | AgentEvent::Assistant { .. } | AgentEvent::Error { .. } => true,
+        // Failed completion with no separate Error event still needs a signal.
+        AgentEvent::Result { success: false, .. } => true,
+        _ => false,
+    }
+}
+
+fn details_default_from_env() -> bool {
+    match std::env::var("ANDY_ACP_VIEW_DETAILS") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "1" | "true" | "yes" | "on" | "full" | "all")
+        }
+        Err(_) => false,
+    }
+}
+
+fn render_transcript(
+    state: &ViewState,
+    skin: &MadSkin,
+    syntax_set: &SyntaxSet,
+    theme: &syntect::highlighting::Theme,
+    width: u16,
+) -> Text<'static> {
+    let display = AgentEvent::coalesce_for_display(&state.events);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (idx, event) in display.iter().enumerate() {
+        if !state.show_details && !event_visible_in_conversation(event) {
+            continue;
+        }
+        match event {
+            AgentEvent::User { text, images, .. } => {
+                lines.push(Line::from(Span::styled(
+                    "you".to_string(),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )));
+                lines.extend(markdown_lines(skin, text, width));
+                for img in images {
+                    let name = PathBuf::from(img)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| img.clone());
+                    lines.push(Line::from(format!("  [image: {name}] ({img})")));
+                }
+                lines.push(Line::from(""));
+            }
+            AgentEvent::Assistant { text, .. } => {
+                lines.push(Line::from(Span::styled(
+                    "assistant".to_string(),
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                )));
+                lines.extend(markdown_lines(skin, text, width));
+                lines.push(Line::from(""));
+            }
+            AgentEvent::Thinking { text, .. } => {
+                lines.push(Line::from(Span::styled(
+                    "thinking".to_string(),
+                    Style::default().fg(Color::DarkGray),
+                )));
+                lines.extend(markdown_lines(skin, text, width));
+                lines.push(Line::from(""));
+            }
+            AgentEvent::Tool {
+                tool_name,
+                summary,
+                detail,
+                state: tool_state,
+                ..
+            } => {
+                let expanded = state.expanded_tools.contains(&idx);
+                lines.push(Line::from(format!(
+                    "▸ {tool_name} [{tool_state}] {summary}"
+                )));
+                if expanded {
+                    lines.extend(highlight_detail(syntax_set, theme, detail));
+                }
+            }
+            AgentEvent::ToolResult {
+                tool_name,
+                summary,
+                detail,
+                is_error,
+                ..
+            } => {
+                let expanded = state.expanded_tools.contains(&idx);
+                let tag = if *is_error { "err" } else { "ok" };
+                lines.push(Line::from(format!("◂ {tool_name} [{tag}] {summary}")));
+                if expanded {
+                    lines.extend(highlight_detail(syntax_set, theme, detail));
+                }
+            }
+            AgentEvent::Plan {
+                entries, markdown, ..
+            } => {
+                lines.push(Line::from(Span::styled(
+                    "plan".to_string(),
+                    Style::default().fg(Color::Yellow),
+                )));
+                if let Some(md) = markdown {
+                    lines.extend(markdown_lines(skin, md, width));
+                } else {
+                    for (content, status) in entries {
+                        lines.push(Line::from(format!("  - [{status}] {content}")));
+                    }
+                }
+                lines.push(Line::from(""));
+            }
+            AgentEvent::Mode { mode_id, .. } => {
+                lines.push(Line::from(format!("mode → {mode_id}")));
+            }
+            AgentEvent::Commands { commands, .. } => {
+                lines.push(Line::from(Span::styled(
+                    "available commands".to_string(),
+                    Style::default().fg(Color::Blue),
+                )));
+                for (name, description) in commands {
+                    if description.is_empty() {
+                        lines.push(Line::from(format!("  /{name}")));
+                    } else {
+                        lines.push(Line::from(format!("  /{name} — {description}")));
+                    }
+                }
+                lines.push(Line::from(""));
+            }
+            AgentEvent::Modes {
+                current_mode_id,
+                modes,
+                ..
+            } => {
+                lines.push(Line::from(Span::styled(
+                    format!("available modes (current={current_mode_id})"),
+                    Style::default().fg(Color::Blue),
+                )));
+                for (id, name) in modes {
+                    lines.push(Line::from(format!("  {id} — {name}")));
+                }
+                lines.push(Line::from(""));
+            }
+            AgentEvent::Permission {
+                tool_name,
+                question,
+                ..
+            } => {
+                lines.push(Line::from(Span::styled(
+                    format!("permission · {tool_name}: {question}"),
+                    Style::default().fg(Color::Magenta),
+                )));
+            }
+            AgentEvent::PermissionResolved {
+                allowed,
+                option_id,
+                note,
+                ..
+            } => {
+                let note = note.clone().unwrap_or_default();
+                lines.push(Line::from(format!(
+                    "permission resolved · allowed={allowed} · {option_id} {note}"
+                )));
+            }
+            AgentEvent::Result {
+                success,
+                final_text,
+                ..
+            } => {
+                lines.push(Line::from(format!(
+                    "result · success={success} {}",
+                    final_text.chars().take(200).collect::<String>()
+                )));
+            }
+            AgentEvent::Error { text, .. } => {
+                lines.push(Line::from(Span::styled(
+                    format!("error: {text}"),
+                    Style::default().fg(Color::Red),
+                )));
+            }
+            AgentEvent::Raw { line, .. } => {
+                lines.push(Line::from(format!("raw: {line}")));
+            }
+            AgentEvent::Session { model, .. } => {
+                lines.push(Line::from(format!("session · model={model}")));
+            }
+            AgentEvent::Usage {
+                used_tokens,
+                window_tokens,
+                ..
+            } => {
+                lines.push(Line::from(format!(
+                    "usage · {used_tokens}/{window_tokens} tokens"
+                )));
+            }
+            AgentEvent::Unknown { .. } => {}
+        }
+    }
+    Text::from(lines)
+}
+
+fn markdown_lines(skin: &MadSkin, text: &str, width: u16) -> Vec<Line<'static>> {
+    let rendered = skin
+        .text(text, Some(width.saturating_sub(2) as usize))
+        .to_string();
+    rendered
+        .lines()
+        .map(|l| Line::from(l.to_string()))
+        .collect()
+}
+
+fn highlight_detail(
+    syntax_set: &SyntaxSet,
+    theme: &syntect::highlighting::Theme,
+    detail: &str,
+) -> Vec<Line<'static>> {
+    let lines: Vec<&str> = detail.lines().collect();
+    let truncated = lines.len() > DETAIL_TRUNCATE_LINES;
+    let slice = if truncated {
+        &lines[..DETAIL_TRUNCATE_LINES]
+    } else {
+        &lines[..]
+    };
+    let syntax = syntax_set
+        .find_syntax_by_extension("diff")
+        .or_else(|| syntax_set.find_syntax_by_extension("rs"))
+        .unwrap_or_else(|| syntax_set.find_syntax_plain_text());
+    let mut highlighter = HighlightLines::new(syntax, theme);
+    let mut out = Vec::new();
+    let joined = slice.join("\n");
+    for line in LinesWithEndings::from(&joined) {
+        let ranges = highlighter
+            .highlight_line(line, syntax_set)
+            .unwrap_or_default();
+        let mut spans = vec![Span::raw("    ")];
+        for (style, text) in ranges {
+            let fg = style.foreground;
+            spans.push(Span::styled(
+                text.to_string(),
+                Style::default().fg(Color::Rgb(fg.r, fg.g, fg.b)),
+            ));
+        }
+        out.push(Line::from(spans));
+    }
+    if truncated {
+        out.push(Line::from(format!(
+            "    … {} more lines (space to collapse)",
+            lines.len() - DETAIL_TRUNCATE_LINES
+        )));
+    }
+    out
+}
+
+async fn load_meta(client: &mut McpClient, task_id: &str) -> Result<ChatMeta> {
+    let status_raw = client
+        .call_tool("chat.status", json!({ "taskId": task_id }))
+        .await
+        .context("chat.status")?;
+    let status_v: Value = serde_json::from_str(&status_raw).unwrap_or(Value::Null);
+    let list_raw = client
+        .call_tool("chat.list", Value::Object(Default::default()))
+        .await
+        .unwrap_or_else(|_| "[]".into());
+    let list: Value = serde_json::from_str(&list_raw).unwrap_or(Value::Null);
+    let row = list.as_array().and_then(|arr| {
+        arr.iter()
+            .find(|e| e.get("id").and_then(|id| id.as_str()) == Some(task_id))
+    });
+    Ok(ChatMeta {
+        id: task_id.to_string(),
+        title: row
+            .and_then(|r| r.get("title"))
+            .and_then(|v| v.as_str())
+            .unwrap_or(task_id)
+            .to_string(),
+        status: status_v
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        lane: status_v
+            .get("lane")
+            .or_else(|| row.and_then(|r| r.get("lane")))
+            .and_then(|v| v.as_str())
+            .unwrap_or("Acp")
+            .to_string(),
+        cwd: status_v
+            .get("cwd")
+            .or_else(|| row.and_then(|r| r.get("cwd")))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        origin_dir: status_v
+            .get("originDir")
+            .or_else(|| row.and_then(|r| r.get("originDir")))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+    })
+}
+
+/// Resolve task lane for attach routing. Hard-fails ACP when subscribe is missing.
+pub async fn resolve_lane(client: &mut McpClient, task_id: &str) -> Result<String> {
+    let raw = client
+        .call_tool("chat.status", json!({ "taskId": task_id }))
+        .await
+        .context("chat.status")?;
+    let v: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
+    if let Some(lane) = v
+        .get("lane")
+        .and_then(|l| l.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return Ok(lane.to_string());
+    }
+    let list_raw = client
+        .call_tool("chat.list", Value::Object(Default::default()))
+        .await
+        .context("chat.list")?;
+    let list: Value = serde_json::from_str(&list_raw).unwrap_or(Value::Null);
+    let lane = list
+        .as_array()
+        .and_then(|arr| {
+            arr.iter().find_map(|e| {
+                if e.get("id").and_then(|id| id.as_str()) == Some(task_id) {
+                    e.get("lane")
+                        .and_then(|l| l.as_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+        })
+        .unwrap_or_else(|| "Terminal".to_string());
+    Ok(lane)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+
+    fn empty_state() -> ViewState {
+        ViewState {
+            events: Vec::new(),
+            status: "Idle".into(),
+            input: String::new(),
+            image_paths: Vec::new(),
+            scroll: 0,
+            expanded_tools: Default::default(),
+            pending_permission: None,
+            composer_enabled: true,
+            subscribe_open: true,
+            connection_issue: None,
+            connection_error: None,
+            status_flash: None,
+            show_details: false,
+        }
+    }
+
+    #[test]
+    fn conversation_filter_hides_noise_keeps_dialogue() {
+        assert!(event_visible_in_conversation(&AgentEvent::User {
+            at_millis: 1,
+            text: "hi".into(),
+            images: vec![],
+        }));
+        assert!(event_visible_in_conversation(&AgentEvent::Assistant {
+            at_millis: 2,
+            text: "yo".into(),
+            stream: false,
+        }));
+        assert!(event_visible_in_conversation(&AgentEvent::Error {
+            at_millis: 3,
+            text: "boom".into(),
+        }));
+        assert!(event_visible_in_conversation(&AgentEvent::Result {
+            at_millis: 4,
+            success: false,
+            final_text: "failed".into(),
+        }));
+        assert!(!event_visible_in_conversation(&AgentEvent::Result {
+            at_millis: 5,
+            success: true,
+            final_text: "done".into(),
+        }));
+        assert!(!event_visible_in_conversation(&AgentEvent::Thinking {
+            at_millis: 6,
+            text: "...".into(),
+            stream: true,
+        }));
+        assert!(!event_visible_in_conversation(&AgentEvent::Tool {
+            at_millis: 7,
+            tool_name: "Bash".into(),
+            tool_call_id: "1".into(),
+            summary: "ls".into(),
+            detail: "".into(),
+            kind: "".into(),
+            state: "".into(),
+            locations: vec![],
+        }));
+        assert!(!event_visible_in_conversation(&AgentEvent::Commands {
+            at_millis: 8,
+            commands: vec![("skill".into(), "desc".into())],
+        }));
+        assert!(!event_visible_in_conversation(&AgentEvent::Raw {
+            at_millis: 9,
+            line: "session: null".into(),
+        }));
+        assert!(!event_visible_in_conversation(&AgentEvent::Usage {
+            at_millis: 10,
+            used_tokens: 1,
+            window_tokens: 2,
+        }));
+    }
+
+    #[test]
+    fn v_toggles_details_when_input_empty() {
+        let state = empty_state();
+        assert_eq!(
+            map_key_action(&state, press(KeyCode::Char('v'))),
+            MappedKey::ToggleDetails
+        );
+        let mut typing = empty_state();
+        typing.input = "hi".into();
+        assert_eq!(
+            map_key_action(&typing, press(KeyCode::Char('v'))),
+            MappedKey::Insert('v')
+        );
+    }
+
+    #[test]
+    fn finished_terminal_marks_subscribe_closed_but_keeps_composer() {
+        let mut state = empty_state();
+        state.status = "Working".into();
+        apply_subscribe_message(
+            &mut state,
+            SubscribeMessage::Batch(crate::mcp::SubscribeBatch {
+                subscription_id: "s".into(),
+                task_id: "t".into(),
+                events: vec![json!({
+                    "type": "result",
+                    "atMillis": 1,
+                    "success": true,
+                    "finalText": "done"
+                })],
+                replace_from: None,
+                done: false,
+                error: None,
+            }),
+        );
+        assert!(state.composer_enabled);
+        assert_eq!(state.status, "Done");
+
+        apply_subscribe_message(
+            &mut state,
+            SubscribeMessage::Finished {
+                reason: "terminal".into(),
+            },
+        );
+        assert!(!state.subscribe_open);
+        assert!(state.composer_enabled);
+        assert!(state.connection_issue.is_none());
+    }
+
+    #[test]
+    fn failed_result_disables_composer() {
+        let mut state = empty_state();
+        state.status = "Working".into();
+        apply_subscribe_message(
+            &mut state,
+            SubscribeMessage::Batch(crate::mcp::SubscribeBatch {
+                subscription_id: "s".into(),
+                task_id: "t".into(),
+                events: vec![json!({
+                    "type": "result",
+                    "atMillis": 1,
+                    "success": false,
+                    "finalText": "crashed"
+                })],
+                replace_from: None,
+                done: false,
+                error: None,
+            }),
+        );
+        assert!(!state.composer_enabled);
+        assert_eq!(state.status, "Error");
+    }
+
+    #[test]
+    fn follow_up_routes_active_status_to_queue() {
+        assert_eq!(follow_up_tool_for_status("Done"), "chat.resume");
+        assert_eq!(follow_up_tool_for_status("Idle"), "chat.resume");
+        assert_eq!(follow_up_tool_for_status("Working"), "chat.queue_follow_up");
+        assert_eq!(follow_up_tool_for_status("Blocked"), "chat.queue_follow_up");
+        assert_eq!(
+            follow_up_tool_for_status("Stopping"),
+            "chat.queue_follow_up"
+        );
+    }
+
+    #[test]
+    fn plain_c_inserts_into_composer() {
+        let state = empty_state();
+        assert_eq!(
+            map_key_action(&state, press(KeyCode::Char('c'))),
+            MappedKey::Insert('c')
+        );
+    }
+
+    #[test]
+    fn ctrl_c_exits() {
+        let state = empty_state();
+        assert_eq!(
+            map_key_action(&state, ctrl(KeyCode::Char('c'))),
+            MappedKey::Exit
+        );
+    }
+
+    #[test]
+    fn lost_connection_offers_retry() {
+        let mut state = empty_state();
+        state.connection_issue = Some(ConnectionIssue::Lost);
+        state.composer_enabled = false;
+        assert_eq!(
+            map_key_action(&state, press(KeyCode::Char('r'))),
+            MappedKey::Retry
+        );
+        assert_eq!(
+            map_key_action(&state, press(KeyCode::Char('q'))),
+            MappedKey::Exit
+        );
+    }
+
+    #[test]
+    fn highlight_detail_emits_colored_spans() {
+        let syntax_set = SyntaxSet::load_defaults_newlines();
+        let theme_set = ThemeSet::load_defaults();
+        let theme = theme_set
+            .themes
+            .get("base16-ocean.dark")
+            .or_else(|| theme_set.themes.values().next())
+            .unwrap();
+        let lines = highlight_detail(&syntax_set, theme, "@@ -1 +1 @@\n-old\n+new\n");
+        assert!(!lines.is_empty());
+        let has_rgb = lines.iter().any(|line| {
+            line.spans
+                .iter()
+                .any(|span| matches!(span.style.fg, Some(Color::Rgb(_, _, _))))
+        });
+        assert!(has_rgb, "expected RGB-styled spans from syntect");
+    }
+
+    #[test]
+    fn apply_replace_from_updates_in_place() {
+        let mut state = empty_state();
+        state.events.push(AgentEvent::User {
+            at_millis: 1,
+            text: "hi".into(),
+            images: vec![],
+        });
+        state.events.push(AgentEvent::Assistant {
+            at_millis: 2,
+            text: "hel".into(),
+            stream: true,
+        });
+        apply_subscribe_message(
+            &mut state,
+            SubscribeMessage::Batch(crate::mcp::SubscribeBatch {
+                subscription_id: "s".into(),
+                task_id: "t".into(),
+                events: vec![json!({
+                    "type": "assistant",
+                    "atMillis": 2,
+                    "text": "hello",
+                    "stream": true
+                })],
+                replace_from: Some(1),
+                done: false,
+                error: None,
+            }),
+        );
+        assert_eq!(state.events.len(), 2);
+        match &state.events[1] {
+            AgentEvent::Assistant { text, .. } => assert_eq!(text, "hello"),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn toggle_expand_uses_coalesced_display_index() {
+        let mut state = empty_state();
+        // Two streamed assistant deltas coalesce to one display bubble; tool follows.
+        state.events.push(AgentEvent::Assistant {
+            at_millis: 1,
+            text: "hel".into(),
+            stream: true,
+        });
+        state.events.push(AgentEvent::Assistant {
+            at_millis: 2,
+            text: "lo".into(),
+            stream: true,
+        });
+        state.events.push(AgentEvent::Tool {
+            at_millis: 3,
+            tool_name: "edit".into(),
+            tool_call_id: "1".into(),
+            summary: "patch".into(),
+            detail: "@@ -1 +1 @@\n-old\n+new\n".into(),
+            kind: String::new(),
+            state: "completed".into(),
+            locations: vec![],
+        });
+
+        let display = AgentEvent::coalesce_for_display(&state.events);
+        assert_eq!(display.len(), 2, "assistant deltas should coalesce");
+        let raw_tool_idx = 2;
+        let display_tool_idx = 1;
+        assert!(matches!(display[display_tool_idx], AgentEvent::Tool { .. }));
+
+        toggle_last_tool_expand(&mut state);
+        assert!(
+            state.expanded_tools.contains(&display_tool_idx),
+            "expand set should use display index {display_tool_idx}"
+        );
+        assert!(
+            !state.expanded_tools.contains(&raw_tool_idx),
+            "must not store the raw events index"
+        );
+    }
+
+    #[test]
+    fn stop_without_task_result_reaches_done_on_subscribe_end() {
+        let mut state = empty_state();
+        state.status = "Stopping".into();
+        apply_subscribe_message(
+            &mut state,
+            SubscribeMessage::Batch(crate::mcp::SubscribeBatch {
+                subscription_id: "s".into(),
+                task_id: "t".into(),
+                events: vec![],
+                replace_from: None,
+                done: true,
+                error: None,
+            }),
+        );
+        // done batch alone does not promote — Finished reason distinguishes Done vs Error.
+        assert_eq!(state.status, "Stopping");
+        assert!(!state.subscribe_open);
+
+        apply_subscribe_message(
+            &mut state,
+            SubscribeMessage::Finished {
+                reason: "terminal".into(),
+            },
+        );
+        assert_eq!(state.status, "Done");
+        assert!(state.composer_enabled);
+    }
+
+    #[test]
+    fn finished_error_disables_composer_without_task_result() {
+        let mut state = empty_state();
+        state.status = "Working".into();
+        apply_subscribe_message(
+            &mut state,
+            SubscribeMessage::Finished {
+                reason: "error".into(),
+            },
+        );
+        assert!(!state.subscribe_open);
+        assert!(!state.composer_enabled);
+        assert_eq!(state.status, "Error");
+    }
+
+    #[test]
+    fn apply_stop_success_prefers_daemon_status() {
+        let mut state = empty_state();
+        state.status = "Stopping".into();
+        apply_stop_success(&mut state, Some("Done".into()));
+        assert_eq!(state.status, "Done");
+        assert_eq!(state.status_flash.as_deref(), Some("stopped"));
+
+        let mut state = empty_state();
+        state.status = "Stopping".into();
+        apply_stop_success(&mut state, None);
+        assert_eq!(state.status, "Done");
+    }
+}

--- a/cli/andy/src/acp_view.rs
+++ b/cli/andy/src/acp_view.rs
@@ -530,13 +530,9 @@ fn map_key_action(state: &ViewState, key: KeyEvent) -> MappedKey {
         KeyCode::Char('q') if state.input.is_empty() && modifiers_allow_typing(key.modifiers) => {
             MappedKey::Exit
         }
-        KeyCode::Char('s') if state.input.is_empty() && modifiers_allow_typing(key.modifiers) => {
-            MappedKey::Stop
-        }
+        KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => MappedKey::Stop,
         KeyCode::Char('i')
-            if state.input.is_empty()
-                && state.composer_enabled
-                && modifiers_allow_typing(key.modifiers) =>
+            if key.modifiers.contains(KeyModifiers::CONTROL) && state.composer_enabled =>
         {
             MappedKey::PickImage
         }
@@ -584,25 +580,34 @@ async fn respond_permission(
 }
 
 fn pick_permission_label(options: &[(String, String)], choice: PermissionChoice) -> Option<String> {
-    let needle: &[&str] = match choice {
-        PermissionChoice::Yes => &["allow_once", "allow once", "allow"],
+    let ranked_needles: &[&str] = match choice {
+        PermissionChoice::Yes => &["allow_once", "allow once"],
         PermissionChoice::No => &["reject_once", "reject once", "reject", "deny"],
         PermissionChoice::Always => &["allow_always", "allow always", "always"],
     };
-    for (label, description) in options {
-        let blob = format!("{label} {description}").to_lowercase();
-        if needle.iter().any(|n| blob.contains(n)) {
-            return Some(label.clone());
+    for needle in ranked_needles {
+        for (label, description) in options {
+            let blob = format!("{label} {description}").to_lowercase();
+            if blob.contains(needle) {
+                return Some(label.clone());
+            }
         }
     }
     match choice {
-        PermissionChoice::Yes => options.first().map(|(l, _)| l.clone()),
-        PermissionChoice::No => options.last().map(|(l, _)| l.clone()),
+        PermissionChoice::Yes => options
+            .iter()
+            .find(|(label, description)| {
+                let blob = format!("{label} {description}").to_lowercase();
+                blob.contains("allow") && !blob.contains("always")
+            })
+            .map(|(label, _)| label.clone())
+            .or_else(|| options.first().map(|(label, _)| label.clone())),
+        PermissionChoice::No => options.last().map(|(label, _)| label.clone()),
         PermissionChoice::Always => options
             .iter()
-            .find(|(_, d)| d.to_lowercase().contains("always"))
-            .map(|(l, _)| l.clone())
-            .or_else(|| options.first().map(|(l, _)| l.clone())),
+            .find(|(_, description)| description.to_lowercase().contains("always"))
+            .map(|(label, _)| label.clone())
+            .or_else(|| options.first().map(|(label, _)| label.clone())),
     }
 }
 
@@ -1255,6 +1260,48 @@ mod tests {
         assert_eq!(
             map_key_action(&state, press(KeyCode::Char('c'))),
             MappedKey::Insert('c')
+        );
+    }
+
+    #[test]
+    fn plain_s_and_i_insert_into_composer() {
+        let state = empty_state();
+        assert_eq!(
+            map_key_action(&state, press(KeyCode::Char('s'))),
+            MappedKey::Insert('s')
+        );
+        assert_eq!(
+            map_key_action(&state, press(KeyCode::Char('i'))),
+            MappedKey::Insert('i')
+        );
+    }
+
+    #[test]
+    fn ctrl_s_stops_and_ctrl_i_picks_image() {
+        let state = empty_state();
+        assert_eq!(
+            map_key_action(&state, ctrl(KeyCode::Char('s'))),
+            MappedKey::Stop
+        );
+        assert_eq!(
+            map_key_action(&state, ctrl(KeyCode::Char('i'))),
+            MappedKey::PickImage
+        );
+    }
+
+    #[test]
+    fn permission_yes_prefers_allow_once_over_allow_always() {
+        let options = vec![
+            ("Allow always".into(), "allow_always".into()),
+            ("Allow once".into(), "allow_once".into()),
+        ];
+        assert_eq!(
+            pick_permission_label(&options, PermissionChoice::Yes).as_deref(),
+            Some("Allow once")
+        );
+        assert_eq!(
+            pick_permission_label(&options, PermissionChoice::Always).as_deref(),
+            Some("Allow always")
         );
     }
 

--- a/cli/andy/src/args.rs
+++ b/cli/andy/src/args.rs
@@ -10,8 +10,8 @@ pub fn merge_tool_args(
 ) -> Result<Value> {
     let mut map = base;
     if let Some(raw) = json_args {
-        let parsed: Value = serde_json::from_str(raw)
-            .map_err(|e| anyhow::anyhow!("invalid --json-args: {e}"))?;
+        let parsed: Value =
+            serde_json::from_str(raw).map_err(|e| anyhow::anyhow!("invalid --json-args: {e}"))?;
         let Value::Object(obj) = parsed else {
             bail!("--json-args must be a JSON object");
         };

--- a/cli/andy/src/attach.rs
+++ b/cli/andy/src/attach.rs
@@ -3,25 +3,34 @@ use serde_json::{json, Value};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
+use crate::acp_view;
 use crate::mcp::McpClient;
 use crate::tmux;
 
 const SESSION_WAIT: Duration = Duration::from_secs(60);
 const POLL_INTERVAL: Duration = Duration::from_millis(400);
 
-/// Attach to a live tmux session.
+/// Attach to a chat — ACP lane opens the native viewer; Terminal lane uses tmux
+/// with the same header/status/hotkey chrome framing.
 ///
-/// For a freshly started chat, waits for the session to appear. If it never does,
-/// tries quiet provider reattach (ended chats) before failing.
+/// For a freshly started Terminal chat, waits for the session to appear. If it
+/// never does, tries quiet provider reattach (ended chats) before failing.
 pub async fn attach_or_reattach(client: &mut McpClient, task_id: &str) -> Result<()> {
+    let lane = acp_view::resolve_lane(client, task_id).await?;
+    if lane.eq_ignore_ascii_case("Acp") {
+        return acp_view::run_acp_viewer(client, task_id).await;
+    }
+
+    let (title, status) = load_terminal_chrome(client, task_id).await;
+
     if tmux::has_session(task_id) && !tmux::session_looks_broken(task_id) {
-        return tmux::attach(task_id);
+        return tmux::attach(task_id, &title, &status);
     }
 
     // New starts are Queued briefly before tmux exists — wait first.
     match wait_for_tmux(client, task_id, AbortOnTerminalStatus::Yes).await? {
         WaitOutcome::Ready if !tmux::session_looks_broken(task_id) => {
-            return tmux::attach(task_id);
+            return tmux::attach(task_id, &title, &status);
         }
         WaitOutcome::Ready | WaitOutcome::TimedOut | WaitOutcome::TerminalStatus => {}
     }
@@ -47,7 +56,7 @@ pub async fn attach_or_reattach(client: &mut McpClient, task_id: &str) -> Result
                 .context("chat.resume after reattach failure")?;
             match wait_for_tmux(client, task_id, AbortOnTerminalStatus::No).await? {
                 WaitOutcome::Ready if !tmux::session_looks_broken(task_id) => {
-                    return tmux::attach(task_id);
+                    return tmux::attach(task_id, &title, &status);
                 }
                 WaitOutcome::Ready | WaitOutcome::TimedOut | WaitOutcome::TerminalStatus => {}
             }
@@ -79,7 +88,37 @@ pub async fn attach_or_reattach(client: &mut McpClient, task_id: &str) -> Result
         );
     }
 
-    tmux::attach(task_id)
+    let (title, status) = load_terminal_chrome(client, task_id).await;
+    tmux::attach(task_id, &title, &status)
+}
+
+async fn load_terminal_chrome(client: &mut McpClient, task_id: &str) -> (String, String) {
+    let status_raw = client
+        .call_tool("chat.status", json!({ "taskId": task_id }))
+        .await
+        .unwrap_or_default();
+    let status_v: Value = serde_json::from_str(&status_raw).unwrap_or(Value::Null);
+    let list_raw = client
+        .call_tool("chat.list", Value::Object(Default::default()))
+        .await
+        .unwrap_or_else(|_| "[]".into());
+    let list: Value = serde_json::from_str(&list_raw).unwrap_or(Value::Null);
+    let row = list.as_array().and_then(|arr| {
+        arr.iter()
+            .find(|e| e.get("id").and_then(|id| id.as_str()) == Some(task_id))
+    });
+    let title = row
+        .and_then(|r| r.get("title"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(task_id)
+        .to_string();
+    let status = status_v
+        .get("status")
+        .or_else(|| status_v.get("taskStatus"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("Attached")
+        .to_string();
+    (title, status)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/cli/andy/src/chats.rs
+++ b/cli/andy/src/chats.rs
@@ -41,7 +41,11 @@ pub fn parse_chats(raw: &str) -> Vec<ChatRow> {
                 return None;
             }
             // CLI never shows archived chats (still present in --json raw payload).
-            if el.get("archived").and_then(|v| v.as_bool()).unwrap_or(false) {
+            if el
+                .get("archived")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
                 return None;
             }
             Some(ChatRow {

--- a/cli/andy/src/compose.rs
+++ b/cli/andy/src/compose.rs
@@ -3,9 +3,11 @@ use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 use serde_json::{json, Value};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::attach;
+use crate::file_picker;
 use crate::mcp::McpClient;
 
 #[derive(Clone, Debug)]
@@ -41,6 +43,7 @@ pub struct ComposeDraft {
     project_label: String,
     directory: String,
     prompt: String,
+    image_paths: Vec<String>,
 }
 
 enum StepView {
@@ -103,6 +106,7 @@ pub async fn run_composer(
         project_label,
         directory: project_dir,
         prompt: String::new(),
+        image_paths: Vec::new(),
     };
 
     let mut step = Step::Agent;
@@ -186,13 +190,29 @@ pub async fn run_composer(
                     frame.render_widget(body, chunks[1]);
                 }
                 StepView::Confirm => {
+                    let images = if draft.image_paths.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        draft
+                            .image_paths
+                            .iter()
+                            .map(|p| {
+                                PathBuf::from(p)
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().into_owned())
+                                    .unwrap_or_else(|| p.clone())
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
                     let summary = format!(
-                        "Provider:  {}\nModel:     {}\nAutonomy:  {}\nProject:   {}\nDirectory: {}\n\nPrompt:\n{}",
+                        "Provider:  {}\nModel:     {}\nAutonomy:  {}\nProject:   {}\nDirectory: {}\nImages:    {}\n\nPrompt:\n{}",
                         draft.agent_label,
                         draft.model_label,
                         draft.autonomy_label,
                         draft.project_label,
                         draft.directory,
+                        images,
                         draft.prompt
                     );
                     let body = Paragraph::new(summary)
@@ -240,17 +260,43 @@ pub async fn run_composer(
                     value.pop();
                 }
             }
+            KeyCode::Char('a') if step == Step::Confirm => {
+                match start_and_attach(client, terminal, &draft, &mut status).await {
+                    Ok(outcome) => return Ok(Some(outcome)),
+                    Err(err) => status = format!("error: {err:#}"),
+                }
+            }
+            KeyCode::Char('i')
+                if step == Step::Prompt
+                    && matches!(&view, StepView::Text { value, .. } if value.is_empty())
+                    || step == Step::Confirm =>
+            {
+                // Empty prompt (or Confirm): open image picker. Typing 'i' still works once text exists.
+                let start = if !draft.directory.trim().is_empty() {
+                    PathBuf::from(draft.directory.trim())
+                } else {
+                    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+                };
+                match file_picker::pick_image(terminal, start) {
+                    Ok(Some(path)) => {
+                        draft.image_paths.push(path.display().to_string());
+                        status = format!(
+                            "attached {} image(s) · i attach another · Enter confirm",
+                            draft.image_paths.len()
+                        );
+                        if let StepView::Text { hint, .. } = &mut view {
+                            *hint = prompt_hint(&draft);
+                        }
+                    }
+                    Ok(None) => status = "image attach cancelled".into(),
+                    Err(err) => status = format!("image picker error: {err:#}"),
+                }
+            }
             KeyCode::Char(c) if matches!(view, StepView::Text { .. }) => {
                 if let StepView::Text { value, .. } = &mut view {
                     if !c.is_control() {
                         value.push(c);
                     }
-                }
-            }
-            KeyCode::Char('a') if step == Step::Confirm => {
-                match start_and_attach(client, terminal, &draft, &mut status).await {
-                    Ok(outcome) => return Ok(Some(outcome)),
-                    Err(err) => status = format!("error: {err:#}"),
                 }
             }
             KeyCode::Enter => match step {
@@ -315,7 +361,10 @@ async fn load_catalog(client: &mut McpClient) -> Result<Catalog> {
     let projects = parse_rows(v.get("projects"), /*with_directory*/ true);
     Ok(Catalog {
         agents,
-        models: v.get("models").cloned().unwrap_or(Value::Object(Default::default())),
+        models: v
+            .get("models")
+            .cloned()
+            .unwrap_or(Value::Object(Default::default())),
         autonomies,
         projects,
     })
@@ -438,7 +487,11 @@ fn pick_view(title: &str, rows: Vec<OptionRow>, selected: usize) -> StepView {
 
 fn view_for_step(step: Step, catalog: &Catalog, draft: &ComposeDraft) -> StepView {
     match step {
-        Step::Agent => pick_view("Provider", catalog.agents.clone(), preferred_index(&catalog.agents)),
+        Step::Agent => pick_view(
+            "Provider",
+            catalog.agents.clone(),
+            preferred_index(&catalog.agents),
+        ),
         Step::Model => {
             let rows = models_for(catalog, &draft.agent_id);
             pick_view("Model", rows, 0)
@@ -467,9 +520,28 @@ fn view_for_step(step: Step, catalog: &Catalog, draft: &ComposeDraft) -> StepVie
         Step::Prompt => StepView::Text {
             title: "Prompt".into(),
             value: draft.prompt.clone(),
-            hint: "type prompt · Enter confirm · Esc back".into(),
+            hint: prompt_hint(draft),
         },
         Step::Confirm => StepView::Confirm,
+    }
+}
+
+fn prompt_hint(draft: &ComposeDraft) -> String {
+    if draft.image_paths.is_empty() {
+        "type prompt · i attach image · Enter confirm · Esc back".into()
+    } else {
+        let names = draft
+            .image_paths
+            .iter()
+            .map(|p| {
+                PathBuf::from(p)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| p.clone())
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("images: {names} · i attach another · Enter confirm · Esc back")
     }
 }
 
@@ -548,14 +620,18 @@ fn step_label(step: Step) -> &'static str {
 fn step_status(step: Step) -> String {
     match step {
         Step::Confirm => "Enter / a  start + attach · Esc back".into(),
-        Step::Directory | Step::Prompt => "type · Enter next · Esc back".into(),
+        Step::Prompt => "type · i attach image · Enter next · Esc back".into(),
+        Step::Directory => "type · Enter next · Esc back".into(),
         _ => "↑↓ select · Enter next · Esc back".into(),
     }
 }
 
 fn move_pick(view: &mut StepView, delta: isize) {
     let StepView::Pick {
-        rows, selected, list_state, ..
+        rows,
+        selected,
+        list_state,
+        ..
     } = view
     else {
         return;
@@ -615,6 +691,9 @@ async fn start_chat(client: &mut McpClient, draft: &ComposeDraft) -> Result<Stri
     }
     if !draft.directory.trim().is_empty() {
         args["directory"] = json!(draft.directory.trim());
+    }
+    if !draft.image_paths.is_empty() {
+        args["imagePaths"] = json!(draft.image_paths);
     }
     let raw = client.call_tool("chat.start", args).await?;
     let v: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);

--- a/cli/andy/src/events.rs
+++ b/cli/andy/src/events.rs
@@ -1,0 +1,439 @@
+use serde_json::Value;
+
+/// Wire-format agent transcript event (mirrors Kotlin `AgentEvent.toWire()`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentEvent {
+    Session {
+        at_millis: i64,
+        session_id: String,
+        model: String,
+    },
+    User {
+        at_millis: i64,
+        text: String,
+        images: Vec<String>,
+    },
+    Assistant {
+        at_millis: i64,
+        text: String,
+        stream: bool,
+    },
+    Thinking {
+        at_millis: i64,
+        text: String,
+        stream: bool,
+    },
+    Tool {
+        at_millis: i64,
+        tool_name: String,
+        tool_call_id: String,
+        summary: String,
+        detail: String,
+        kind: String,
+        state: String,
+        locations: Vec<String>,
+    },
+    ToolResult {
+        at_millis: i64,
+        tool_name: String,
+        summary: String,
+        detail: String,
+        is_error: bool,
+    },
+    Error {
+        at_millis: i64,
+        text: String,
+    },
+    Result {
+        at_millis: i64,
+        success: bool,
+        final_text: String,
+    },
+    Usage {
+        at_millis: i64,
+        used_tokens: i64,
+        window_tokens: i64,
+    },
+    Plan {
+        at_millis: i64,
+        entries: Vec<(String, String)>,
+        markdown: Option<String>,
+    },
+    Mode {
+        at_millis: i64,
+        mode_id: String,
+    },
+    Commands {
+        at_millis: i64,
+        commands: Vec<(String, String)>,
+    },
+    Modes {
+        at_millis: i64,
+        current_mode_id: String,
+        modes: Vec<(String, String)>,
+    },
+    Permission {
+        at_millis: i64,
+        request_id: String,
+        tool_name: String,
+        question: String,
+        options: Vec<(String, String)>,
+    },
+    PermissionResolved {
+        at_millis: i64,
+        request_id: String,
+        option_id: String,
+        allowed: bool,
+        note: Option<String>,
+    },
+    Raw {
+        at_millis: i64,
+        line: String,
+    },
+    Unknown {
+        at_millis: i64,
+        raw: Value,
+    },
+}
+
+impl AgentEvent {
+    pub fn from_wire(value: &Value) -> Self {
+        let at = value.get("atMillis").and_then(|v| v.as_i64()).unwrap_or(0);
+        let ty = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        match ty {
+            "session" => Self::Session {
+                at_millis: at,
+                session_id: string_field(value, "sessionId"),
+                model: string_field(value, "model"),
+            },
+            "user" => Self::User {
+                at_millis: at,
+                text: string_field(value, "text"),
+                images: string_array(value, "images"),
+            },
+            "assistant" => Self::Assistant {
+                at_millis: at,
+                text: string_field(value, "text"),
+                stream: value
+                    .get("stream")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            },
+            "thinking" => Self::Thinking {
+                at_millis: at,
+                text: string_field(value, "text"),
+                stream: value
+                    .get("stream")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            },
+            "tool" => Self::Tool {
+                at_millis: at,
+                tool_name: string_field(value, "toolName"),
+                tool_call_id: string_field(value, "toolCallId"),
+                summary: string_field(value, "summary"),
+                detail: string_field(value, "detail"),
+                kind: string_field(value, "kind"),
+                state: string_field(value, "state"),
+                locations: string_array(value, "locations"),
+            },
+            "tool-result" => Self::ToolResult {
+                at_millis: at,
+                tool_name: string_field(value, "toolName"),
+                summary: string_field(value, "summary"),
+                detail: string_field(value, "detail"),
+                is_error: value
+                    .get("isError")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            },
+            "error" => Self::Error {
+                at_millis: at,
+                text: string_field(value, "text"),
+            },
+            "result" => Self::Result {
+                at_millis: at,
+                success: value
+                    .get("success")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                final_text: string_field(value, "finalText"),
+            },
+            "usage" => Self::Usage {
+                at_millis: at,
+                used_tokens: value
+                    .get("usedTokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0),
+                window_tokens: value
+                    .get("windowTokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0),
+            },
+            "plan" => Self::Plan {
+                at_millis: at,
+                entries: value
+                    .get("entries")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|e| (string_field(e, "content"), string_field(e, "status")))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                markdown: value
+                    .get("markdown")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            },
+            "mode" => Self::Mode {
+                at_millis: at,
+                mode_id: string_field(value, "modeId"),
+            },
+            "commands" => Self::Commands {
+                at_millis: at,
+                commands: value
+                    .get("commands")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|e| (string_field(e, "name"), string_field(e, "description")))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            },
+            "modes" => Self::Modes {
+                at_millis: at,
+                current_mode_id: string_field(value, "currentModeId"),
+                modes: value
+                    .get("modes")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|e| (string_field(e, "id"), string_field(e, "name")))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            },
+            "permission" => Self::Permission {
+                at_millis: at,
+                request_id: string_field(value, "requestId"),
+                tool_name: string_field(value, "toolName"),
+                question: string_field(value, "question"),
+                options: value
+                    .get("options")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|e| (string_field(e, "label"), string_field(e, "description")))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            },
+            "permission-resolved" => Self::PermissionResolved {
+                at_millis: at,
+                request_id: string_field(value, "requestId"),
+                option_id: string_field(value, "optionId"),
+                allowed: value
+                    .get("allowed")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                note: value
+                    .get("note")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            },
+            "raw" => Self::Raw {
+                at_millis: at,
+                line: string_field(value, "line"),
+            },
+            _ => Self::Unknown {
+                at_millis: at,
+                raw: value.clone(),
+            },
+        }
+    }
+
+    pub fn parse_list(raw: &str) -> Vec<Self> {
+        let Ok(Value::Array(arr)) = serde_json::from_str::<Value>(raw) else {
+            return Vec::new();
+        };
+        arr.iter().map(Self::from_wire).collect()
+    }
+
+    /// Merge streamed assistant/thinking deltas into a display-friendly list.
+    pub fn coalesce_for_display(events: &[Self]) -> Vec<Self> {
+        let mut out: Vec<Self> = Vec::new();
+        for event in events {
+            match (out.last_mut(), event) {
+                (
+                    Some(Self::Assistant {
+                        text,
+                        stream: prev_stream,
+                        ..
+                    }),
+                    Self::Assistant {
+                        text: next,
+                        stream: true,
+                        at_millis,
+                        ..
+                    },
+                ) if *prev_stream => {
+                    // Only coalesce into a prior stream bubble — a completed (non-stream)
+                    // assistant event is a barrier, matching GUI coalesceAgentStreamDeltas.
+                    text.push_str(next);
+                    *prev_stream = true;
+                    let _ = at_millis;
+                }
+                (
+                    Some(Self::Thinking {
+                        text,
+                        stream: prev_stream,
+                        ..
+                    }),
+                    Self::Thinking {
+                        text: next,
+                        stream: true,
+                        ..
+                    },
+                ) if *prev_stream => {
+                    text.push_str(next);
+                    *prev_stream = true;
+                }
+                _ => out.push(event.clone()),
+            }
+        }
+        out
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn string_array(value: &Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_each_event_type() {
+        let samples = vec![
+            json!({"type":"session","atMillis":1,"sessionId":"s","model":"m"}),
+            json!({"type":"user","atMillis":2,"text":"hi","images":["/a.png"]}),
+            json!({"type":"assistant","atMillis":3,"text":"yo","stream":true}),
+            json!({"type":"thinking","atMillis":4,"text":"...","stream":false}),
+            json!({"type":"tool","atMillis":5,"toolName":"Bash","toolCallId":"1","summary":"run","detail":"ls","kind":"Execute","state":"Completed","locations":[]}),
+            json!({"type":"tool-result","atMillis":6,"toolName":"Bash","summary":"ok","detail":"out","isError":false}),
+            json!({"type":"error","atMillis":7,"text":"boom"}),
+            json!({"type":"result","atMillis":8,"success":true,"finalText":"done"}),
+            json!({"type":"usage","atMillis":9,"usedTokens":1,"windowTokens":2}),
+            json!({"type":"plan","atMillis":10,"entries":[{"content":"a","status":"pending"}],"markdown":"# p"}),
+            json!({"type":"mode","atMillis":11,"modeId":"plan"}),
+            json!({"type":"commands","atMillis":12,"commands":[{"name":"x","description":"d","inputHint":""}]}),
+            json!({"type":"modes","atMillis":13,"currentModeId":"c","modes":[{"id":"c","name":"C","description":""}]}),
+            json!({"type":"permission","atMillis":14,"requestId":"r","toolName":"Edit","question":"ok?","options":[{"label":"Allow","description":"allow_once · 1"}]}),
+            json!({"type":"permission-resolved","atMillis":15,"requestId":"r","optionId":"1","allowed":true,"note":"n"}),
+            json!({"type":"raw","atMillis":16,"line":"x"}),
+        ];
+        for sample in samples {
+            let parsed = AgentEvent::from_wire(&sample);
+            assert!(
+                !matches!(parsed, AgentEvent::Unknown { .. }),
+                "failed to parse {sample}"
+            );
+        }
+    }
+
+    #[test]
+    fn coalesce_streams_assistant_deltas() {
+        let events = vec![
+            AgentEvent::Assistant {
+                at_millis: 1,
+                text: "Hel".into(),
+                stream: true,
+            },
+            AgentEvent::Assistant {
+                at_millis: 2,
+                text: "lo".into(),
+                stream: true,
+            },
+        ];
+        let coalesced = AgentEvent::coalesce_for_display(&events);
+        assert_eq!(coalesced.len(), 1);
+        match &coalesced[0] {
+            AgentEvent::Assistant { text, .. } => assert_eq!(text, "Hello"),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coalesce_does_not_merge_stream_onto_non_stream_assistant() {
+        let events = vec![
+            AgentEvent::Assistant {
+                at_millis: 1,
+                text: "complete".into(),
+                stream: false,
+            },
+            AgentEvent::Assistant {
+                at_millis: 2,
+                text: "next".into(),
+                stream: true,
+            },
+        ];
+        let coalesced = AgentEvent::coalesce_for_display(&events);
+        assert_eq!(coalesced.len(), 2);
+        match (&coalesced[0], &coalesced[1]) {
+            (
+                AgentEvent::Assistant {
+                    text: a,
+                    stream: false,
+                    ..
+                },
+                AgentEvent::Assistant {
+                    text: b,
+                    stream: true,
+                    ..
+                },
+            ) => {
+                assert_eq!(a, "complete");
+                assert_eq!(b, "next");
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coalesce_does_not_merge_stream_onto_non_stream_thinking() {
+        let events = vec![
+            AgentEvent::Thinking {
+                at_millis: 1,
+                text: "done thinking".into(),
+                stream: false,
+            },
+            AgentEvent::Thinking {
+                at_millis: 2,
+                text: "more".into(),
+                stream: true,
+            },
+        ];
+        let coalesced = AgentEvent::coalesce_for_display(&events);
+        assert_eq!(coalesced.len(), 2);
+    }
+}

--- a/cli/andy/src/file_picker.rs
+++ b/cli/andy/src/file_picker.rs
@@ -1,0 +1,230 @@
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::ExecutableCommand;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use std::fs;
+use std::io::stdout;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp"];
+
+#[derive(Debug, Clone)]
+pub struct DirEntry {
+    pub name: String,
+    pub path: PathBuf,
+    pub is_dir: bool,
+}
+
+/// Pure listing/filter helpers — unit-tested without a TUI.
+pub fn is_image_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| {
+            IMAGE_EXTENSIONS
+                .iter()
+                .any(|ext| e.eq_ignore_ascii_case(ext))
+        })
+        .unwrap_or(false)
+}
+
+pub fn list_picker_entries(dir: &Path) -> Result<Vec<DirEntry>> {
+    let mut dirs = Vec::new();
+    let mut files = Vec::new();
+    let read = fs::read_dir(dir)?;
+    for entry in read.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let is_dir = path.is_dir();
+        if is_dir {
+            dirs.push(DirEntry {
+                name,
+                path,
+                is_dir: true,
+            });
+        } else if is_image_path(&path) {
+            files.push(DirEntry {
+                name,
+                path,
+                is_dir: false,
+            });
+        }
+    }
+    dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    let mut out = dirs;
+    out.extend(files);
+    Ok(out)
+}
+
+/// Standalone picker for non-TUI entry points (e.g. `andy chat start --pick-image`).
+/// Enters/leaves the alternate screen around [pick_image].
+pub fn pick_image_standalone(start_dir: impl AsRef<Path>) -> Result<Option<PathBuf>> {
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    let result = pick_image(&mut terminal, start_dir);
+    let _ = disable_raw_mode();
+    let _ = stdout().execute(LeaveAlternateScreen);
+    let _ = terminal.show_cursor();
+    result
+}
+
+/// Modal filesystem browser that returns one absolute image path, or `None` if cancelled.
+pub fn pick_image(
+    terminal: &mut Terminal<impl Backend>,
+    start_dir: impl AsRef<Path>,
+) -> Result<Option<PathBuf>> {
+    let mut cwd = start_dir.as_ref().to_path_buf();
+    if !cwd.is_dir() {
+        cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    }
+    let mut selected: usize = 0;
+    let mut list_state = ListState::default();
+    list_state.select(Some(0));
+
+    loop {
+        let entries = list_picker_entries(&cwd).unwrap_or_default();
+        if selected >= entries.len() && !entries.is_empty() {
+            selected = entries.len() - 1;
+        }
+        if entries.is_empty() {
+            selected = 0;
+        }
+        list_state.select(if entries.is_empty() {
+            None
+        } else {
+            Some(selected)
+        });
+
+        terminal.draw(|frame| {
+            let area = frame.area();
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(3),
+                    Constraint::Min(3),
+                    Constraint::Length(2),
+                ])
+                .split(area);
+
+            frame.render_widget(
+                Paragraph::new(format!(" Attach image · {}", cwd.display())).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Image picker "),
+                ),
+                chunks[0],
+            );
+
+            let items: Vec<ListItem> = if entries.is_empty() {
+                vec![ListItem::new(" (no images or folders here) ")]
+            } else {
+                entries
+                    .iter()
+                    .map(|e| {
+                        let prefix = if e.is_dir { "[dir] " } else { "[img] " };
+                        ListItem::new(format!("{prefix}{}", e.name))
+                    })
+                    .collect()
+            };
+            frame.render_stateful_widget(
+                List::new(items)
+                    .block(Block::default().borders(Borders::ALL))
+                    .highlight_style(Style::default().add_modifier(Modifier::REVERSED)),
+                chunks[1],
+                &mut list_state,
+            );
+            frame.render_widget(
+                Paragraph::new("Enter open/select · Backspace up · Esc cancel"),
+                chunks[2],
+            );
+        })?;
+
+        if !event::poll(Duration::from_millis(200))? {
+            continue;
+        }
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        match key.code {
+            KeyCode::Esc => return Ok(None),
+            KeyCode::Up | KeyCode::Char('k') => {
+                if !entries.is_empty() {
+                    selected = selected.saturating_sub(1);
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !entries.is_empty() {
+                    selected = (selected + 1).min(entries.len() - 1);
+                }
+            }
+            KeyCode::Backspace => {
+                if let Some(parent) = cwd.parent() {
+                    cwd = parent.to_path_buf();
+                    selected = 0;
+                }
+            }
+            KeyCode::Enter => {
+                if let Some(entry) = entries.get(selected) {
+                    if entry.is_dir {
+                        cwd = entry.path.clone();
+                        selected = 0;
+                    } else {
+                        return Ok(Some(
+                            entry.path.canonicalize().unwrap_or(entry.path.clone()),
+                        ));
+                    }
+                }
+            }
+            KeyCode::Char('.') => {
+                // Allow selecting `..` via a synthetic parent navigation.
+                if let Some(parent) = cwd.parent() {
+                    cwd = parent.to_path_buf();
+                    selected = 0;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn filters_to_images_and_dirs_sorted() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join("subdir")).unwrap();
+        fs::write(dir.path().join("a.png"), b"x").unwrap();
+        fs::write(dir.path().join("b.txt"), b"x").unwrap();
+        fs::write(dir.path().join("c.JPG"), b"x").unwrap();
+        fs::write(dir.path().join(".hidden.png"), b"x").unwrap();
+
+        let entries = list_picker_entries(dir.path()).unwrap();
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["subdir", "a.png", "c.JPG"]);
+        assert!(entries[0].is_dir);
+        assert!(!entries[1].is_dir);
+    }
+
+    #[test]
+    fn is_image_path_accepts_known_extensions() {
+        assert!(is_image_path(Path::new("/tmp/x.webp")));
+        assert!(is_image_path(Path::new("/tmp/x.GIF")));
+        assert!(!is_image_path(Path::new("/tmp/x.pdf")));
+    }
+}

--- a/cli/andy/src/lib.rs
+++ b/cli/andy/src/lib.rs
@@ -1,0 +1,18 @@
+//! Andy CLI library — shared by the `andy` binary and integration tests.
+
+pub mod acp_view;
+pub mod args;
+pub mod attach;
+pub mod chats;
+pub mod compose;
+pub mod daemon;
+pub mod device_cli;
+pub mod device_map;
+pub mod dispatch;
+pub mod events;
+pub mod file_picker;
+pub mod mcp;
+pub mod tmux;
+pub mod tool_cmd;
+pub mod tui;
+pub mod viewer_chrome;

--- a/cli/andy/src/main.rs
+++ b/cli/andy/src/main.rs
@@ -1,27 +1,19 @@
-mod args;
-mod attach;
-mod chats;
-mod compose;
-mod daemon;
-mod device_cli;
-mod device_map;
-mod dispatch;
-mod mcp;
-mod tmux;
-mod tool_cmd;
-mod tui;
-
+use andy_cli::attach;
+use andy_cli::chats;
+use andy_cli::daemon;
+use andy_cli::device_cli::{
+    self, AppCmd, AvdCmd, DeviceCmd, EmulatorCmd, FileCmd, InputCmd, IntentCmd, NetworkCmd,
+    SnapshotCmd, SystemImageCmd,
+};
+use andy_cli::file_picker;
+use andy_cli::mcp::{default_socket_path, McpClient};
+use andy_cli::tool_cmd::{self, ToolCmd};
+use andy_cli::tui;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use device_cli::{
-    AppCmd, AvdCmd, DeviceCmd, EmulatorCmd, FileCmd, InputCmd, IntentCmd, NetworkCmd, SnapshotCmd,
-    SystemImageCmd,
-};
-use mcp::{default_socket_path, McpClient};
 use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::process::Command;
-use tool_cmd::ToolCmd;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -105,13 +97,23 @@ enum ChatCmd {
         directory: Option<String>,
         #[arg(long)]
         title: Option<String>,
+        /// Attach image file(s) to the first user message (repeatable).
+        #[arg(long = "image", value_name = "PATH")]
+        images: Vec<PathBuf>,
+        /// Open the filesystem image picker before starting (can combine with --image).
+        #[arg(long)]
+        pick_image: bool,
         /// Print the MCP response and exit without attaching to tmux.
         #[arg(long)]
         no_attach: bool,
         prompt: String,
     },
-    Stop { task_id: String },
-    Status { task_id: String },
+    Stop {
+        task_id: String,
+    },
+    Status {
+        task_id: String,
+    },
     Resume {
         task_id: String,
         follow_up: String,
@@ -153,9 +155,23 @@ async fn main() -> Result<()> {
             project,
             directory,
             title,
+            images,
+            pick_image,
             no_attach,
             prompt,
         }) => {
+            let mut image_paths: Vec<String> = images
+                .into_iter()
+                .map(|p| p.canonicalize().unwrap_or(p).display().to_string())
+                .collect();
+            if pick_image {
+                let start = directory.as_ref().map(PathBuf::from).unwrap_or_else(|| {
+                    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+                });
+                if let Some(path) = file_picker::pick_image_standalone(start)? {
+                    image_paths.push(path.display().to_string());
+                }
+            }
             let mut args = json!({
                 "agent": agent,
                 "prompt": prompt,
@@ -168,6 +184,9 @@ async fn main() -> Result<()> {
             }
             if let Some(t) = title {
                 args["title"] = json!(t);
+            }
+            if !image_paths.is_empty() {
+                args["imagePaths"] = json!(image_paths);
             }
             let raw = client.call_tool("chat.start", args).await?;
             if no_attach {
@@ -199,10 +218,7 @@ async fn main() -> Result<()> {
                 .await?;
             println!("{raw}");
         }
-        Commands::Chat(ChatCmd::Resume {
-            task_id,
-            follow_up,
-        }) => {
+        Commands::Chat(ChatCmd::Resume { task_id, follow_up }) => {
             let raw = client
                 .call_tool(
                     "chat.resume",
@@ -241,7 +257,10 @@ async fn resolve_socket(cli: &Cli) -> Result<PathBuf> {
 
     // Always bind the forward to a fresh local path so an existing ~/.andy/andyd.sock
     // is never mistaken for the remote tunnel.
-    let local = PathBuf::from(format!("/tmp/andy-remote-local-{}.sock", std::process::id()));
+    let local = PathBuf::from(format!(
+        "/tmp/andy-remote-local-{}.sock",
+        std::process::id()
+    ));
     let _ = std::fs::remove_file(&local);
     let remote_path = "~/.andy/andyd.sock";
     let status = Command::new("ssh")

--- a/cli/andy/src/mcp.rs
+++ b/cli/andy/src/mcp.rs
@@ -3,6 +3,31 @@ use serde_json::{json, Value};
 use std::path::PathBuf;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+
+pub const CHAT_SUBSCRIBE_METHOD: &str = "notifications/andy/chat.events";
+
+pub const SUBSCRIBE_MISSING_ERROR: &str =
+    "andyd does not support the chat viewer yet (missing chat.subscribe) — restart Andy / update andyd, then retry.";
+
+#[derive(Debug, Clone)]
+pub struct SubscribeBatch {
+    pub subscription_id: String,
+    pub task_id: String,
+    pub events: Vec<Value>,
+    /// When set, replace the client's event list from this index with [events]
+    /// (ACP in-place coalescing keeps list size stable while mutating entries).
+    pub replace_from: Option<usize>,
+    pub done: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum SubscribeMessage {
+    Batch(SubscribeBatch),
+    Finished { reason: String },
+    Disconnected(String),
+}
 
 pub fn default_socket_path() -> PathBuf {
     crate::daemon::default_socket_path()
@@ -17,9 +42,7 @@ pub struct ToolInfo {
 
 impl ToolInfo {
     pub fn accepts_serial(&self) -> bool {
-        self.input_schema
-            .pointer("/properties/serial")
-            .is_some()
+        self.input_schema.pointer("/properties/serial").is_some()
     }
 }
 
@@ -94,10 +117,11 @@ pub struct McpClient {
 
 impl McpClient {
     pub fn new(socket: PathBuf) -> Self {
-        Self {
-            socket,
-            next_id: 1,
-        }
+        Self { socket, next_id: 1 }
+    }
+
+    pub fn socket_path(&self) -> PathBuf {
+        self.socket.clone()
     }
 
     /// Backward-compatible helper: returns concatenated text content.
@@ -174,6 +198,194 @@ impl McpClient {
                 })
             })
             .collect())
+    }
+
+    pub async fn requires_chat_subscribe(&mut self) -> Result<()> {
+        let tools = self.list_tools().await?;
+        if tools.iter().any(|t| t.name == "chat.subscribe") {
+            return Ok(());
+        }
+        bail!("{SUBSCRIBE_MISSING_ERROR}");
+    }
+
+    /// Opens a long-lived `chat.subscribe` session and streams batches on [tx].
+    ///
+    /// Drops when the receiver is closed or the daemon ends the subscription.
+    pub async fn subscribe_chat_events(
+        &mut self,
+        task_id: &str,
+        tx: mpsc::Sender<SubscribeMessage>,
+    ) -> Result<()> {
+        if !self.socket.exists() {
+            bail!(
+                "andyd socket not found at {} — could not start or connect to the daemon",
+                self.socket.display()
+            );
+        }
+        let stream = UnixStream::connect(&self.socket)
+            .await
+            .with_context(|| format!("connect {}", self.socket.display()))?;
+        let (reader, mut writer) = stream.into_split();
+        let mut lines = BufReader::new(reader).lines();
+
+        let init_id = self.next_id;
+        self.next_id += 1;
+        let init = json!({
+            "jsonrpc": "2.0",
+            "id": init_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "andy-cli", "version": "0.1.0" }
+            }
+        });
+        writer
+            .write_all(format!("{init}\n").as_bytes())
+            .await
+            .context("write initialize")?;
+        let _ = lines.next_line().await.context("read initialize result")?;
+
+        writer
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+            .await
+            .context("write initialized")?;
+
+        let call_id = self.next_id;
+        self.next_id += 1;
+        let call = json!({
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {
+                "name": "chat.subscribe",
+                "arguments": { "taskId": task_id }
+            }
+        });
+        writer
+            .write_all(format!("{call}\n").as_bytes())
+            .await
+            .context("write chat.subscribe")?;
+
+        loop {
+            let line = match lines.next_line().await {
+                Ok(Some(line)) => line,
+                Ok(None) => {
+                    let _ = tx
+                        .send(SubscribeMessage::Disconnected(
+                            "lost connection to andyd".into(),
+                        ))
+                        .await;
+                    break;
+                }
+                Err(err) => {
+                    let _ = tx
+                        .send(SubscribeMessage::Disconnected(format!(
+                            "lost connection to andyd: {err}"
+                        )))
+                        .await;
+                    break;
+                }
+            };
+            let root: Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            if root.get("id").and_then(|id| id.as_u64()) == Some(call_id)
+                || root.get("id").and_then(|id| id.as_i64()) == Some(call_id as i64)
+            {
+                if let Some(err) = root.get("error") {
+                    let msg = err
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("chat.subscribe failed");
+                    if msg.contains("Method not found") || msg.contains("tool not found") {
+                        bail!("{SUBSCRIBE_MISSING_ERROR}");
+                    }
+                    bail!("{msg}");
+                }
+                let result = root.get("result").cloned().unwrap_or(Value::Null);
+                let is_error = result
+                    .get("isError")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let text = ToolResult::parse_content(&result)
+                    .into_iter()
+                    .filter_map(|p| match p {
+                        ContentPart::Text(t) => Some(t),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if is_error {
+                    if text.contains("chat.subscribe") || text.contains("Method not found") {
+                        bail!("{SUBSCRIBE_MISSING_ERROR}");
+                    }
+                    bail!("{text}");
+                }
+                let reason = serde_json::from_str::<Value>(&text)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("reason")
+                            .and_then(|r| r.as_str())
+                            .map(|s| s.to_string())
+                    })
+                    .unwrap_or_else(|| "done".to_string());
+                let _ = tx.send(SubscribeMessage::Finished { reason }).await;
+                break;
+            }
+
+            let method = root.get("method").and_then(|m| m.as_str()).unwrap_or("");
+            if method != CHAT_SUBSCRIBE_METHOD {
+                continue;
+            }
+            let params = root.get("params").cloned().unwrap_or(Value::Null);
+            let meta = params
+                .get("_meta")
+                .or_else(|| params.get("meta"))
+                .cloned()
+                .unwrap_or(params);
+            let batch = SubscribeBatch {
+                subscription_id: meta
+                    .get("subscriptionId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                task_id: meta
+                    .get("taskId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(task_id)
+                    .to_string(),
+                events: meta
+                    .get("events")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default(),
+                replace_from: meta.get("replaceFrom").and_then(|v| {
+                    v.as_u64()
+                        .or_else(|| v.as_i64().map(|n| n as u64))
+                        .map(|n| n as usize)
+                }),
+                done: meta.get("done").and_then(|v| v.as_bool()).unwrap_or(false),
+                error: meta
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            };
+            if tx
+                .send(SubscribeMessage::Batch(batch.clone()))
+                .await
+                .is_err()
+            {
+                break;
+            }
+            if batch.done {
+                // Final tool result should follow; keep reading until id matches.
+                continue;
+            }
+        }
+        Ok(())
     }
 
     async fn rpc(&mut self, method: &str, params: Value) -> Result<Value> {

--- a/cli/andy/src/tmux.rs
+++ b/cli/andy/src/tmux.rs
@@ -2,6 +2,8 @@ use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+use crate::viewer_chrome;
+
 pub fn session_name(task_id: &str) -> String {
     format!("andy-task-{task_id}")
 }
@@ -28,11 +30,11 @@ fn tmux_binary() -> Result<String> {
 }
 
 fn which_tmux() -> Option<String> {
-    for dir in std::env::var("PATH")
-        .unwrap_or_default()
-        .split(':')
-        .chain(["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"].iter().copied())
-    {
+    for dir in std::env::var("PATH").unwrap_or_default().split(':').chain(
+        ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"]
+            .iter()
+            .copied(),
+    ) {
         let candidate = PathBuf::from(dir).join("tmux");
         if candidate.is_file() {
             return Some(candidate.display().to_string());
@@ -45,6 +47,21 @@ fn tmux_command(args: &[&str]) -> Result<Command> {
     let mut command = Command::new(tmux_binary()?);
     command.args(args);
     Ok(command)
+}
+
+/// Run a tmux command with null stdio; returns Err when the process fails to spawn
+/// or exits non-zero.
+pub fn run_tmux(args: &[&str]) -> Result<()> {
+    let status = tmux_command(args)?
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .with_context(|| format!("tmux {}", args.join(" ")))?;
+    if !status.success() {
+        bail!("tmux {} failed", args.join(" "));
+    }
+    Ok(())
 }
 
 pub fn has_session(task_id: &str) -> bool {
@@ -84,8 +101,7 @@ pub fn session_looks_broken(task_id: &str) -> bool {
         || (output.contains("getcwd") && output.contains("cannot access parent directories"))
 }
 
-const DETACH_HINT: &str =
-    "Press F12, Alt+d, or Ctrl-b then d to return to the chat list";
+const DETACH_HINT: &str = "Press F12, Alt+d, or Ctrl-b then d to return to the chat list";
 
 pub fn detach_hint() -> &'static str {
     DETACH_HINT
@@ -122,14 +138,26 @@ fn ensure_detach_keys() {
     });
 }
 
-pub fn attach(task_id: &str) -> Result<()> {
+/// Attach to a Terminal-lane session with the same header/status/hotkey framing
+/// used by the ACP viewer. Tmux remains the transport; chrome is a session-local
+/// status line plus a brief banner before the TTY is handed over.
+pub fn attach(task_id: &str, title: &str, status: &str) -> Result<()> {
     let name = session_name(task_id);
     ensure_detach_keys();
-    eprintln!("Attached to {name}. {DETACH_HINT}.");
-    let status = tmux_command(&["-L", "andy", "attach-session", "-t", &name])?
+    let title = if title.is_empty() { task_id } else { title };
+    let status = if status.is_empty() {
+        "Attached"
+    } else {
+        status
+    };
+    viewer_chrome::print_attach_banner(task_id, title, status);
+    // Best-effort: older/broken tmux still gets the banner + detach keys.
+    let _ = viewer_chrome::apply_tmux_session_chrome(task_id, title, status);
+    let attach_status = tmux_command(&["-L", "andy", "attach-session", "-t", &name])?
         .status()
         .context("spawn tmux attach")?;
-    if !status.success() {
+    let _ = viewer_chrome::clear_tmux_session_chrome(task_id);
+    if !attach_status.success() {
         bail!("tmux attach failed for session {name}");
     }
     Ok(())

--- a/cli/andy/src/tui.rs
+++ b/cli/andy/src/tui.rs
@@ -3,7 +3,9 @@ use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, MouseButton,
     MouseEventKind,
 };
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
 use crossterm::ExecutableCommand;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
@@ -93,7 +95,12 @@ pub async fn run_dashboard(mut client: McpClient) -> Result<()> {
 
             let refresh_button = Line::from(vec![
                 Span::styled("[", Style::default().fg(Color::DarkGray)),
-                Span::styled("r", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    "r",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
                 Span::styled("] Refresh ", Style::default().fg(Color::Cyan)),
             ])
             .right_aligned();
@@ -147,9 +154,9 @@ pub async fn run_dashboard(mut client: McpClient) -> Result<()> {
                                         &mut status,
                                     )
                                     .await;
-                                    if let Some(idx) = entries.iter().position(|e| {
-                                        matches!(e, ListEntry::Chat(c) if c.id == task_id)
-                                    }) {
+                                    if let Some(idx) = entries.iter().position(
+                                        |e| matches!(e, ListEntry::Chat(c) if c.id == task_id),
+                                    ) {
                                         selected = idx;
                                         list_state.select(Some(selected));
                                     }
@@ -213,8 +220,11 @@ pub async fn run_dashboard(mut client: McpClient) -> Result<()> {
                             list_state.select(Some(selected));
                         }
                         KeyCode::Right | KeyCode::Char('l') => {
-                            if let Some(ListEntry::Header { key, expanded: open, .. }) =
-                                entries.get(selected)
+                            if let Some(ListEntry::Header {
+                                key,
+                                expanded: open,
+                                ..
+                            }) = entries.get(selected)
                             {
                                 if !*open {
                                     expanded.insert(key.clone());
@@ -246,37 +256,35 @@ pub async fn run_dashboard(mut client: McpClient) -> Result<()> {
                                 &mut list_state,
                             );
                         }
-                        KeyCode::Enter => {
-                            match entries.get(selected) {
-                                Some(ListEntry::Header { .. }) => {
-                                    toggle_or_noop(
-                                        &groups,
+                        KeyCode::Enter => match entries.get(selected) {
+                            Some(ListEntry::Header { .. }) => {
+                                toggle_or_noop(
+                                    &groups,
+                                    &mut expanded,
+                                    &mut entries,
+                                    &mut selected,
+                                    &mut list_state,
+                                );
+                            }
+                            Some(ListEntry::Chat(chat)) => {
+                                let id = chat.id.clone();
+                                if confirm_attach(&mut terminal, &id)? {
+                                    flash = attach_selected_chat(
+                                        &mut client,
+                                        &mut terminal,
+                                        &mut groups,
                                         &mut expanded,
                                         &mut entries,
                                         &mut selected,
                                         &mut list_state,
-                                    );
+                                        &mut status,
+                                        &id,
+                                    )
+                                    .await?;
                                 }
-                                Some(ListEntry::Chat(chat)) => {
-                                    let id = chat.id.clone();
-                                    if confirm_attach(&mut terminal, &id)? {
-                                        flash = attach_selected_chat(
-                                            &mut client,
-                                            &mut terminal,
-                                            &mut groups,
-                                            &mut expanded,
-                                            &mut entries,
-                                            &mut selected,
-                                            &mut list_state,
-                                            &mut status,
-                                            &id,
-                                        )
-                                        .await?;
-                                    }
-                                }
-                                None => {}
                             }
-                        }
+                            None => {}
+                        },
                         KeyCode::Char('a') => {
                             if let Some(ListEntry::Chat(chat)) = entries.get(selected) {
                                 let id = chat.id.clone();
@@ -368,7 +376,9 @@ fn rebuild_visible(
     *entries = chats::visible_entries(groups, expanded);
 
     if let Some(chat_id) = prev_chat_id {
-        if let Some(idx) = entries.iter().position(|e| matches!(e, ListEntry::Chat(c) if c.id == chat_id))
+        if let Some(idx) = entries
+            .iter()
+            .position(|e| matches!(e, ListEntry::Chat(c) if c.id == chat_id))
         {
             *selected = idx;
             list_state.select(Some(*selected));
@@ -398,7 +408,12 @@ fn toggle_or_noop(
     selected: &mut usize,
     list_state: &mut ListState,
 ) {
-    let Some(ListEntry::Header { key, expanded: open, .. }) = entries.get(*selected) else {
+    let Some(ListEntry::Header {
+        key,
+        expanded: open,
+        ..
+    }) = entries.get(*selected)
+    else {
         return;
     };
     let key = key.clone();
@@ -477,7 +492,10 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result
 }
 
 /// Pause on a full-screen hint so users see how to get back before tmux takes over.
-fn confirm_attach(terminal: &mut Terminal<CrosstermBackend<Stdout>>, task_id: &str) -> Result<bool> {
+fn confirm_attach(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    task_id: &str,
+) -> Result<bool> {
     loop {
         terminal.draw(|frame| {
             let area = frame.area();
@@ -542,13 +560,7 @@ async fn attach_selected_chat(
         None
     };
     refresh(
-        client,
-        groups,
-        expanded,
-        entries,
-        selected,
-        list_state,
-        status,
+        client, groups, expanded, entries, selected, list_state, status,
     )
     .await;
     Ok(flash)

--- a/cli/andy/src/viewer_chrome.rs
+++ b/cli/andy/src/viewer_chrome.rs
@@ -1,0 +1,165 @@
+//! Shared attach UI chrome for ACP (ratatui) and Terminal (tmux status) lanes.
+//!
+//! Both lanes show the same framing: task id · title · [status] plus lane-specific
+//! hotkey hints. Terminal keeps tmux as the real transport; chrome is applied as a
+//! session-local status line for the duration of `andy attach`.
+
+use anyhow::{Context, Result};
+
+use crate::tmux;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lane {
+    Acp,
+    Terminal,
+}
+
+impl Lane {
+    pub fn parse(raw: &str) -> Self {
+        if raw.eq_ignore_ascii_case("Acp") {
+            Self::Acp
+        } else {
+            Self::Terminal
+        }
+    }
+
+    pub fn frame_title(self) -> &'static str {
+        match self {
+            Self::Acp => " Andy ACP ",
+            Self::Terminal => " Andy Terminal ",
+        }
+    }
+
+    pub fn hotkey_hint(self) -> &'static str {
+        match self {
+            Self::Acp => "Esc/q quit · s stop · i image · v details · Enter send",
+            Self::Terminal => "F12/Alt+d/Ctrl-b d detach",
+        }
+    }
+}
+
+/// One-line header shared by both attach viewers.
+pub fn format_header(task_id: &str, title: &str, status: &str, lane: Lane) -> String {
+    format!(" {task_id} · {title} · [{status}]  {} ", lane.hotkey_hint())
+}
+
+/// Footer / status flash line (hotkeys + detach mental model).
+pub fn format_status_line(lane: Lane, flash: Option<&str>) -> String {
+    flash.map(|s| s.to_string()).unwrap_or_else(|| match lane {
+        Lane::Acp => {
+            " y/n/a when prompted · v details · space expand tool · ↑↓ scroll ".into()
+        }
+        Lane::Terminal => {
+            format!(" {} — task keeps running after detach ", lane.hotkey_hint())
+        }
+    })
+}
+
+/// Apply session-local tmux status chrome for a Terminal-lane attach.
+///
+/// Uses non-global (`-t session`) options so the Andy server's global `status off`
+/// (required by the GUI scraper) is restored when [clear_tmux_session_chrome] runs.
+pub fn apply_tmux_session_chrome(task_id: &str, title: &str, status: &str) -> Result<()> {
+    let name = tmux::session_name(task_id);
+    let header = format_header(task_id, title, status, Lane::Terminal);
+    // tmux status-left interprets `#` — escape by doubling.
+    let safe = header.replace('#', "##");
+    tmux::run_tmux(&[
+        "-L",
+        "andy",
+        "set-option",
+        "-t",
+        &name,
+        "status",
+        "on",
+        ";",
+        "set-option",
+        "-t",
+        &name,
+        "status-position",
+        "top",
+        ";",
+        "set-option",
+        "-t",
+        &name,
+        "status-style",
+        "bg=colour236,fg=colour255",
+        ";",
+        "set-option",
+        "-t",
+        &name,
+        "status-left-length",
+        "120",
+        ";",
+        "set-option",
+        "-t",
+        &name,
+        "status-right-length",
+        "80",
+        ";",
+        "set-option",
+        "-t",
+        &name,
+        "status-left",
+        &safe,
+        ";",
+        "set-option",
+        "-t",
+        &name,
+        "status-right",
+        &format!(" {} ", Lane::Terminal.frame_title().trim()),
+        ";",
+        "set-option",
+        "-t",
+        &name,
+        "pane-border-status",
+        "off",
+    ])
+    .context("apply terminal viewer chrome")?;
+    Ok(())
+}
+
+pub fn clear_tmux_session_chrome(task_id: &str) -> Result<()> {
+    let name = tmux::session_name(task_id);
+    // Best-effort: session may already be gone after detach/kill.
+    let _ = tmux::run_tmux(&["-L", "andy", "set-option", "-t", &name, "status", "off"]);
+    Ok(())
+}
+
+/// Print the shared framing to stderr before handing the TTY to tmux (also used when
+/// status cannot be applied). Returns the formatted header for tests.
+pub fn print_attach_banner(task_id: &str, title: &str, status: &str) -> String {
+    let lane = Lane::Terminal;
+    let header = format_header(task_id, title, status, lane);
+    let bar = "─".repeat(header.chars().count().clamp(20, 100));
+    eprintln!("{}", lane.frame_title().trim());
+    eprintln!("{bar}");
+    eprintln!("{}", header.trim());
+    eprintln!("{}", format_status_line(lane, None).trim());
+    eprintln!("{bar}");
+    header
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acp_and_terminal_headers_share_framing_shape() {
+        let acp = format_header("t1", "Demo", "Working", Lane::Acp);
+        let term = format_header("t1", "Demo", "Working", Lane::Terminal);
+        assert!(acp.contains("t1 · Demo · [Working]"));
+        assert!(term.contains("t1 · Demo · [Working]"));
+        assert!(acp.contains("Esc/q quit"));
+        assert!(term.contains("F12"));
+        assert_eq!(Lane::Acp.frame_title(), " Andy ACP ");
+        assert_eq!(Lane::Terminal.frame_title(), " Andy Terminal ");
+    }
+
+    #[test]
+    fn status_line_mentions_detach_keeps_running() {
+        let line = format_status_line(Lane::Terminal, None);
+        assert!(line.contains("detach"));
+        assert!(line.contains("keeps running"));
+    }
+}

--- a/cli/andy/src/viewer_chrome.rs
+++ b/cli/andy/src/viewer_chrome.rs
@@ -32,7 +32,7 @@ impl Lane {
 
     pub fn hotkey_hint(self) -> &'static str {
         match self {
-            Self::Acp => "Esc/q quit · s stop · i image · v details · Enter send",
+            Self::Acp => "Esc/q quit · Ctrl-s stop · Ctrl-i image · v details · Enter send",
             Self::Terminal => "F12/Alt+d/Ctrl-b d detach",
         }
     }

--- a/cli/andy/tests/common/mock_mcp.rs
+++ b/cli/andy/tests/common/mock_mcp.rs
@@ -1,0 +1,356 @@
+//! Hand-rolled newline-delimited JSON-RPC MCP mock for unix-socket integration tests.
+//!
+//! Speaks the same framing as `andy_cli::mcp::McpClient` / andyd's unix socket server.
+
+use serde_json::{json, Value};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+pub const CHAT_SUBSCRIBE_METHOD: &str = "notifications/andy/chat.events";
+
+#[derive(Debug, Clone, Default)]
+pub struct MockState {
+    pub tools: Vec<&'static str>,
+    pub backlog: Vec<Value>,
+    /// Live events pushed after subscribe starts (drained by the subscribe handler).
+    pub live_events: Vec<Value>,
+    /// Captured tools/call argument objects keyed by tool name.
+    pub calls: Vec<(String, Value)>,
+    /// When set, chat.subscribe finishes with this reason after backlog (+ live).
+    pub subscribe_finish_reason: Option<String>,
+    /// When true, tools/call for chat.subscribe returns a Method not found error.
+    pub subscribe_missing: bool,
+}
+
+impl MockState {
+    pub fn with_subscribe() -> Self {
+        Self {
+            tools: vec![
+                "chat.subscribe",
+                "chat.events",
+                "chat.resume",
+                "chat.queue_follow_up",
+                "chat.status",
+                "chat.list",
+            ],
+            backlog: Vec::new(),
+            live_events: Vec::new(),
+            calls: Vec::new(),
+            subscribe_finish_reason: Some("terminal".into()),
+            subscribe_missing: false,
+        }
+    }
+
+    pub fn without_subscribe() -> Self {
+        let mut s = Self::with_subscribe();
+        s.tools.retain(|t| *t != "chat.subscribe");
+        s.subscribe_missing = true;
+        s
+    }
+}
+
+pub struct MockMcpServer {
+    pub socket: PathBuf,
+    state: Arc<Mutex<MockState>>,
+    handle: JoinHandle<()>,
+    _dir: tempfile::TempDir,
+}
+
+impl MockMcpServer {
+    pub async fn spawn(state: MockState) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("mock-andyd.sock");
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).expect("bind mock socket");
+        let state = Arc::new(Mutex::new(state));
+        let state_clone = Arc::clone(&state);
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let st = Arc::clone(&state_clone);
+                tokio::spawn(async move {
+                    if let Err(err) = handle_client(stream, st).await {
+                        eprintln!("mock mcp client error: {err:#}");
+                    }
+                });
+            }
+        });
+        Self {
+            socket,
+            state,
+            handle,
+            _dir: dir,
+        }
+    }
+
+    pub fn state(&self) -> Arc<Mutex<MockState>> {
+        Arc::clone(&self.state)
+    }
+}
+
+impl Drop for MockMcpServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+        let _ = std::fs::remove_file(&self.socket);
+    }
+}
+
+async fn handle_client(stream: UnixStream, state: Arc<Mutex<MockState>>) -> anyhow::Result<()> {
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let root: Value = serde_json::from_str(&line)?;
+        let method = root.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let id = root.get("id").cloned();
+
+        match method {
+            "initialize" => {
+                let resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": { "name": "mock-andyd", "version": "test" }
+                    }
+                });
+                writer.write_all(format!("{resp}\n").as_bytes()).await?;
+            }
+            "notifications/initialized" => {}
+            "tools/list" => {
+                let tools = {
+                    let st = state.lock().unwrap();
+                    st.tools
+                        .iter()
+                        .map(|name| {
+                            json!({
+                                "name": name,
+                                "description": name,
+                                "inputSchema": { "type": "object", "properties": {} }
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                };
+                let resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": { "tools": tools }
+                });
+                writer.write_all(format!("{resp}\n").as_bytes()).await?;
+            }
+            "tools/call" => {
+                let params = root.get("params").cloned().unwrap_or(Value::Null);
+                let name = params
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = params
+                    .get("arguments")
+                    .cloned()
+                    .unwrap_or(Value::Object(Default::default()));
+                {
+                    let mut st = state.lock().unwrap();
+                    st.calls.push((name.clone(), args.clone()));
+                }
+
+                if name == "chat.subscribe" {
+                    let (backlog, live, finish, missing) = {
+                        let mut st = state.lock().unwrap();
+                        let backlog = st.backlog.clone();
+                        let live = std::mem::take(&mut st.live_events);
+                        let finish = st.subscribe_finish_reason.clone();
+                        let missing = st.subscribe_missing
+                            || !st.tools.iter().any(|t| *t == "chat.subscribe");
+                        (backlog, live, finish, missing)
+                    };
+                    if missing {
+                        let resp = json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "error": {
+                                "code": -32601,
+                                "message": "Method not found: chat.subscribe"
+                            }
+                        });
+                        writer.write_all(format!("{resp}\n").as_bytes()).await?;
+                        continue;
+                    }
+
+                    let task_id = args
+                        .get("taskId")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("task")
+                        .to_string();
+                    let sub_id = "sub-test";
+
+                    let batch = json!({
+                        "jsonrpc": "2.0",
+                        "method": CHAT_SUBSCRIBE_METHOD,
+                        "params": {
+                            "_meta": {
+                                "subscriptionId": sub_id,
+                                "taskId": task_id,
+                                "events": backlog,
+                                "done": false
+                            }
+                        }
+                    });
+                    writer.write_all(format!("{batch}\n").as_bytes()).await?;
+
+                    if !live.is_empty() {
+                        let live_batch = json!({
+                            "jsonrpc": "2.0",
+                            "method": CHAT_SUBSCRIBE_METHOD,
+                            "params": {
+                                "_meta": {
+                                    "subscriptionId": sub_id,
+                                    "taskId": task_id,
+                                    "events": live,
+                                    "done": false
+                                }
+                            }
+                        });
+                        writer
+                            .write_all(format!("{live_batch}\n").as_bytes())
+                            .await?;
+                    }
+
+                    if let Some(reason) = finish {
+                        let done_batch = json!({
+                            "jsonrpc": "2.0",
+                            "method": CHAT_SUBSCRIBE_METHOD,
+                            "params": {
+                                "_meta": {
+                                    "subscriptionId": sub_id,
+                                    "taskId": task_id,
+                                    "events": [],
+                                    "done": true
+                                }
+                            }
+                        });
+                        writer
+                            .write_all(format!("{done_batch}\n").as_bytes())
+                            .await?;
+                        let result_text = json!({ "ok": true, "reason": reason }).to_string();
+                        let resp = json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "result": {
+                                "content": [{ "type": "text", "text": result_text }],
+                                "isError": false
+                            }
+                        });
+                        writer.write_all(format!("{resp}\n").as_bytes()).await?;
+                    } else {
+                        while let Some(extra) = lines.next_line().await? {
+                            let _ = extra;
+                        }
+                        break;
+                    }
+                    continue;
+                }
+
+                let text = match name.as_str() {
+                    "chat.start" | "chat.resume" | "chat.queue_follow_up" => {
+                        json!({ "ok": true, "tool": name, "arguments": args }).to_string()
+                    }
+                    "chat.status" => json!({
+                        "status": "Done",
+                        "lane": "Acp",
+                        "cwd": "/tmp",
+                    })
+                    .to_string(),
+                    "chat.list" => json!([{
+                        "id": "task-1",
+                        "title": "Mock",
+                        "lane": "Acp",
+                    }])
+                    .to_string(),
+                    "chat.events" => {
+                        let backlog = state.lock().unwrap().backlog.clone();
+                        Value::Array(backlog).to_string()
+                    }
+                    other => json!({ "ok": true, "tool": other }).to_string(),
+                };
+                let resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "content": [{ "type": "text", "text": text }],
+                        "isError": false
+                    }
+                });
+                writer.write_all(format!("{resp}\n").as_bytes()).await?;
+            }
+            _ => {
+                if id.is_some() {
+                    let resp = json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "error": { "code": -32601, "message": format!("Method not found: {method}") }
+                    });
+                    writer.write_all(format!("{resp}\n").as_bytes()).await?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Drain subscribe messages until Finished/Disconnected or timeout.
+pub async fn collect_subscribe(
+    client: &mut andy_cli::mcp::McpClient,
+    task_id: &str,
+) -> Vec<andy_cli::mcp::SubscribeMessage> {
+    let (tx, mut rx) = mpsc::channel(32);
+    let mut sub = andy_cli::mcp::McpClient::new(client.socket_path());
+    let task = task_id.to_string();
+    let join = tokio::spawn(async move {
+        let _ = sub.subscribe_chat_events(&task, tx).await;
+    });
+    let mut out = Vec::new();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        tokio::select! {
+            msg = rx.recv() => {
+                match msg {
+                    Some(m) => {
+                        let terminal = matches!(
+                            m,
+                            andy_cli::mcp::SubscribeMessage::Finished { .. }
+                                | andy_cli::mcp::SubscribeMessage::Disconnected(_)
+                        );
+                        out.push(m);
+                        if terminal {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => break,
+        }
+    }
+    join.abort();
+    out
+}
+
+pub fn calls_for(state: &MockState, tool: &str) -> Vec<Value> {
+    state
+        .calls
+        .iter()
+        .filter(|(n, _)| n == tool)
+        .map(|(_, a)| a.clone())
+        .collect()
+}

--- a/cli/andy/tests/common/mod.rs
+++ b/cli/andy/tests/common/mod.rs
@@ -1,0 +1,5 @@
+//! Shared helpers for Andy CLI integration tests.
+
+mod mock_mcp;
+
+pub use mock_mcp::*;

--- a/cli/andy/tests/subscribe_integration.rs
+++ b/cli/andy/tests/subscribe_integration.rs
@@ -1,0 +1,193 @@
+//! Mock-MCP integration coverage for chat.subscribe / imagePaths wire protocol.
+
+mod common;
+
+use andy_cli::events::AgentEvent;
+use andy_cli::mcp::{McpClient, SubscribeMessage, SUBSCRIBE_MISSING_ERROR};
+use common::{calls_for, collect_subscribe, MockMcpServer, MockState};
+use serde_json::json;
+
+#[tokio::test]
+async fn subscribe_delivers_backlog_then_live_events() {
+    let mut state = MockState::with_subscribe();
+    state.backlog = vec![json!({
+        "type": "user",
+        "atMillis": 1,
+        "text": "hello",
+        "images": []
+    })];
+    state.live_events = vec![json!({
+        "type": "assistant",
+        "atMillis": 2,
+        "text": "world",
+        "stream": false
+    })];
+    state.subscribe_finish_reason = Some("terminal".into());
+
+    let server = MockMcpServer::spawn(state).await;
+    let mut client = McpClient::new(server.socket.clone());
+
+    let msgs = collect_subscribe(&mut client, "task-1").await;
+    let mut events = Vec::new();
+    let mut finished = None;
+    for msg in msgs {
+        match msg {
+            SubscribeMessage::Batch(batch) => {
+                for raw in batch.events {
+                    events.push(AgentEvent::from_wire(&raw));
+                }
+            }
+            SubscribeMessage::Finished { reason } => finished = Some(reason),
+            SubscribeMessage::Disconnected(err) => panic!("unexpected disconnect: {err}"),
+        }
+    }
+
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::User { text, .. } if text == "hello")),
+        "backlog user message missing: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::Assistant { text, .. } if text == "world")),
+        "live assistant event missing: {events:?}"
+    );
+    assert_eq!(finished.as_deref(), Some("terminal"));
+}
+
+#[tokio::test]
+async fn missing_chat_subscribe_hard_fails_with_upgrade_message() {
+    let server = MockMcpServer::spawn(MockState::without_subscribe()).await;
+    let mut client = McpClient::new(server.socket.clone());
+
+    let err = client
+        .requires_chat_subscribe()
+        .await
+        .expect_err("expected upgrade-needed error");
+    assert!(
+        err.to_string().contains("chat.subscribe"),
+        "unexpected error: {err:#}"
+    );
+    assert_eq!(err.to_string(), SUBSCRIBE_MISSING_ERROR);
+
+    // Direct subscribe path must also hard-fail (no hang / silent polling).
+    let (tx, _rx) = tokio::sync::mpsc::channel(4);
+    let sub_err = client
+        .subscribe_chat_events("task-1", tx)
+        .await
+        .expect_err("subscribe against old daemon");
+    assert!(
+        sub_err.to_string().contains("chat.subscribe")
+            || sub_err.to_string().contains(SUBSCRIBE_MISSING_ERROR),
+        "unexpected subscribe error: {sub_err:#}"
+    );
+}
+
+#[tokio::test]
+async fn start_resume_and_queue_follow_up_carry_image_paths() {
+    let server = MockMcpServer::spawn(MockState::with_subscribe()).await;
+    let mut client = McpClient::new(server.socket.clone());
+
+    client
+        .call_tool(
+            "chat.start",
+            json!({
+                "agent": "ClaudeCode",
+                "prompt": "first message",
+                "imagePaths": ["/tmp/start.png"]
+            }),
+        )
+        .await
+        .expect("chat.start");
+
+    client
+        .call_tool(
+            "chat.resume",
+            json!({
+                "taskId": "task-1",
+                "followUp": "look at this",
+                "imagePaths": ["/tmp/a.png", "/tmp/b.webp"]
+            }),
+        )
+        .await
+        .expect("chat.resume");
+
+    client
+        .call_tool(
+            "chat.queue_follow_up",
+            json!({
+                "taskId": "task-1",
+                "followUp": "queued",
+                "imagePaths": ["/tmp/c.jpg"]
+            }),
+        )
+        .await
+        .expect("chat.queue_follow_up");
+
+    let st = server.state();
+    let guard = st.lock().unwrap();
+    let start = &calls_for(&guard, "chat.start")[0];
+    assert_eq!(start.get("imagePaths"), Some(&json!(["/tmp/start.png"])));
+    let resume = &calls_for(&guard, "chat.resume")[0];
+    assert_eq!(
+        resume.get("imagePaths"),
+        Some(&json!(["/tmp/a.png", "/tmp/b.webp"]))
+    );
+    let queued = &calls_for(&guard, "chat.queue_follow_up")[0];
+    assert_eq!(queued.get("imagePaths"), Some(&json!(["/tmp/c.jpg"])));
+}
+
+#[tokio::test]
+async fn subscribe_backlog_is_renderable_as_agent_events() {
+    // Mirrors the "backlog rendered on open" requirement: wire payloads round-trip
+    // through AgentEvent::from_wire the same way acp_view applies Batch messages.
+    let mut state = MockState::with_subscribe();
+    state.backlog = vec![
+        json!({"type": "user", "atMillis": 1, "text": "hi", "images": ["/x.png"]}),
+        json!({"type": "assistant", "atMillis": 2, "text": "**ok**", "stream": false}),
+        json!({
+            "type": "tool",
+            "atMillis": 3,
+            "toolName": "edit",
+            "toolCallId": "c1",
+            "summary": "patch",
+            "detail": "@@ -1 +1 @@\n-a\n+b\n",
+            "kind": "edit",
+            "state": "completed"
+        }),
+    ];
+    state.live_events.clear();
+    state.subscribe_finish_reason = Some("done".into());
+
+    let server = MockMcpServer::spawn(state).await;
+    let mut client = McpClient::new(server.socket.clone());
+    let msgs = collect_subscribe(&mut client, "task-1").await;
+
+    let batch = msgs
+        .into_iter()
+        .find_map(|m| match m {
+            SubscribeMessage::Batch(b) if !b.events.is_empty() => Some(b),
+            _ => None,
+        })
+        .expect("expected backlog batch");
+
+    let rendered: Vec<_> = batch.events.iter().map(AgentEvent::from_wire).collect();
+    assert_eq!(rendered.len(), 3);
+    match &rendered[0] {
+        AgentEvent::User { text, images, .. } => {
+            assert_eq!(text, "hi");
+            assert_eq!(images, &vec!["/x.png".to_string()]);
+        }
+        other => panic!("expected user, got {other:?}"),
+    }
+    assert!(matches!(
+        &rendered[1],
+        AgentEvent::Assistant { text, .. } if text == "**ok**"
+    ));
+    assert!(matches!(
+        &rendered[2],
+        AgentEvent::Tool { tool_name, .. } if tool_name == "edit"
+    ));
+}

--- a/docs/ANDYD.md
+++ b/docs/ANDYD.md
@@ -1,8 +1,11 @@
 # Andy daemon (`andyd`) + CLI
 
-Andy’s center of gravity is a headless daemon that owns agent/project state and
-spawns agent CLIs into Andy-managed tmux sessions. The Compose GUI and the Rust
-CLI are equal clients over a Unix domain socket.
+Andy’s center of gravity is a headless daemon that owns agent/project state.
+Terminal-lane agents (Antigravity, Hermes, OpenClaw, …) run in Andy-managed
+tmux sessions; ACP-lane agents (Claude Code, Codex, Cursor, OpenCode, Pi) use a
+structured protocol subprocess and a JSONL transcript. The Compose GUI and the
+Rust CLI are equal clients over a Unix domain socket — `andy attach` routes to
+tmux or the native ACP viewer by lane.
 
 The CLI is **macOS and Linux only** (not Windows). It auto-starts `andyd` when
 the socket is not already live.
@@ -95,7 +98,7 @@ andy chat list                 # grouped by project (Inbox / projectId)
 andy chat list --json          # raw MCP payload
 andy chat start --agent ClaudeCode --directory "$PWD" "Reply with pong"
 andy chat start --no-attach --agent ClaudeCode "fire and forget JSON only"
-andy attach <taskId>           # live tmux, or quiet provider reattach then attach
+andy attach <taskId>           # ACP: native viewer · Terminal: tmux (or quiet reattach)
 andy tui                       # n new chat · grouped projects · a / Enter attach
 andy chat resume <taskId> "…"  # when quiet reattach isn't possible
 andy --remote user@mac.local chat list   # SSH tunnel the socket
@@ -168,14 +171,18 @@ andy tui
 andy attach <taskId>
 ```
 
-This live-attaches to the chat's tmux pane (or quietly reattaches an ended
-provider session first, same as GUI reattach). `andy tui` lists chats grouped
-by project — press **Enter** / **a** to attach without remembering a task id.
+This opens the lane-appropriate viewer: the native ACP chat UI for Claude Code /
+Codex / Cursor / OpenCode / Pi, or a live tmux pane for Terminal-lane agents
+(with quiet provider reattach when needed, same as GUI reattach). `andy tui`
+lists chats grouped by project — press **Enter** / **a** to attach without
+remembering a task id.
 
-**7. Detach without stopping the agent.** Press **F12**, **Alt+d**, or the
-usual tmux **Ctrl-b** then **d**. The agent keeps running on the host;
-reconnect later — even from a different phone or SSH session — with
-`andy attach <taskId>`.
+**7. Detach without stopping the agent.** For Terminal/tmux: press **F12**,
+**Alt+d**, or the usual tmux **Ctrl-b** then **d**. For the ACP viewer: press
+**Esc** / **q** / **Ctrl-C**. The agent keeps running on the host; reconnect
+later — even from a different phone or SSH session — with `andy attach <taskId>`.
+The ACP viewer defaults to conversation-only (user/assistant); press **v** for
+tools/commands/raw/usage detail, or set `ANDY_ACP_VIEW_DETAILS=1`.
 
 ### Device / network scripting
 
@@ -198,16 +205,27 @@ Curated groups: `device`, `emulator`, `avd`, `system-image`, `snapshot`,
 `input`, `app`, `intent`, `file`, `network`. Extra tool args:
 `--arg key=value` (JSON literals coerced) and `--json-args '{…}'`.
 
-`andy attach` / TUI attach first checks for a live `tmux -L andy` session. If the
-chat has ended but Andy can reopen the provider CLI (same as GUI reattach), it
-calls `chat.reattach`, waits for tmux, then attaches. Otherwise it tells you to
-use `andy chat resume`.
+`andy attach` / TUI attach resolves the task `lane` first:
+
+- **Acp** — opens the native CLI viewer (history via `chat.events` / live
+  updates via `chat.subscribe`). Requires a daemon that advertises
+  `chat.subscribe`; older andyd builds hard-fail with an upgrade message.
+- **Terminal** — checks for a live `tmux -L andy` session. If the chat has
+  ended but Andy can reopen the provider CLI (same as GUI reattach), it calls
+  `chat.reattach`, waits for tmux, then attaches. Otherwise it tells you to use
+  `andy chat resume`.
 
 Dev loop without installing: `cargo run --manifest-path cli/andy/Cargo.toml -- chat list`
 
-Live terminal view is always `tmux -L andy attach -t andy-task-<id>` — MCP never
-streams PTY bytes. From the TUI or `andy attach`, press **F12**, **Alt+d**, or the
-usual tmux **Ctrl-b** then **d** to detach back to the chat list without stopping the agent.
+CLI tests (unit + mock-MCP integration): `cargo test --manifest-path cli/andy/Cargo.toml`
+
+Terminal-lane live view is always `tmux -L andy attach -t andy-task-<id>` — MCP
+never streams PTY bytes. `andy attach` wraps that session with the same
+header/status/hotkey chrome as the ACP viewer (session-local tmux status line +
+banner), then hands the TTY to tmux. From the TUI or `andy attach` on a Terminal
+chat, press **F12**, **Alt+d**, or the usual tmux **Ctrl-b** then **d** to
+detach back to the chat list without stopping the agent. ACP chats use
+Esc/q/Ctrl-C for the same “detach, keep running” behavior.
 
 ## launchd (macOS)
 
@@ -260,10 +278,11 @@ Claude Code, Codex, Cursor, OpenCode, and Pi default to the ACP stdio lane. ACP
 sessions use the official Kotlin ACP client, persist structured JSONL transcripts
 under `~/.andy/agents/<task-id>/transcript.jsonl`, and keep their ACP session id
 separate from vendor CLI session ids. The GUI renders those events with the
-structured transcript surface and can continue a stored session after restart.
+structured transcript surface; the CLI uses the same event stream via
+`chat.subscribe` in `andy attach`. Both can continue a stored session after restart.
 
-Antigravity, Hermes, and OpenClaw remain on the terminal/tmux lane. If ACP
-spawn or initialization fails, Andy records the diagnostic and falls back to the
-existing terminal lane for that task. Override routing for a rollout with
-`ANDY_AGENT_LANE=terminal|acp` or the provider-specific
+Antigravity, Hermes, and OpenClaw remain on the terminal/tmux lane (`andy attach`
+→ `tmux -L andy`). If ACP spawn or initialization fails, Andy records the
+diagnostic and falls back to the existing terminal lane for that task. Override
+routing for a rollout with `ANDY_AGENT_LANE=terminal|acp` or the provider-specific
 `ANDY_AGENT_LANE_<AGENT_KIND>` variable.

--- a/src/desktopMain/kotlin/app/andy/desktop/service/ChatSubscribeSupport.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/ChatSubscribeSupport.kt
@@ -1,0 +1,424 @@
+package app.andy.desktop.service
+
+import app.andy.model.AgentEvent
+import app.andy.model.AgentStatus
+import app.andy.service.AgentRunService
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.types.BaseNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.CustomNotification
+import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+
+private class ChatSubscribeFinished(val reason: String) : Exception(reason)
+
+/** MCP notification method for [chat.subscribe] event batches. */
+const val ChatSubscribeNotificationMethod = "notifications/andy/chat.events"
+
+private val AllowedImageExtensions = setOf("jpg", "jpeg", "png", "gif", "webp")
+
+/** Tracks live [chat.subscribe] collectors so tests can assert disconnect cleanup. */
+internal object ChatSubscribeMetrics {
+    private val activeCollectors = AtomicInteger(0)
+
+    fun activeCollectorCount(): Int = activeCollectors.get()
+
+    fun track(job: Job) {
+        activeCollectors.incrementAndGet()
+        job.invokeOnCompletion {
+            activeCollectors.decrementAndGet()
+        }
+    }
+}
+
+/**
+ * The MCP Kotlin SDK does not cancel in-flight tool handlers when the transport
+ * closes. [chat.subscribe] therefore registers its collector Job here so
+ * [McpUnixSocketServer] can cancel it from the session `onClose` callback.
+ */
+internal object ChatSubscribeRegistry {
+    private val bySession = ConcurrentHashMap<String, CopyOnWriteArrayList<Job>>()
+
+    fun register(sessionId: String, job: Job) {
+        bySession.getOrPut(sessionId) { CopyOnWriteArrayList() }.add(job)
+        job.invokeOnCompletion {
+            bySession[sessionId]?.remove(job)
+            if (bySession[sessionId].isNullOrEmpty()) {
+                bySession.remove(sessionId)
+            }
+        }
+    }
+
+    fun cancelSession(sessionId: String) {
+        val jobs = bySession.remove(sessionId).orEmpty()
+        jobs.forEach { job ->
+            job.cancel(CancellationException("chat.subscribe: client disconnected"))
+        }
+    }
+
+    fun cancelAll() {
+        bySession.keys.toList().forEach { cancelSession(it) }
+    }
+}
+
+/**
+ * Parses and validates the MCP `imagePaths` argument. Rejects wrong container/item
+ * types before checking absolute-path shape, existence, regular-file status, and extension.
+ */
+internal fun parseImagePathsArg(args: Map<String, JsonElement>): List<String> {
+    val element = args["imagePaths"] ?: return emptyList()
+    val array = element as? JsonArray
+        ?: error("imagePaths must be an array of strings")
+    val paths = array.mapIndexed { index, item ->
+        val primitive = item as? JsonPrimitive
+        if (primitive == null || !primitive.isString) {
+            error("imagePaths[$index] must be a string")
+        }
+        primitive.content
+    }
+    return validateImagePaths(paths)
+}
+
+/**
+ * Validates raw local image paths for MCP chat tools. Rejects missing files and
+ * non-image extensions rather than silently dropping them.
+ */
+internal fun validateImagePaths(paths: List<String>): List<String> {
+    for (path in paths) {
+        val file = File(path)
+        if (!file.isAbsolute) {
+            error("image path must be absolute: $path")
+        }
+        if (!file.isFile) {
+            error("image path not found or not a regular file: $path")
+        }
+        val ext = file.extension.lowercase()
+        if (ext !in AllowedImageExtensions) {
+            error(
+                "unsupported image type '.$ext' for $path " +
+                    "(allowed: ${AllowedImageExtensions.joinToString(", ")})",
+            )
+        }
+    }
+    return paths
+}
+
+/**
+ * First index where [next] differs from [prev], or null when identical.
+ * In-place ACP coalescing (stream text / tool updates) keeps list size stable while
+ * mutating entries — callers must push from this index with replace semantics.
+ */
+internal fun firstChangedEventIndex(prev: List<AgentEvent>, next: List<AgentEvent>): Int? {
+    if (next.size < prev.size) return 0
+    val shared = prev.size
+    for (i in 0 until shared) {
+        if (prev[i] != next[i]) return i
+    }
+    return if (next.size > prev.size) prev.size else null
+}
+
+/** Wire shape shared by [chat.events] and [chat.subscribe] payloads. */
+internal fun AgentEvent.toWire(): JsonObject = buildJsonObject {
+    put("atMillis", atMillis)
+    when (this@toWire) {
+        is AgentEvent.SessionStarted -> {
+            put("type", "session")
+            put("sessionId", sessionId.orEmpty())
+            put("model", model.orEmpty())
+        }
+        is AgentEvent.AssistantText -> {
+            put("type", "assistant")
+            put("text", text)
+            put("stream", isStreamDelta)
+        }
+        is AgentEvent.Thinking -> {
+            put("type", "thinking")
+            put("text", text)
+            put("stream", isStreamDelta)
+        }
+        is AgentEvent.UserMessage -> {
+            put("type", "user")
+            put("text", text)
+            put("images", JsonArray(imagePaths.map(::JsonPrimitive)))
+        }
+        is AgentEvent.ToolCall -> {
+            put("type", "tool")
+            put("toolName", toolName)
+            put("toolCallId", toolCallId.orEmpty())
+            put("summary", summary)
+            put("detail", detail)
+            put("kind", kind?.name.orEmpty())
+            put("state", state.name)
+            put("locations", JsonArray(locations.map(::JsonPrimitive)))
+        }
+        is AgentEvent.ToolResult -> {
+            put("type", "tool-result")
+            put("toolName", toolName.orEmpty())
+            put("summary", summary)
+            put("detail", detail)
+            put("isError", isError)
+        }
+        is AgentEvent.TaskError -> {
+            put("type", "error")
+            put("text", message)
+        }
+        is AgentEvent.TaskResult -> {
+            put("type", "result")
+            put("success", success)
+            put("finalText", finalText.orEmpty())
+            put("costUsd", costUsd ?: 0.0)
+            put("costEstimated", costIsEstimated)
+            put("inputTokens", inputTokens ?: 0L)
+            put("outputTokens", outputTokens ?: 0L)
+            put("durationMs", durationMs ?: 0L)
+        }
+        is AgentEvent.ContextUsage -> {
+            put("type", "usage")
+            put("usedTokens", usedTokens ?: 0L)
+            put("windowTokens", windowTokens ?: 0L)
+        }
+        is AgentEvent.PlanUpdate -> {
+            put("type", "plan")
+            put(
+                "entries",
+                buildJsonArray {
+                    entries.forEach { entry ->
+                        add(
+                            buildJsonObject {
+                                put("content", entry.content)
+                                put("status", entry.status)
+                            },
+                        )
+                    }
+                },
+            )
+            markdown?.let { put("markdown", it) }
+        }
+        is AgentEvent.ModeChanged -> {
+            put("type", "mode")
+            put("modeId", modeId)
+        }
+        is AgentEvent.AvailableCommands -> {
+            put("type", "commands")
+            put(
+                "commands",
+                buildJsonArray {
+                    commands.forEach { command ->
+                        add(
+                            buildJsonObject {
+                                put("name", command.name)
+                                put("description", command.description)
+                                put("inputHint", command.inputHint.orEmpty())
+                            },
+                        )
+                    }
+                },
+            )
+        }
+        is AgentEvent.AvailableModes -> {
+            put("type", "modes")
+            put("currentModeId", currentModeId.orEmpty())
+            put(
+                "modes",
+                buildJsonArray {
+                    modes.forEach { mode ->
+                        add(
+                            buildJsonObject {
+                                put("id", mode.id)
+                                put("name", mode.name)
+                                put("description", mode.description.orEmpty())
+                            },
+                        )
+                    }
+                },
+            )
+        }
+        is AgentEvent.PermissionRequest -> {
+            put("type", "permission")
+            put("requestId", requestId)
+            put("toolName", toolName)
+            put("question", question)
+            put(
+                "options",
+                buildJsonArray {
+                    options.forEach { option ->
+                        add(
+                            buildJsonObject {
+                                put("label", option.label)
+                                put("description", option.description)
+                            },
+                        )
+                    }
+                },
+            )
+        }
+        is AgentEvent.PermissionResolved -> {
+            put("type", "permission-resolved")
+            put("requestId", requestId)
+            put("optionId", optionId)
+            put("allowed", allowed)
+            note?.let { put("note", it) }
+        }
+        is AgentEvent.Raw -> {
+            put("type", "raw")
+            put("line", line)
+        }
+    }
+}
+
+/**
+ * Streams transcript events for [taskId] as MCP notifications until the client
+ * cancels, the chat disappears, or the task reaches a terminal status with the
+ * backlog flushed.
+ */
+internal suspend fun runChatSubscribe(
+    client: ClientConnection,
+    agentRuns: AgentRunService,
+    taskId: String,
+): CallToolResult {
+    val taskExists = agentRuns.tasks.value.any { it.id == taskId }
+    if (!taskExists && agentRuns.events(taskId).value.isEmpty()) {
+        return CallToolResult(
+            content = listOf(TextContent(text = "Error: chat no longer exists: $taskId")),
+            isError = true,
+        )
+    }
+
+    val subscriptionId = UUID.randomUUID().toString()
+    var lastSent: List<AgentEvent> = emptyList()
+    var sawInitial = false
+    var endReason = "cancelled"
+
+    // Lifetime token: cancelled by ChatSubscribeRegistry on transport close. Metrics track
+    // this token (not the collector) so the count drops even if a mid-push write is stuck.
+    val lifetime = Job()
+    ChatSubscribeMetrics.track(lifetime)
+    ChatSubscribeRegistry.register(client.sessionId, lifetime)
+
+    fun batchPayload(
+        events: List<AgentEvent>,
+        done: Boolean = false,
+        error: String? = null,
+        replaceFrom: Int? = null,
+    ): JsonObject =
+        buildJsonObject {
+            put("subscriptionId", subscriptionId)
+            put("taskId", taskId)
+            put("events", buildJsonArray { events.forEach { add(it.toWire()) } })
+            if (replaceFrom != null) put("replaceFrom", replaceFrom)
+            if (done) put("done", true)
+            if (error != null) put("error", error)
+        }
+
+    suspend fun push(
+        events: List<AgentEvent>,
+        done: Boolean = false,
+        error: String? = null,
+        replaceFrom: Int? = null,
+    ) {
+        if (events.isEmpty() && replaceFrom == null && !done && error == null && sawInitial) return
+        try {
+            client.notification(
+                CustomNotification(
+                    method = Method.Custom(ChatSubscribeNotificationMethod),
+                    params = BaseNotificationParams(meta = batchPayload(events, done, error, replaceFrom)),
+                ),
+            )
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            // Peer disconnect / wedged writer: drop the lifetime token so collectors are not leaked.
+            lifetime.cancel(CancellationException("chat.subscribe: push failed: ${error.message}"))
+            throw error
+        }
+    }
+
+    suspend fun pushSnapshotDiff(snapshot: List<AgentEvent>) {
+        val diffFrom = firstChangedEventIndex(lastSent, snapshot)
+        if (!sawInitial) {
+            push(snapshot)
+            lastSent = snapshot.toList()
+            sawInitial = true
+            return
+        }
+        if (diffFrom == null) return
+        push(snapshot.subList(diffFrom, snapshot.size), replaceFrom = diffFrom)
+        lastSent = snapshot.toList()
+    }
+
+    try {
+        coroutineScope {
+            val collectorJob = launch {
+                val eventsFlow = agentRuns.events(taskId)
+                val taskFlow = agentRuns.tasks
+                    .map { list -> list.firstOrNull { it.id == taskId } }
+                    .distinctUntilChanged()
+                combine(eventsFlow, taskFlow) { snapshot, task -> snapshot to task }
+                    .collect { (snapshot, task) ->
+                        lifetime.ensureActive()
+                        pushSnapshotDiff(snapshot)
+
+                        if (task == null) {
+                            push(emptyList(), done = true, error = "chat no longer exists")
+                            throw ChatSubscribeFinished("gone")
+                        }
+                        if (task.status == AgentStatus.Done || task.status == AgentStatus.Error) {
+                            pushSnapshotDiff(eventsFlow.value)
+                            push(emptyList(), done = true)
+                            // Distinguish Error from Done so the CLI can lock the composer on
+                            // crash/failure (AgentStatus.Error may arrive without TaskError/TaskResult).
+                            throw ChatSubscribeFinished(
+                                if (task.status == AgentStatus.Error) "error" else "terminal",
+                            )
+                        }
+                    }
+            }
+            lifetime.invokeOnCompletion { collectorJob.cancel() }
+            collectorJob.join()
+        }
+    } catch (finished: ChatSubscribeFinished) {
+        endReason = finished.reason
+    } catch (cancelled: CancellationException) {
+        endReason = "cancelled"
+        // Disconnect cancel is an expected end of subscribe — return ok rather than error.
+        if (cancelled.message?.contains("client disconnected") != true) {
+            throw cancelled
+        }
+    } finally {
+        lifetime.complete()
+    }
+
+    return CallToolResult(
+        content = listOf(
+            TextContent(
+                text = buildJsonObject {
+                    put("ok", true)
+                    put("subscriptionId", subscriptionId)
+                    put("taskId", taskId)
+                    put("reason", endReason)
+                }.toString(),
+            ),
+        ),
+    )
+}

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopKanbanService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopKanbanService.kt
@@ -160,6 +160,13 @@ class DesktopKanbanService(
         }
     }
 
+    /** Wait for queued persists and write the latest in-memory board (tests / harness). */
+    suspend fun flushPersist() {
+        saveMutex.withLock {
+            store.saveKanbanBoard(_board.value)
+        }
+    }
+
     private fun nextId(prefix: String, board: KanbanBoard): String {
         val existing = buildSet {
             board.lanes.forEach { lane ->

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
@@ -637,6 +637,9 @@ class McpAgentRunClient(
                 put("attachAndyMcp", JsonPrimitive(draft.attachAndyMcp))
                 put("autonomy", JsonPrimitive(draft.autonomy.name))
                 draft.model?.takeIf { it.isNotBlank() }?.let { put("model", JsonPrimitive(it)) }
+                if (draft.imagePaths.isNotEmpty()) {
+                    put("imagePaths", JsonArray(draft.imagePaths.map { JsonPrimitive(it) }))
+                }
                 // Managed evidence bundle ids only (§4) — never a local filesystem path.
                 if (draft.contextBundleIds.isNotEmpty()) {
                     put("contextBundleIds", JsonArray(draft.contextBundleIds.map { JsonPrimitive(it) }))
@@ -683,6 +686,9 @@ class McpAgentRunClient(
                 buildMap {
                     put("taskId", JsonPrimitive(taskId))
                     put("followUp", JsonPrimitive(followUp))
+                    if (imagePaths.isNotEmpty()) {
+                        put("imagePaths", JsonArray(imagePaths.map { JsonPrimitive(it) }))
+                    }
                     // Managed evidence bundle ids only (§4) — never a local filesystem path.
                     if (contextBundleIds.isNotEmpty()) {
                         put("contextBundleIds", JsonArray(contextBundleIds.map { JsonPrimitive(it) }))
@@ -774,6 +780,9 @@ class McpAgentRunClient(
                 buildMap {
                     put("taskId", JsonPrimitive(taskId))
                     put("followUp", JsonPrimitive(followUp))
+                    if (imagePaths.isNotEmpty()) {
+                        put("imagePaths", JsonArray(imagePaths.map { JsonPrimitive(it) }))
+                    }
                     if (contextBundleIds.isNotEmpty()) {
                         put("contextBundleIds", JsonArray(contextBundleIds.map { JsonPrimitive(it) }))
                     }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
@@ -34,6 +34,15 @@ import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import java.io.File
 
+private val ImagePathsSchema = buildJsonObject {
+    put("type", "array")
+    put("items", buildJsonObject { put("type", "string") })
+    put(
+        "description",
+        "Raw local absolute image paths on the same host (jpg/jpeg/png/gif/webp)",
+    )
+}
+
 /** MCP argument keys that would smuggle a raw filesystem path in place of a managed evidence bundle id. */
 private val DisallowedRawPathKeys = listOf("evidencePath", "evidencePaths", "filePath", "filePaths", "localPath")
 
@@ -87,69 +96,11 @@ fun Server.registerAgentProjectTools(
     fun textResult(value: String) =
         CallToolResult(content = listOf(TextContent(text = value)))
 
-    fun AgentEvent.toWire(): JsonObject = buildJsonObject {
-        put("atMillis", atMillis)
-        when (this@toWire) {
-            is AgentEvent.SessionStarted -> { put("type", "session"); put("sessionId", sessionId.orEmpty()); put("model", model.orEmpty()) }
-            is AgentEvent.AssistantText -> { put("type", "assistant"); put("text", text); put("stream", isStreamDelta) }
-            is AgentEvent.Thinking -> { put("type", "thinking"); put("text", text); put("stream", isStreamDelta) }
-            is AgentEvent.UserMessage -> { put("type", "user"); put("text", text); put("images", JsonArray(imagePaths.map(::JsonPrimitive))) }
-            is AgentEvent.ToolCall -> {
-                put("type", "tool")
-                put("toolName", toolName)
-                put("toolCallId", toolCallId.orEmpty())
-                put("summary", summary)
-                put("detail", detail)
-                put("kind", kind?.name.orEmpty())
-                put("state", state.name)
-                put("locations", JsonArray(locations.map(::JsonPrimitive)))
-            }
-            is AgentEvent.ToolResult -> {
-                put("type", "tool-result"); put("toolName", toolName.orEmpty()); put("summary", summary)
-                put("detail", detail); put("isError", isError)
-            }
-            is AgentEvent.TaskError -> { put("type", "error"); put("text", message) }
-            is AgentEvent.TaskResult -> {
-                put("type", "result"); put("success", success); put("finalText", finalText.orEmpty())
-                put("costUsd", costUsd ?: 0.0); put("costEstimated", costIsEstimated)
-                put("inputTokens", inputTokens ?: 0L); put("outputTokens", outputTokens ?: 0L)
-                put("durationMs", durationMs ?: 0L)
-            }
-            is AgentEvent.ContextUsage -> { put("type", "usage"); put("usedTokens", usedTokens ?: 0L); put("windowTokens", windowTokens ?: 0L) }
-            is AgentEvent.PlanUpdate -> {
-                put("type", "plan")
-                put("entries", buildJsonArray { entries.forEach { entry -> add(buildJsonObject { put("content", entry.content); put("status", entry.status) }) } })
-                markdown?.let { put("markdown", it) }
-            }
-            is AgentEvent.ModeChanged -> { put("type", "mode"); put("modeId", modeId) }
-            is AgentEvent.AvailableCommands -> {
-                put("type", "commands")
-                put("commands", buildJsonArray { commands.forEach { command -> add(buildJsonObject { put("name", command.name); put("description", command.description); put("inputHint", command.inputHint.orEmpty()) }) } })
-            }
-            is AgentEvent.AvailableModes -> {
-                put("type", "modes")
-                put("currentModeId", currentModeId.orEmpty())
-                put("modes", buildJsonArray { modes.forEach { mode -> add(buildJsonObject { put("id", mode.id); put("name", mode.name); put("description", mode.description.orEmpty()) }) } })
-            }
-            is AgentEvent.PermissionRequest -> {
-                put("type", "permission"); put("requestId", requestId); put("toolName", toolName); put("question", question)
-                put("options", buildJsonArray { options.forEach { option -> add(buildJsonObject { put("label", option.label); put("description", option.description) }) } })
-            }
-            is AgentEvent.PermissionResolved -> {
-                put("type", "permission-resolved")
-                put("requestId", requestId)
-                put("optionId", optionId)
-                put("allowed", allowed)
-                note?.let { put("note", it) }
-            }
-            is AgentEvent.Raw -> { put("type", "raw"); put("line", line) }
-        }
-    }
-
     /**
      * Managed evidence bundle ids are the only way to attach investigation context over MCP
      * (§4/§5) — reject any argument that looks like it is trying to smuggle a raw filesystem
      * path instead, with a clear error pointing the caller at `contextBundleIds`.
+     * Chat image attachments use the separate `imagePaths` parameter and are not covered here.
      */
     fun rejectRawEvidencePaths(args: Map<String, JsonElement>) {
         val found = DisallowedRawPathKeys.firstOrNull { it in args }
@@ -361,6 +312,31 @@ fun Server.registerAgentProjectTools(
         textResult(buildJsonArray { events.forEach { add(it.toWire()) } }.toString())
     }
 
+    addTool(
+        "chat.subscribe",
+        "Stream structured transcript events for an ACP chat until cancelled",
+        ToolSchema(
+            properties = buildJsonObject {
+                put("taskId", buildJsonObject { put("type", "string") })
+            },
+            required = listOf("taskId"),
+        ),
+    ) { request ->
+        // Receiver is ClientConnection — required for mid-call notifications.
+        try {
+            val id = request.arguments?.get("taskId")?.jsonPrimitive?.contentOrNull
+                ?: error("taskId required")
+            runChatSubscribe(this, agentRuns, id)
+        } catch (cancelled: kotlinx.coroutines.CancellationException) {
+            throw cancelled
+        } catch (e: Exception) {
+            CallToolResult(
+                content = listOf(TextContent(text = "Error: ${e.message ?: e.toString()}")),
+                isError = true,
+            )
+        }
+    }
+
     register(
         name = "chat.start",
         description = "Start a new agent chat/task",
@@ -422,6 +398,7 @@ fun Server.registerAgentProjectTools(
                 put("items", buildJsonObject { put("type", "string") })
                 put("description", "Managed evidence bundle ids (§4) to attach; never raw filesystem paths")
             },
+            "imagePaths" to ImagePathsSchema,
             "provenance" to buildJsonObject {
                 put("type", "object")
                 put(
@@ -454,6 +431,7 @@ fun Server.registerAgentProjectTools(
         val attachAndyMcp = args["attachAndyMcp"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull()
             ?: args["attachAndyMcp"]?.jsonPrimitive?.booleanOrNull
             ?: false
+        val imagePaths = parseImagePathsArg(args)
         val task = agentRuns.createAndStart(
             AgentTaskDraft(
                 title = str(args, "title")?.takeIf { it.isNotBlank() } ?: prompt.take(48),
@@ -467,6 +445,7 @@ fun Server.registerAgentProjectTools(
                 attachAndyMcp = attachAndyMcp,
                 autonomy = autonomy,
                 model = model,
+                imagePaths = imagePaths,
                 contextBundleIds = strList(args, "contextBundleIds"),
                 provenance = parseProvenance(args),
             ),
@@ -677,13 +656,20 @@ fun Server.registerAgentProjectTools(
                 put("items", buildJsonObject { put("type", "string") })
                 put("description", "Managed evidence bundle ids (§4) to attach; never raw filesystem paths")
             },
+            "imagePaths" to ImagePathsSchema,
         ),
         required = listOf("taskId", "followUp"),
     ) { args ->
         rejectRawEvidencePaths(args)
         val id = str(args, "taskId") ?: error("taskId required")
         val followUp = str(args, "followUp") ?: error("followUp required")
-        agentRuns.resume(id, followUp, contextBundleIds = strList(args, "contextBundleIds"))
+        val imagePaths = parseImagePathsArg(args)
+        agentRuns.resume(
+            id,
+            followUp,
+            imagePaths = imagePaths,
+            contextBundleIds = strList(args, "contextBundleIds"),
+        )
         textResult("""{"ok":true,"id":"$id"}""")
     }
 
@@ -698,13 +684,20 @@ fun Server.registerAgentProjectTools(
                 put("items", buildJsonObject { put("type", "string") })
                 put("description", "Managed evidence bundle ids (§4) to attach; never raw filesystem paths")
             },
+            "imagePaths" to ImagePathsSchema,
         ),
         required = listOf("taskId", "followUp"),
     ) { args ->
         rejectRawEvidencePaths(args)
         val id = str(args, "taskId") ?: error("taskId required")
         val followUp = str(args, "followUp") ?: error("followUp required")
-        agentRuns.queueFollowUp(id, followUp, contextBundleIds = strList(args, "contextBundleIds"))
+        val imagePaths = parseImagePathsArg(args)
+        agentRuns.queueFollowUp(
+            id,
+            followUp,
+            imagePaths = imagePaths,
+            contextBundleIds = strList(args, "contextBundleIds"),
+        )
         textResult("""{"ok":true,"id":"$id"}""")
     }
 
@@ -802,9 +795,12 @@ fun Server.registerAgentProjectTools(
             buildJsonObject {
                 put("id", id)
                 put("status", task?.status?.name.orEmpty())
+                put("lane", task?.lane?.name.orEmpty())
                 put("statusConfident", task?.statusConfident ?: false)
                 put("tmuxAlive", TmuxAndy.isAvailable() && TmuxAndy.hasSession(id))
                 put("tmuxSession", TmuxAndy.sessionName(id))
+                put("cwd", task?.cwd.orEmpty())
+                put("originDir", task?.originDir.orEmpty())
             }.toString(),
         )
     }
@@ -1036,6 +1032,8 @@ fun Server.registerAgentProjectTools(
 fun agentProjectToolNames(): List<String> = listOf(
     "chat.list",
     "chat.composer_options",
+    "chat.events",
+    "chat.subscribe",
     "chat.start",
     "chat.stop",
     "chat.mark_read",

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpUnixSocketServer.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpUnixSocketServer.kt
@@ -1,12 +1,13 @@
 package app.andy.desktop.service
 
 import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerSession
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.io.asSink
 import kotlinx.io.asSource
@@ -74,6 +75,7 @@ class McpUnixSocketServer(
 
     fun stopBlocking() {
         if (!started.compareAndSet(true, false)) return
+        ChatSubscribeRegistry.cancelAll()
         runCatching { serverChannel?.close() }
         serverChannel = null
         acceptThread?.interrupt()
@@ -100,21 +102,34 @@ class McpUnixSocketServer(
     }
 
     private suspend fun handleClient(client: SocketChannel) {
+        var transport: StdioServerTransport? = null
+        var session: ServerSession? = null
         try {
             val input = Channels.newInputStream(client)
             val output = Channels.newOutputStream(client)
-            val transport = StdioServerTransport(
+            transport = StdioServerTransport(
                 input = input.asSource().buffered(),
                 output = output.asSink().buffered(),
             )
             val server = createServer()
-            server.createSession(transport)
-            while (client.isOpen && started.get() && scope.isActive) {
-                kotlinx.coroutines.delay(500)
+            // Peer disconnect does not flip SocketChannel.isOpen — wait on session close
+            // (transport EOF) so in-flight tools like chat.subscribe are cancelled.
+            val sessionClosed = CompletableDeferred<Unit>()
+            session = server.createSession(transport).also { created ->
+                created.onClose {
+                    // SDK leaves in-flight tool coroutines running on transport EOF;
+                    // cancel chat.subscribe collectors registered for this session.
+                    ChatSubscribeRegistry.cancelSession(created.sessionId)
+                    sessionClosed.complete(Unit)
+                }
             }
+            sessionClosed.await()
         } catch (_: Exception) {
             // Client disconnect is normal.
         } finally {
+            session?.sessionId?.let { ChatSubscribeRegistry.cancelSession(it) }
+            runCatching { session?.close() }
+            runCatching { transport?.close() }
             runCatching { client.close() }
         }
     }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/McpUnixSocketServer.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/McpUnixSocketServer.kt
@@ -12,6 +12,9 @@ import kotlinx.coroutines.launch
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import java.io.File
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
@@ -105,8 +108,19 @@ class McpUnixSocketServer(
         var transport: StdioServerTransport? = null
         var session: ServerSession? = null
         try {
-            val input = Channels.newInputStream(client)
-            val output = Channels.newOutputStream(client)
+            val sessionClosed = CompletableDeferred<Unit>()
+            val disconnected = AtomicBoolean(false)
+            fun onPeerDisconnect() {
+                if (!disconnected.compareAndSet(false, true)) return
+                session?.sessionId?.let { ChatSubscribeRegistry.cancelSession(it) }
+                sessionClosed.complete(Unit)
+            }
+
+            val input = EofNotifyingInputStream(Channels.newInputStream(client), ::onPeerDisconnect)
+            val output = PeerDisconnectNotifyingOutputStream(
+                FlushOnWriteOutputStream(Channels.newOutputStream(client)),
+                ::onPeerDisconnect,
+            )
             transport = StdioServerTransport(
                 input = input.asSource().buffered(),
                 output = output.asSink().buffered(),
@@ -114,13 +128,11 @@ class McpUnixSocketServer(
             val server = createServer()
             // Peer disconnect does not flip SocketChannel.isOpen — wait on session close
             // (transport EOF) so in-flight tools like chat.subscribe are cancelled.
-            val sessionClosed = CompletableDeferred<Unit>()
             session = server.createSession(transport).also { created ->
                 created.onClose {
                     // SDK leaves in-flight tool coroutines running on transport EOF;
                     // cancel chat.subscribe collectors registered for this session.
-                    ChatSubscribeRegistry.cancelSession(created.sessionId)
-                    sessionClosed.complete(Unit)
+                    onPeerDisconnect()
                 }
             }
             sessionClosed.await()
@@ -133,4 +145,88 @@ class McpUnixSocketServer(
             runCatching { client.close() }
         }
     }
+}
+
+/** Flushes after every write so peer-close surfaces as IOException on the next push. */
+private class FlushOnWriteOutputStream(
+    private val delegate: OutputStream,
+) : OutputStream() {
+    override fun write(b: Int) {
+        delegate.write(b)
+        delegate.flush()
+    }
+
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        delegate.write(b, off, len)
+        delegate.flush()
+    }
+
+    override fun flush() = delegate.flush()
+
+    override fun close() = delegate.close()
+}
+
+private class PeerDisconnectNotifyingOutputStream(
+    private val delegate: OutputStream,
+    private val onDisconnect: () -> Unit,
+) : OutputStream() {
+    private fun onIoError(error: IOException): Nothing {
+        onDisconnect()
+        throw error
+    }
+
+    override fun write(b: Int) {
+        try {
+            delegate.write(b)
+        } catch (error: IOException) {
+            onIoError(error)
+        }
+    }
+
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        try {
+            delegate.write(b, off, len)
+        } catch (error: IOException) {
+            onIoError(error)
+        }
+    }
+
+    override fun flush() {
+        try {
+            delegate.flush()
+        } catch (error: IOException) {
+            onIoError(error)
+        }
+    }
+
+    override fun close() = delegate.close()
+}
+
+private class EofNotifyingInputStream(
+    private val delegate: InputStream,
+    private val onEof: () -> Unit,
+) : InputStream() {
+    private val eofNotified = AtomicBoolean(false)
+
+    private fun notifyEof() {
+        if (eofNotified.compareAndSet(false, true)) {
+            onEof()
+        }
+    }
+
+    override fun read(): Int {
+        val value = delegate.read()
+        if (value == -1) notifyEof()
+        return value
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+        val count = delegate.read(b, off, len)
+        if (count == -1) notifyEof()
+        return count
+    }
+
+    override fun available(): Int = delegate.available()
+
+    override fun close() = delegate.close()
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopKanbanServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopKanbanServiceTest.kt
@@ -6,6 +6,7 @@ import app.andy.model.KanbanCard
 import app.andy.model.KanbanLane
 import app.andy.service.KanbanLaneDirection
 import java.io.File
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -111,9 +112,7 @@ class DesktopKanbanServiceTest {
             val service = DesktopKanbanService(store)
             service.addLane("QA")
             service.addCard("todo", "Persist me", "desc", listOf("save"))
-            // Force a synchronous write of the in-memory board so reload does not race
-            // still-queued async saves from mutate().
-            store.saveKanbanBoard(service.board.value)
+            runBlocking { service.flushPersist() }
             val reloaded = DesktopKanbanService(DesktopAgentTaskStore(db))
             assertTrue(reloaded.board.value.lanes.any { it.name == "QA" })
             val todoCards = reloaded.board.value.lanes.first { it.id == "todo" }.cards

--- a/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentEvidenceHandoffTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentEvidenceHandoffTest.kt
@@ -284,7 +284,12 @@ private class FakeEvidenceAgentRunService : AgentRunService by UnavailableAgentR
         val contextBundleIds: List<String>,
         val provenance: AgentContextualProvenance?,
     )
-    data class ResumeCall(val taskId: String, val followUp: String, val contextBundleIds: List<String>)
+    data class ResumeCall(
+        val taskId: String,
+        val followUp: String,
+        val contextBundleIds: List<String>,
+        val imagePaths: List<String>,
+    )
 
     private val _tasks = MutableStateFlow<List<AgentTask>>(emptyList())
     override val tasks: StateFlow<List<AgentTask>> = _tasks
@@ -318,6 +323,6 @@ private class FakeEvidenceAgentRunService : AgentRunService by UnavailableAgentR
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
     ) {
-        resumeCalls += ResumeCall(taskId, followUp, contextBundleIds)
+        resumeCalls += ResumeCall(taskId, followUp, contextBundleIds, imagePaths)
     }
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/McpChatSubscribeTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/McpChatSubscribeTest.kt
@@ -1,0 +1,632 @@
+package app.andy.desktop.service
+
+import app.andy.model.AgentEvent
+import app.andy.model.AgentKind
+import app.andy.model.AgentLaneKind
+import app.andy.model.AgentSkill
+import app.andy.model.AgentStatus
+import app.andy.model.AgentTask
+import app.andy.model.AgentTaskDraft
+import app.andy.service.AgentRunService
+import app.andy.service.UnavailableAgentRunService
+import app.andy.service.UnavailableProjectWorkflowService
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Covers [chat.subscribe] streaming over a real [McpUnixSocketServer] plus
+ * `imagePaths` plumbing/validation on chat.start / chat.resume / chat.queue_follow_up.
+ */
+class McpChatSubscribeTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun subscribePushesBacklogThenLiveEvents() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            fake.seedTask("task-1", AgentStatus.Working)
+            fake.appendEvent("task-1", AgentEvent.UserMessage(1, "hello"))
+
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(socketPath.toPath()))
+                val reader = BufferedReader(Channels.newReader(channel, Charsets.UTF_8))
+                val writer = BufferedWriter(Channels.newWriter(channel, Charsets.UTF_8))
+                handshake(writer, reader)
+
+                writer.write(
+                    buildJsonObject {
+                        put("jsonrpc", "2.0")
+                        put("id", 2)
+                        put("method", "tools/call")
+                        put(
+                            "params",
+                            buildJsonObject {
+                                put("name", "chat.subscribe")
+                                put("arguments", buildJsonObject { put("taskId", "task-1") })
+                            },
+                        )
+                    }.toString(),
+                )
+                writer.write("\n")
+                writer.flush()
+
+                val backlog = withTimeout(10_000) {
+                    awaitSubscribeNotification(reader)
+                }
+                assertEquals("task-1", backlog.string("taskId"))
+                assertEquals(1, backlog.array("events").size)
+                assertEquals("user", backlog.array("events")[0].jsonObject.string("type"))
+
+                withTimeout(10_000) {
+                    while (ChatSubscribeMetrics.activeCollectorCount() < 1) delay(25)
+                }
+
+                fake.appendEvent("task-1", AgentEvent.AssistantText(2, "world"))
+                val live = withTimeout(10_000) {
+                    awaitSubscribeNotification(reader)
+                }
+                assertEquals(1, live.array("events").size)
+                assertEquals("assistant", live.array("events")[0].jsonObject.string("type"))
+                assertEquals("world", live.array("events")[0].jsonObject.string("text"))
+
+                // Closing the socket + a subsequent event wakes the collector; the failed
+                // push cancels the lifetime token (SDK transport close can hang on writers).
+                channel.close()
+                fake.appendEvent("task-1", AgentEvent.AssistantText(3, "after-disconnect"))
+                withTimeout(10_000) {
+                    while (ChatSubscribeMetrics.activeCollectorCount() > 0) delay(25)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun subscribePushesInPlaceCoalescedReplacements() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            fake.seedTask("task-coalesce", AgentStatus.Working)
+            fake.appendEvent("task-coalesce", AgentEvent.UserMessage(1, "hi"))
+            fake.appendEvent(
+                "task-coalesce",
+                AgentEvent.AssistantText(2, "hel", isStreamDelta = true),
+            )
+
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(socketPath.toPath()))
+                val reader = BufferedReader(Channels.newReader(channel, Charsets.UTF_8))
+                val writer = BufferedWriter(Channels.newWriter(channel, Charsets.UTF_8))
+                handshake(writer, reader)
+
+                writer.write(
+                    buildJsonObject {
+                        put("jsonrpc", "2.0")
+                        put("id", 2)
+                        put("method", "tools/call")
+                        put(
+                            "params",
+                            buildJsonObject {
+                                put("name", "chat.subscribe")
+                                put("arguments", buildJsonObject { put("taskId", "task-coalesce") })
+                            },
+                        )
+                    }.toString(),
+                )
+                writer.write("\n")
+                writer.flush()
+
+                val backlog = withTimeout(10_000) { awaitSubscribeNotification(reader) }
+                assertEquals(2, backlog.array("events").size)
+
+                withTimeout(10_000) {
+                    while (ChatSubscribeMetrics.activeCollectorCount() < 1) delay(25)
+                }
+
+                // Same-size in-place coalesce (stream delta append) must still notify.
+                fake.replaceEvent(
+                    "task-coalesce",
+                    1,
+                    AgentEvent.AssistantText(2, "hello", isStreamDelta = true),
+                )
+                val live = withTimeout(10_000) { awaitSubscribeNotification(reader) }
+                assertEquals(1, live.int("replaceFrom"))
+                assertEquals(1, live.array("events").size)
+                assertEquals("assistant", live.array("events")[0].jsonObject.string("type"))
+                assertEquals("hello", live.array("events")[0].jsonObject.string("text"))
+
+                channel.close()
+                fake.appendEvent("task-coalesce", AgentEvent.AssistantText(3, "after"))
+                withTimeout(10_000) {
+                    while (ChatSubscribeMetrics.activeCollectorCount() > 0) delay(25)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun subscribeEndsWhenTaskReachesTerminalStatus() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            fake.seedTask("done-1", AgentStatus.Working)
+            fake.appendEvent("done-1", AgentEvent.UserMessage(1, "hi"))
+
+            val resultText = async(Dispatchers.IO) {
+                callSubscribeUntilResult(socketPath, "done-1") {
+                    fake.setStatus("done-1", AgentStatus.Done)
+                }
+            }
+            val text = withTimeout(15_000) { resultText.await() }
+            assertTrue(text.contains("\"ok\":true") || text.contains("\"ok\": true"), text)
+            assertTrue(text.contains("\"reason\":\"terminal\"") || text.contains("\"reason\": \"terminal\""), text)
+            withTimeout(10_000) {
+                while (ChatSubscribeMetrics.activeCollectorCount() > 0) delay(25)
+            }
+        }
+    }
+
+    @Test
+    fun subscribeEndsWithErrorReasonWhenTaskFails() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            fake.seedTask("err-1", AgentStatus.Working)
+            fake.appendEvent("err-1", AgentEvent.UserMessage(1, "hi"))
+
+            val resultText = async(Dispatchers.IO) {
+                callSubscribeUntilResult(socketPath, "err-1") {
+                    // Error without TaskError/TaskResult — status alone must signal failure.
+                    fake.setStatus("err-1", AgentStatus.Error)
+                }
+            }
+            val text = withTimeout(15_000) { resultText.await() }
+            assertTrue(text.contains("\"ok\":true") || text.contains("\"ok\": true"), text)
+            assertTrue(text.contains("\"reason\":\"error\"") || text.contains("\"reason\": \"error\""), text)
+            assertFalse(text.contains("\"reason\":\"terminal\""), text)
+            withTimeout(10_000) {
+                while (ChatSubscribeMetrics.activeCollectorCount() > 0) delay(25)
+            }
+        }
+    }
+
+    @Test
+    fun resumeForwardsImagePaths() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            val png = File.createTempFile("andy-img", ".png").also { it.writeBytes(byteArrayOf(1, 2, 3)) }
+            try {
+                val (isError, text) = callRawTool(
+                    socketPath,
+                    "chat.resume",
+                    mapOf(
+                        "taskId" to JsonPrimitive("task-1"),
+                        "followUp" to JsonPrimitive("look"),
+                        "imagePaths" to JsonArray(listOf(JsonPrimitive(png.absolutePath))),
+                    ),
+                )
+                assertFalse(isError, text)
+                withTimeout(10_000) { while (fake.resumeCalls.isEmpty()) delay(25) }
+                assertEquals(listOf(png.absolutePath), fake.resumeCalls.single().imagePaths)
+            } finally {
+                png.delete()
+            }
+        }
+    }
+
+    @Test
+    fun queueFollowUpForwardsImagePaths() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            val jpg = File.createTempFile("andy-img", ".jpg").also { it.writeBytes(byteArrayOf(9)) }
+            try {
+                val (isError, text) = callRawTool(
+                    socketPath,
+                    "chat.queue_follow_up",
+                    mapOf(
+                        "taskId" to JsonPrimitive("task-1"),
+                        "followUp" to JsonPrimitive("queued"),
+                        "imagePaths" to JsonArray(listOf(JsonPrimitive(jpg.absolutePath))),
+                    ),
+                )
+                assertFalse(isError, text)
+                withTimeout(10_000) { while (fake.queueCalls.isEmpty()) delay(25) }
+                assertEquals(listOf(jpg.absolutePath), fake.queueCalls.single().imagePaths)
+            } finally {
+                jpg.delete()
+            }
+        }
+    }
+
+    @Test
+    fun chatStartForwardsImagePaths() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            val webp = File.createTempFile("andy-img", ".webp").also { it.writeBytes(byteArrayOf(4)) }
+            try {
+                val (isError, text) = callRawTool(
+                    socketPath,
+                    "chat.start",
+                    mapOf(
+                        "prompt" to JsonPrimitive("with image"),
+                        "agent" to JsonPrimitive("Codex"),
+                        "imagePaths" to JsonArray(listOf(JsonPrimitive(webp.absolutePath))),
+                    ),
+                )
+                assertFalse(isError, text)
+                withTimeout(10_000) { while (fake.startCalls.isEmpty()) delay(25) }
+                assertEquals(listOf(webp.absolutePath), fake.startCalls.single().imagePaths)
+            } finally {
+                webp.delete()
+            }
+        }
+    }
+
+    @Test
+    fun resumeRejectsInvalidImageExtension() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            val txt = File.createTempFile("andy-img", ".txt").also { it.writeText("nope") }
+            try {
+                val (isError, text) = callRawTool(
+                    socketPath,
+                    "chat.resume",
+                    mapOf(
+                        "taskId" to JsonPrimitive("task-1"),
+                        "followUp" to JsonPrimitive("look"),
+                        "imagePaths" to JsonArray(listOf(JsonPrimitive(txt.absolutePath))),
+                    ),
+                )
+                assertTrue(isError, text)
+                assertTrue(text.contains("unsupported image type") || text.contains(".txt"), text)
+                assertTrue(fake.resumeCalls.isEmpty())
+            } finally {
+                txt.delete()
+            }
+        }
+    }
+
+    @Test
+    fun resumeRejectsMissingImagePath() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            val missing = File("/tmp/andy-missing-image-${System.nanoTime()}.png")
+            val (isError, text) = callRawTool(
+                socketPath,
+                "chat.resume",
+                mapOf(
+                    "taskId" to JsonPrimitive("task-1"),
+                    "followUp" to JsonPrimitive("look"),
+                    "imagePaths" to JsonArray(listOf(JsonPrimitive(missing.absolutePath))),
+                ),
+            )
+            assertTrue(isError, text)
+            assertTrue(text.contains("not found") || text.contains("not a regular file"), text)
+            assertTrue(fake.resumeCalls.isEmpty())
+        }
+    }
+
+    @Test
+    fun resumeRejectsNonArrayImagePaths() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            val (isError, text) = callRawTool(
+                socketPath,
+                "chat.resume",
+                mapOf(
+                    "taskId" to JsonPrimitive("task-1"),
+                    "followUp" to JsonPrimitive("look"),
+                    "imagePaths" to JsonPrimitive("/tmp/not-an-array.png"),
+                ),
+            )
+            assertTrue(isError, text)
+            assertTrue(text.contains("imagePaths must be an array"), text)
+            assertTrue(fake.resumeCalls.isEmpty())
+        }
+    }
+
+    @Test
+    fun resumeRejectsNullImagePathEntries() = runBlocking {
+        withMcpHarness { fake, socketPath ->
+            val (isError, text) = callRawTool(
+                socketPath,
+                "chat.resume",
+                mapOf(
+                    "taskId" to JsonPrimitive("task-1"),
+                    "followUp" to JsonPrimitive("look"),
+                    "imagePaths" to JsonArray(listOf(JsonNull)),
+                ),
+            )
+            assertTrue(isError, text)
+            assertTrue(text.contains("imagePaths[0] must be a string"), text)
+            assertTrue(fake.resumeCalls.isEmpty())
+        }
+    }
+
+    private suspend fun withMcpHarness(
+        block: suspend (FakeSubscribeAgentRunService, File) -> Unit,
+    ) {
+        val dir = File.createTempFile("andy-mcp-subscribe", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        val socketPath = File(dir, "andyd.sock")
+        val fake = FakeSubscribeAgentRunService()
+        val unixServer = McpUnixSocketServer(socketPath) {
+            Server(
+                serverInfo = Implementation("andy-test", "1.0.0"),
+                options = ServerOptions(
+                    capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true)),
+                ),
+            ).apply { registerAgentProjectTools(fake, UnavailableProjectWorkflowService) }
+        }
+        try {
+            unixServer.startBlocking()
+            withTimeout(10_000) { while (!socketPath.exists()) delay(25) }
+            block(fake, socketPath)
+        } finally {
+            unixServer.stopBlocking()
+            dir.deleteRecursively()
+        }
+    }
+
+    private fun handshake(writer: BufferedWriter, reader: BufferedReader) {
+        writer.write(
+            buildJsonObject {
+                put("jsonrpc", "2.0")
+                put("id", 1)
+                put("method", "initialize")
+                put(
+                    "params",
+                    buildJsonObject {
+                        put("protocolVersion", "2024-11-05")
+                        put("capabilities", buildJsonObject {})
+                        put(
+                            "clientInfo",
+                            buildJsonObject {
+                                put("name", "andy-test")
+                                put("version", "1.0.0")
+                            },
+                        )
+                    },
+                )
+            }.toString(),
+        )
+        writer.write("\n")
+        writer.flush()
+        reader.readLine()
+        writer.write(buildJsonObject { put("jsonrpc", "2.0"); put("method", "notifications/initialized") }.toString())
+        writer.write("\n")
+        writer.flush()
+    }
+
+    private fun awaitSubscribeNotification(reader: BufferedReader): JsonObject {
+        while (true) {
+            val line = reader.readLine() ?: error("socket closed before subscribe notification")
+            val root = json.parseToJsonElement(line).jsonObject
+            if (root["id"] != null) continue
+            val method = root["method"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            if (method != ChatSubscribeNotificationMethod) continue
+            val params = root["params"]?.jsonObject ?: error("missing params: $line")
+            return params["_meta"]?.jsonObject
+                ?: params["meta"]?.jsonObject
+                ?: error("missing _meta on subscribe notification: $line")
+        }
+    }
+
+    private suspend fun callSubscribeUntilResult(
+        socketPath: File,
+        taskId: String,
+        afterSubscribe: suspend () -> Unit,
+    ): String = withContext(Dispatchers.IO) {
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(socketPath.toPath()))
+            val reader = BufferedReader(Channels.newReader(channel, Charsets.UTF_8))
+            val writer = BufferedWriter(Channels.newWriter(channel, Charsets.UTF_8))
+            handshake(writer, reader)
+            writer.write(
+                buildJsonObject {
+                    put("jsonrpc", "2.0")
+                    put("id", 2)
+                    put("method", "tools/call")
+                    put(
+                        "params",
+                        buildJsonObject {
+                            put("name", "chat.subscribe")
+                            put("arguments", buildJsonObject { put("taskId", taskId) })
+                        },
+                    )
+                }.toString(),
+            )
+            writer.write("\n")
+            writer.flush()
+
+            // Wait for first notification (backlog), then flip status.
+            awaitSubscribeNotification(reader)
+            afterSubscribe()
+
+            while (true) {
+                val line = reader.readLine() ?: error("no final result")
+                val root = json.parseToJsonElement(line).jsonObject
+                val idEl = root["id"]
+                val matchesId = idEl?.jsonPrimitive?.contentOrNull == "2" ||
+                    idEl?.jsonPrimitive?.contentOrNull?.toIntOrNull() == 2 ||
+                    idEl?.toString() == "2"
+                if (!matchesId) continue
+                val result = root["result"]?.jsonObject
+                return@use result
+                    ?.get("content")
+                    ?.jsonArray
+                    ?.firstOrNull()
+                    ?.jsonObject
+                    ?.get("text")
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+                    .orEmpty()
+            }
+            @Suppress("UNREACHABLE_CODE")
+            error("unreachable")
+        }
+    }
+
+    private suspend fun callRawTool(
+        socketPath: File,
+        name: String,
+        arguments: Map<String, JsonElement>,
+    ): Pair<Boolean, String> = withContext(Dispatchers.IO) {
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(socketPath.toPath()))
+            val reader = BufferedReader(Channels.newReader(channel, Charsets.UTF_8))
+            val writer = BufferedWriter(Channels.newWriter(channel, Charsets.UTF_8))
+            handshake(writer, reader)
+            writer.write(
+                buildJsonObject {
+                    put("jsonrpc", "2.0")
+                    put("id", 2)
+                    put("method", "tools/call")
+                    put(
+                        "params",
+                        buildJsonObject {
+                            put("name", name)
+                            put("arguments", JsonObject(arguments))
+                        },
+                    )
+                }.toString(),
+            )
+            writer.write("\n")
+            writer.flush()
+            val line = reader.readLine() ?: error("no response for $name")
+            val root = json.parseToJsonElement(line).jsonObject
+            val rpcError = root["error"]?.jsonObject
+            if (rpcError != null) {
+                return@use true to (rpcError["message"]?.jsonPrimitive?.contentOrNull ?: rpcError.toString())
+            }
+            val result = root["result"]?.jsonObject ?: return@use (false to "")
+            val text = result["content"]?.jsonArray
+                ?.firstOrNull()
+                ?.jsonObject
+                ?.get("text")
+                ?.jsonPrimitive
+                ?.contentOrNull
+                .orEmpty()
+            val isError = result["isError"]?.jsonPrimitive?.booleanOrNull == true
+            isError to text
+        }
+    }
+}
+
+private fun JsonObject.string(key: String): String =
+    this[key]?.jsonPrimitive?.contentOrNull.orEmpty()
+
+private fun JsonObject.int(key: String): Int =
+    this[key]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+        ?: error("missing int $key in $this")
+
+private fun JsonObject.array(key: String): List<JsonElement> =
+    this[key]?.jsonArray?.toList().orEmpty()
+
+private class FakeSubscribeAgentRunService : AgentRunService by UnavailableAgentRunService {
+    data class StartCall(val imagePaths: List<String>)
+    data class ResumeCall(val taskId: String, val followUp: String, val imagePaths: List<String>)
+    data class QueueCall(val taskId: String, val followUp: String, val imagePaths: List<String>)
+
+    private val _tasks = MutableStateFlow<List<AgentTask>>(emptyList())
+    private val eventFlows = mutableMapOf<String, MutableStateFlow<List<AgentEvent>>>()
+
+    override val tasks: StateFlow<List<AgentTask>> = _tasks
+    val startCalls = mutableListOf<StartCall>()
+    val resumeCalls = mutableListOf<ResumeCall>()
+    val queueCalls = mutableListOf<QueueCall>()
+
+    fun seedTask(id: String, status: AgentStatus) {
+        _tasks.value = _tasks.value.filterNot { it.id == id } + AgentTask(
+            id = id,
+            title = id,
+            prompt = "",
+            agent = AgentKind.Codex,
+            lane = AgentLaneKind.Acp,
+            status = status,
+            createdAtMillis = 1,
+        )
+        eventFlows.getOrPut(id) { MutableStateFlow(emptyList()) }
+    }
+
+    fun appendEvent(taskId: String, event: AgentEvent) {
+        val flow = eventFlows.getOrPut(taskId) { MutableStateFlow(emptyList()) }
+        flow.value = flow.value + event
+    }
+
+    /** Same-size in-place replacement — mirrors ACP stream/tool coalescing. */
+    fun replaceEvent(taskId: String, index: Int, event: AgentEvent) {
+        val flow = eventFlows.getOrPut(taskId) { MutableStateFlow(emptyList()) }
+        val next = flow.value.toMutableList()
+        next[index] = event
+        flow.value = next
+    }
+
+    fun setStatus(taskId: String, status: AgentStatus) {
+        _tasks.value = _tasks.value.map {
+            if (it.id == taskId) it.copy(status = status) else it
+        }
+    }
+
+    override fun events(taskId: String): StateFlow<List<AgentEvent>> =
+        eventFlows.getOrPut(taskId) { MutableStateFlow(emptyList()) }
+
+    override suspend fun createAndStart(draft: AgentTaskDraft): AgentTask {
+        startCalls += StartCall(draft.imagePaths)
+        val task = AgentTask(
+            id = "fake-task-${startCalls.size}",
+            title = draft.title,
+            prompt = draft.prompt,
+            agent = draft.agent,
+            lane = AgentLaneKind.Acp,
+            status = AgentStatus.Working,
+            createdAtMillis = 1,
+        )
+        _tasks.value = _tasks.value + task
+        return task
+    }
+
+    override fun resume(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: app.andy.model.AgentContextualProvenance?,
+    ) {
+        resumeCalls += ResumeCall(taskId, followUp, imagePaths)
+    }
+
+    override fun queueFollowUp(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: app.andy.model.AgentContextualProvenance?,
+    ) {
+        queueCalls += QueueCall(taskId, followUp, imagePaths)
+    }
+}

--- a/src/desktopTest/kotlin/app/andy/desktop/service/McpChatSubscribeTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/McpChatSubscribeTest.kt
@@ -104,7 +104,7 @@ class McpChatSubscribeTest {
 
                 // Closing the socket + a subsequent event wakes the collector; the failed
                 // push cancels the lifetime token (SDK transport close can hang on writers).
-                channel.close()
+                disconnectClient(channel)
                 fake.appendEvent("task-1", AgentEvent.AssistantText(3, "after-disconnect"))
                 withTimeout(10_000) {
                     while (ChatSubscribeMetrics.activeCollectorCount() > 0) delay(25)
@@ -165,7 +165,7 @@ class McpChatSubscribeTest {
                 assertEquals("assistant", live.array("events")[0].jsonObject.string("type"))
                 assertEquals("hello", live.array("events")[0].jsonObject.string("text"))
 
-                channel.close()
+                disconnectClient(channel)
                 fake.appendEvent("task-coalesce", AgentEvent.AssistantText(3, "after"))
                 withTimeout(10_000) {
                     while (ChatSubscribeMetrics.activeCollectorCount() > 0) delay(25)
@@ -361,6 +361,12 @@ class McpChatSubscribeTest {
             assertTrue(text.contains("imagePaths[0] must be a string"), text)
             assertTrue(fake.resumeCalls.isEmpty())
         }
+    }
+
+    /** Half-close output before close so Windows UDS delivers EOF to the server reader. */
+    private fun disconnectClient(channel: SocketChannel) {
+        runCatching { channel.shutdownOutput() }
+        runCatching { channel.close() }
     }
 
     private suspend fun withMcpHarness(


### PR DESCRIPTION
## Summary
- Add `chat.subscribe` MCP tool and notification stream in andyd so clients receive backlog + live agent events with proper disconnect cleanup.
- Route `andy attach` by task lane: ACP agents open a native Ratatui viewer (conversation, follow-ups, stop/queue, image attachments); terminal agents keep tmux with shared viewer chrome.
- Add Rust mock-MCP integration tests and run `cargo test` in the Andy CLI CI job; document ACP vs terminal attach behavior in ANDYD.md.

## Test plan
- [x] `cargo test --manifest-path cli/andy/Cargo.toml` (unit + subscribe integration)
- [x] `./gradlew :desktopTest --tests McpChatSubscribeTest --tests McpAgentEvidenceHandoffTest`
- [ ] CI: Andy CLI build + test, desktop tests, full PR checks


Made with [Cursor](https://cursor.com)