### PR TITLE
Improve tool call transcript presentation

### DIFF
--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -92,7 +92,7 @@ fun parseToolCallFileArguments(text: String, kind: AgentToolKind? = null): ToolC
     val newKeys = ExplicitNewTextArgumentKeys + if (editKind) AmbiguousNewTextArgumentKeys else emptyList()
     val oldText = oldKeys.firstNotNullOfOrNull { obj.stringValue(it, allowEmpty = true) }
     val newText = newKeys.firstNotNullOfOrNull { obj.stringValue(it, allowEmpty = true) }
-    if (oldText == null && newText == null) return null
+    if (oldText == null && newText == null && kind != AgentToolKind.Delete && kind != AgentToolKind.Move) return null
     return ToolCallFileContent(path = path, oldText = oldText, newText = newText, extraDetail = extraDetail)
 }
 

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -24,7 +24,7 @@ private const val NewMarker = "\n+++ new\n"
 /** Parses tool output shaped like ACP [ToolCallContent.Diff] rendering. */
 fun parseToolCallFileContent(text: String): ToolCallFileContent? {
     val trimmed = text.trim()
-    if (trimmed.isEmpty()) return null
+    if (trimmed.isEmpty() || looksLikeProviderPayload(trimmed)) return null
 
     val oldIndex = trimmed.indexOf(OldMarker)
     val newIndex = trimmed.indexOf(NewMarker)
@@ -79,15 +79,22 @@ fun diffFromToolCallFileContent(content: ToolCallFileContent): AgentFileDiff =
     diffTextLines(content.path, content.oldText, content.newText)
 
 private val WindowsDriveLetter = Regex("""^[A-Za-z]:\\""")
-private const val PathPunctuation = "{}[]\"'`,;()<>|*?\n"
+private val ProviderAssignment = Regex("""^[A-Za-z][A-Za-z0-9 _-]*\s*=""")
+
+private fun looksLikeProviderPayload(text: String): Boolean {
+    val firstLine = text.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
+    return firstLine.startsWith("{") ||
+        firstLine.startsWith("[") ||
+        firstLine.startsWith("- **") ||
+        ProviderAssignment.containsMatchIn(firstLine)
+}
 
 internal fun looksLikeFilePath(text: String): Boolean {
     val trimmed = text.trim()
-    if (trimmed.isBlank() || trimmed.length > 512) return false
-    // Provider payloads are full of slashes and dots, so "has a slash" is not enough: a path is a
-    // single bare token. Anything carrying whitespace or JSON punctuation is a payload, not a path,
-    // and must not be offered as a file to open.
-    if (trimmed.any { it.isWhitespace() || it in PathPunctuation }) return false
+    if (trimmed.isBlank() || trimmed.length > 512 || trimmed.contains('\n')) return false
+    if (trimmed.startsWith("{") || trimmed.startsWith("[") || trimmed.startsWith("- **")) return false
+    // Paths from ACP's structured path field or the dedicated first line may legally contain spaces.
+    // Payload-shaped outer text is rejected before reaching this helper.
     if (trimmed.startsWith("/") || trimmed.startsWith("~/")) return true
     if (WindowsDriveLetter.containsMatchIn(trimmed)) return true
     return trimmed.contains('/') && trimmed.contains('.')

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -1,5 +1,6 @@
 package app.andy.domain
 
+import app.andy.model.AcpToolCallPresentation
 import app.andy.model.AgentFileDiff
 import app.andy.model.AgentToolKind
 import app.andy.model.DiffLine
@@ -14,6 +15,7 @@ data class ToolCallFileContent(
     val path: String,
     val oldText: String?,
     val newText: String?,
+    val extraDetail: String? = null,
 ) {
     /** ACP diff payloads always carry an old snapshot (possibly empty for a new file). */
     val hasDiff: Boolean get() = oldText != null
@@ -37,8 +39,16 @@ fun parseToolCallFileContent(text: String): ToolCallFileContent? {
             ?.takeIf { looksLikeStructuredFilePath(it) }
             ?: return null
         val oldText = trimmed.substring(oldIndex + OldMarker.length, newIndex)
-        val newText = trimmed.substring(newIndex + NewMarker.length)
-        return ToolCallFileContent(path = path, oldText = oldText, newText = newText)
+        val newAndExtra = trimmed.substring(newIndex + NewMarker.length)
+        val separatorIndex = newAndExtra.indexOf(AcpToolCallPresentation.DetailSeparator)
+        val newText = if (separatorIndex >= 0) newAndExtra.substring(0, separatorIndex) else newAndExtra
+        val extraDetail = if (separatorIndex >= 0) {
+            newAndExtra.substring(separatorIndex + AcpToolCallPresentation.DetailSeparator.length)
+                .takeIf { it.isNotBlank() }
+        } else {
+            null
+        }
+        return ToolCallFileContent(path = path, oldText = oldText, newText = newText, extraDetail = extraDetail)
     }
 
     val firstLine = trimmed.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
@@ -168,13 +178,17 @@ private sealed interface LineDiffOp {
 }
 
 private const val MaxLcsCells = 1_000_000L
+private const val MaxLcsDimension = 10_000
 
 private fun lineDiffOperations(oldLines: List<String>, newLines: List<String>): List<LineDiffOp> {
   if (oldLines == newLines) return oldLines.map(LineDiffOp::Context)
   // The exact LCS implementation is quadratic in memory and this function can run while an
   // expanded tool row is being composed. Keep large snapshots responsive by falling back to a
   // linear all-delete/all-add representation rather than allocating an unbounded matrix.
-  if (oldLines.size.toLong() * newLines.size.toLong() > MaxLcsCells) {
+  if (oldLines.size > MaxLcsDimension ||
+      newLines.size > MaxLcsDimension ||
+      oldLines.size.toLong() * newLines.size.toLong() > MaxLcsCells
+  ) {
     return oldLines.map(LineDiffOp::Deletion) + newLines.map(LineDiffOp::Addition)
   }
   val lcs = longestCommonSubsequence(oldLines, newLines)

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -74,8 +74,16 @@ private val AmbiguousNewTextArgumentKeys = listOf("new", "after", "content", "co
  */
 fun parseToolCallFileArguments(text: String, kind: AgentToolKind? = null): ToolCallFileContent? {
     val trimmed = text.trim()
-    if (!trimmed.startsWith("{")) return null
-    val obj = runCatching { toolArgumentJson.parseToJsonElement(trimmed) }.getOrNull() as? JsonObject ?: return null
+    val separatorIndex = trimmed.indexOf(AcpToolCallPresentation.DetailSeparator)
+    val arguments = if (separatorIndex >= 0) trimmed.substring(0, separatorIndex) else trimmed
+    val extraDetail = if (separatorIndex >= 0) {
+        trimmed.substring(separatorIndex + AcpToolCallPresentation.DetailSeparator.length)
+            .takeIf { it.isNotBlank() }
+    } else {
+        null
+    }
+    if (!arguments.startsWith("{")) return null
+    val obj = runCatching { toolArgumentJson.parseToJsonElement(arguments) }.getOrNull() as? JsonObject ?: return null
     val path = PathArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
         ?.takeIf { looksLikeStructuredFilePath(it) }
         ?: return null
@@ -85,7 +93,7 @@ fun parseToolCallFileArguments(text: String, kind: AgentToolKind? = null): ToolC
     val oldText = oldKeys.firstNotNullOfOrNull { obj.stringValue(it) }
     val newText = newKeys.firstNotNullOfOrNull { obj.stringValue(it) }
     if (oldText == null && newText == null) return null
-    return ToolCallFileContent(path = path, oldText = oldText, newText = newText)
+    return ToolCallFileContent(path = path, oldText = oldText, newText = newText, extraDetail = extraDetail)
 }
 
 private fun JsonObject.stringValue(key: String): String? =
@@ -167,6 +175,7 @@ fun diffTextLines(path: String, oldText: String?, newText: String?): AgentFileDi
 }
 
 private fun String.normalizedLines(): List<String> {
+    if (isEmpty()) return emptyList()
     val rows = lines()
     return if (endsWith("\n") && rows.lastOrNull() == "") rows.dropLast(1) else rows
 }

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -179,6 +179,7 @@ private sealed interface LineDiffOp {
 
 private const val MaxLcsCells = 1_000_000L
 private const val MaxLcsDimension = 10_000
+private const val MaxFallbackLinesPerSide = 2_000
 
 private fun lineDiffOperations(oldLines: List<String>, newLines: List<String>): List<LineDiffOp> {
   if (oldLines == newLines) return oldLines.map(LineDiffOp::Context)
@@ -189,7 +190,7 @@ private fun lineDiffOperations(oldLines: List<String>, newLines: List<String>): 
       newLines.size > MaxLcsDimension ||
       oldLines.size.toLong() * newLines.size.toLong() > MaxLcsCells
   ) {
-    return oldLines.map(LineDiffOp::Deletion) + newLines.map(LineDiffOp::Addition)
+    return boundedFallbackOperations(oldLines, newLines)
   }
   val lcs = longestCommonSubsequence(oldLines, newLines)
   val operations = mutableListOf<LineDiffOp>()
@@ -225,6 +226,18 @@ private fun lineDiffOperations(oldLines: List<String>, newLines: List<String>): 
   }
   return operations
 }
+
+private fun boundedFallbackOperations(oldLines: List<String>, newLines: List<String>): List<LineDiffOp> =
+  buildList {
+    addAll(oldLines.take(MaxFallbackLinesPerSide).map(LineDiffOp::Deletion))
+    if (oldLines.size > MaxFallbackLinesPerSide) {
+      add(LineDiffOp.Deletion("… ${oldLines.size - MaxFallbackLinesPerSide} lines omitted"))
+    }
+    addAll(newLines.take(MaxFallbackLinesPerSide).map(LineDiffOp::Addition))
+    if (newLines.size > MaxFallbackLinesPerSide) {
+      add(LineDiffOp.Addition("… ${newLines.size - MaxFallbackLinesPerSide} lines omitted"))
+    }
+  }
 
 private fun longestCommonSubsequence(left: List<String>, right: List<String>): List<String> {
   val table = Array(left.size + 1) { IntArray(right.size + 1) }

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -3,6 +3,10 @@ package app.andy.domain
 import app.andy.model.AgentFileDiff
 import app.andy.model.DiffLine
 import app.andy.model.DiffLineKind
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /** Parsed file reference from an ACP tool-call detail block. */
 data class ToolCallFileContent(
@@ -10,7 +14,8 @@ data class ToolCallFileContent(
     val oldText: String?,
     val newText: String?,
 ) {
-    val hasDiff: Boolean get() = !oldText.isNullOrEmpty() || !newText.isNullOrEmpty()
+    /** ACP diff payloads always carry an old snapshot (possibly empty for a new file). */
+    val hasDiff: Boolean get() = oldText != null
 }
 
 private const val OldMarker = "\n--- old\n"
@@ -45,14 +50,47 @@ fun parseToolCallFileContent(text: String): ToolCallFileContent? {
     )
 }
 
+private val toolArgumentJson = Json { ignoreUnknownKeys = true; isLenient = true }
+private val PathArgumentKeys = listOf("path", "file_path", "filePath", "file", "target_file", "uri")
+private val OldTextArgumentKeys = listOf("old_string", "oldText", "old_str", "old", "before", "search")
+private val NewTextArgumentKeys = listOf("new_string", "newText", "new_str", "new", "after", "content", "contents", "replace")
+
+/**
+ * Edit and write tools frequently send their arguments as JSON instead of a rendered diff.
+ * Recognizing that shape lets the transcript show a real diff rather than the payload.
+ */
+fun parseToolCallFileArguments(text: String): ToolCallFileContent? {
+    val trimmed = text.trim()
+    if (!trimmed.startsWith("{")) return null
+    val obj = runCatching { toolArgumentJson.parseToJsonElement(trimmed) }.getOrNull() as? JsonObject ?: return null
+    val path = PathArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
+        ?.takeIf { looksLikeFilePath(it) }
+        ?: return null
+    val oldText = OldTextArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
+    val newText = NewTextArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
+    if (oldText == null && newText == null) return null
+    return ToolCallFileContent(path = path, oldText = oldText, newText = newText)
+}
+
+private fun JsonObject.stringValue(key: String): String? =
+    (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull?.takeIf { it.isNotEmpty() }
+
 fun diffFromToolCallFileContent(content: ToolCallFileContent): AgentFileDiff =
     diffTextLines(content.path, content.oldText, content.newText)
 
+private val WindowsDriveLetter = Regex("""^[A-Za-z]:\\""")
+private const val PathPunctuation = "{}[]\"'`,;()<>|*?\n"
+
 internal fun looksLikeFilePath(text: String): Boolean {
-    if (text.isBlank()) return false
-    if (text.startsWith("/") || text.startsWith("~/")) return true
-    if (Regex("""^[A-Za-z]:\\""").containsMatchIn(text)) return true
-    return text.contains('/') && text.contains('.')
+    val trimmed = text.trim()
+    if (trimmed.isBlank() || trimmed.length > 512) return false
+    // Provider payloads are full of slashes and dots, so "has a slash" is not enough: a path is a
+    // single bare token. Anything carrying whitespace or JSON punctuation is a payload, not a path,
+    // and must not be offered as a file to open.
+    if (trimmed.any { it.isWhitespace() || it in PathPunctuation }) return false
+    if (trimmed.startsWith("/") || trimmed.startsWith("~/")) return true
+    if (WindowsDriveLetter.containsMatchIn(trimmed)) return true
+    return trimmed.contains('/') && trimmed.contains('.')
 }
 
 /** Builds numbered diff lines from optional before/after snapshots. */

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -1,6 +1,7 @@
 package app.andy.domain
 
 import app.andy.model.AgentFileDiff
+import app.andy.model.AgentToolKind
 import app.andy.model.DiffLine
 import app.andy.model.DiffLineKind
 import kotlinx.serialization.json.Json
@@ -33,7 +34,7 @@ fun parseToolCallFileContent(text: String): ToolCallFileContent? {
             .lineSequence()
             .firstOrNull { it.isNotBlank() }
             ?.trim()
-            ?.takeIf { looksLikeFilePath(it) }
+            ?.takeIf { looksLikeStructuredFilePath(it) }
             ?: return null
         val oldText = trimmed.substring(oldIndex + OldMarker.length, newIndex)
         val newText = trimmed.substring(newIndex + NewMarker.length)
@@ -52,22 +53,27 @@ fun parseToolCallFileContent(text: String): ToolCallFileContent? {
 
 private val toolArgumentJson = Json { ignoreUnknownKeys = true; isLenient = true }
 private val PathArgumentKeys = listOf("path", "file_path", "filePath", "file", "target_file", "uri")
-private val OldTextArgumentKeys = listOf("old_string", "oldText", "old_str", "old", "before", "search")
-private val NewTextArgumentKeys = listOf("new_string", "newText", "new_str", "new", "after", "content", "contents", "replace")
+private val ExplicitOldTextArgumentKeys = listOf("old_string", "oldText", "old_str")
+private val ExplicitNewTextArgumentKeys = listOf("new_string", "newText", "new_str", "replace")
+private val AmbiguousOldTextArgumentKeys = listOf("old", "before", "search")
+private val AmbiguousNewTextArgumentKeys = listOf("new", "after", "content", "contents")
 
 /**
  * Edit and write tools frequently send their arguments as JSON instead of a rendered diff.
  * Recognizing that shape lets the transcript show a real diff rather than the payload.
  */
-fun parseToolCallFileArguments(text: String): ToolCallFileContent? {
+fun parseToolCallFileArguments(text: String, kind: AgentToolKind? = null): ToolCallFileContent? {
     val trimmed = text.trim()
     if (!trimmed.startsWith("{")) return null
     val obj = runCatching { toolArgumentJson.parseToJsonElement(trimmed) }.getOrNull() as? JsonObject ?: return null
     val path = PathArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
-        ?.takeIf { looksLikeFilePath(it) }
+        ?.takeIf { looksLikeStructuredFilePath(it) }
         ?: return null
-    val oldText = OldTextArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
-    val newText = NewTextArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
+    val editKind = kind == AgentToolKind.Edit || kind == AgentToolKind.Delete || kind == AgentToolKind.Move
+    val oldKeys = ExplicitOldTextArgumentKeys + if (editKind) AmbiguousOldTextArgumentKeys else emptyList()
+    val newKeys = ExplicitNewTextArgumentKeys + if (editKind) AmbiguousNewTextArgumentKeys else emptyList()
+    val oldText = oldKeys.firstNotNullOfOrNull { obj.stringValue(it) }
+    val newText = newKeys.firstNotNullOfOrNull { obj.stringValue(it) }
     if (oldText == null && newText == null) return null
     return ToolCallFileContent(path = path, oldText = oldText, newText = newText)
 }
@@ -87,6 +93,14 @@ private fun looksLikeProviderPayload(text: String): Boolean {
         firstLine.startsWith("[") ||
         firstLine.startsWith("- **") ||
         ProviderAssignment.containsMatchIn(firstLine)
+}
+
+private fun looksLikeStructuredFilePath(text: String): Boolean {
+    val trimmed = text.trim()
+    return trimmed.isNotBlank() &&
+        trimmed.length <= 512 &&
+        !trimmed.contains('\n') &&
+        !looksLikeProviderPayload(trimmed)
 }
 
 internal fun looksLikeFilePath(text: String): Boolean {
@@ -153,8 +167,16 @@ private sealed interface LineDiffOp {
     data class Addition(val text: String) : LineDiffOp
 }
 
+private const val MaxLcsCells = 1_000_000L
+
 private fun lineDiffOperations(oldLines: List<String>, newLines: List<String>): List<LineDiffOp> {
   if (oldLines == newLines) return oldLines.map(LineDiffOp::Context)
+  // The exact LCS implementation is quadratic in memory and this function can run while an
+  // expanded tool row is being composed. Keep large snapshots responsive by falling back to a
+  // linear all-delete/all-add representation rather than allocating an unbounded matrix.
+  if (oldLines.size.toLong() * newLines.size.toLong() > MaxLcsCells) {
+    return oldLines.map(LineDiffOp::Deletion) + newLines.map(LineDiffOp::Addition)
+  }
   val lcs = longestCommonSubsequence(oldLines, newLines)
   val operations = mutableListOf<LineDiffOp>()
   var oldIndex = 0

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -90,14 +90,17 @@ fun parseToolCallFileArguments(text: String, kind: AgentToolKind? = null): ToolC
     val editKind = kind == AgentToolKind.Edit || kind == AgentToolKind.Delete || kind == AgentToolKind.Move
     val oldKeys = ExplicitOldTextArgumentKeys + if (editKind) AmbiguousOldTextArgumentKeys else emptyList()
     val newKeys = ExplicitNewTextArgumentKeys + if (editKind) AmbiguousNewTextArgumentKeys else emptyList()
-    val oldText = oldKeys.firstNotNullOfOrNull { obj.stringValue(it) }
-    val newText = newKeys.firstNotNullOfOrNull { obj.stringValue(it) }
+    val oldText = oldKeys.firstNotNullOfOrNull { obj.stringValue(it, allowEmpty = true) }
+    val newText = newKeys.firstNotNullOfOrNull { obj.stringValue(it, allowEmpty = true) }
     if (oldText == null && newText == null) return null
     return ToolCallFileContent(path = path, oldText = oldText, newText = newText, extraDetail = extraDetail)
 }
 
-private fun JsonObject.stringValue(key: String): String? =
-    (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull?.takeIf { it.isNotEmpty() }
+private fun JsonObject.stringValue(key: String, allowEmpty: Boolean = false): String? =
+    (this[key] as? JsonPrimitive)
+        ?.takeIf { it.isString }
+        ?.contentOrNull
+        ?.takeIf { allowEmpty || it.isNotEmpty() }
 
 fun diffFromToolCallFileContent(content: ToolCallFileContent): AgentFileDiff =
     diffTextLines(content.path, content.oldText, content.newText)

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -80,7 +80,7 @@ private fun countHeaderPairsOutsideHunks(text: String): Int {
 
 /** Parses a unified diff into numbered add/delete/context lines for inline review. */
 fun parseUnifiedDiff(text: String, path: String): AgentFileDiff {
-    if (text.contains("Binary files ") && text.contains(" differ")) {
+    if (text.lineSequence().any { it.startsWith("Binary files ") && it.endsWith(" differ") }) {
         return AgentFileDiff(path = path, lines = emptyList(), isBinary = true)
     }
 

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -21,10 +21,12 @@ fun looksLikeUnifiedDiff(text: String): Boolean {
 
 /** Path referenced by the diff's `+++`/`---` headers, stripping the `a/`/`b/` prefixes git adds. */
 fun unifiedDiffPath(text: String): String? {
-    val newHeader = text.lineSequence().firstOrNull { it.startsWith("+++ ") }?.removePrefix("+++ ")?.trim()
-    val oldHeader = text.lineSequence().firstOrNull { it.startsWith("--- ") }?.removePrefix("--- ")?.trim()
+    val newHeader = text.lineSequence().firstOrNull { it.startsWith("+++ ") }
+        ?.removePrefix("+++ ")?.substringBefore('\t')?.trim()
+    val oldHeader = text.lineSequence().firstOrNull { it.startsWith("--- ") }
+        ?.removePrefix("--- ")?.substringBefore('\t')?.trim()
     val candidate = newHeader?.takeUnless { it == "/dev/null" } ?: oldHeader?.takeUnless { it == "/dev/null" }
-    return candidate?.substringBefore('\t')?.removePrefix("b/")?.removePrefix("a/")
+    return candidate?.removePrefix("b/")?.removePrefix("a/")
 }
 
 /** Parses [text] as a unified diff if it looks like one, otherwise returns null. */

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -30,6 +30,12 @@ fun unifiedDiffPath(text: String): String? {
 /** Parses [text] as a unified diff if it looks like one, otherwise returns null. */
 fun detectUnifiedDiff(text: String): AgentFileDiff? {
     if (!looksLikeUnifiedDiff(text)) return null
+    // AgentFileDiff represents one file. Rendering a multi-file patch as one file resets line
+    // numbers at each later hunk and can let a binary entry hide earlier textual changes.
+    val fileCount = text.lineSequence().count { it.startsWith("diff --git ") }
+        .takeIf { it > 0 }
+        ?: text.lineSequence().count { it.startsWith("+++ ") }
+    if (fileCount != 1) return null
     val path = unifiedDiffPath(text) ?: "diff"
     return runCatching { parseUnifiedDiff(text, path) }.getOrNull()
         ?.takeIf { it.isBinary || it.lines.isNotEmpty() }

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -19,6 +19,12 @@ fun looksLikeUnifiedDiff(text: String): Boolean {
     return sawOld && sawNew
 }
 
+/** Returns the patch portion while leaving any leading command diagnostics outside it. */
+fun extractUnifiedDiffText(text: String): String? {
+    val start = Regex("""(?m)^(?:diff --git |--- )""").find(text)?.range?.first ?: return null
+    return text.substring(start).takeIf(::looksLikeUnifiedDiff)
+}
+
 /** Path referenced by the diff's `+++`/`---` headers, stripping the `a/`/`b/` prefixes git adds. */
 fun unifiedDiffPath(text: String): String? {
     val newHeader = text.lineSequence().firstOrNull { it.startsWith("+++ ") }

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -5,6 +5,35 @@ import app.andy.model.DiffLine
 import app.andy.model.DiffLineKind
 
 private val HunkHeader = Regex("""^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s@@""")
+private val HunkMarker = Regex("""(?m)^@@ .+ @@""")
+
+/** True when [text] looks like a unified diff (---/+++ headers plus at least one @@ hunk). */
+fun looksLikeUnifiedDiff(text: String): Boolean {
+    if (!HunkMarker.containsMatchIn(text)) return false
+    var sawOld = false
+    var sawNew = false
+    text.lineSequence().forEach { line ->
+        if (line.startsWith("--- ")) sawOld = true
+        if (line.startsWith("+++ ")) sawNew = true
+    }
+    return sawOld && sawNew
+}
+
+/** Path referenced by the diff's `+++`/`---` headers, stripping the `a/`/`b/` prefixes git adds. */
+fun unifiedDiffPath(text: String): String? {
+    val newHeader = text.lineSequence().firstOrNull { it.startsWith("+++ ") }?.removePrefix("+++ ")?.trim()
+    val oldHeader = text.lineSequence().firstOrNull { it.startsWith("--- ") }?.removePrefix("--- ")?.trim()
+    val candidate = newHeader?.takeUnless { it == "/dev/null" } ?: oldHeader?.takeUnless { it == "/dev/null" }
+    return candidate?.substringBefore('\t')?.removePrefix("b/")?.removePrefix("a/")
+}
+
+/** Parses [text] as a unified diff if it looks like one, otherwise returns null. */
+fun detectUnifiedDiff(text: String): AgentFileDiff? {
+    if (!looksLikeUnifiedDiff(text)) return null
+    val path = unifiedDiffPath(text) ?: "diff"
+    return runCatching { parseUnifiedDiff(text, path) }.getOrNull()
+        ?.takeIf { it.isBinary || it.lines.isNotEmpty() }
+}
 
 /** Parses a unified diff into numbered add/delete/context lines for inline review. */
 fun parseUnifiedDiff(text: String, path: String): AgentFileDiff {

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -34,11 +34,46 @@ fun detectUnifiedDiff(text: String): AgentFileDiff? {
     // numbers at each later hunk and can let a binary entry hide earlier textual changes.
     val fileCount = text.lineSequence().count { it.startsWith("diff --git ") }
         .takeIf { it > 0 }
-        ?: text.lineSequence().count { it.startsWith("+++ ") }
+        ?: countHeaderPairsOutsideHunks(text)
     if (fileCount != 1) return null
     val path = unifiedDiffPath(text) ?: "diff"
     return runCatching { parseUnifiedDiff(text, path) }.getOrNull()
         ?.takeIf { it.isBinary || it.lines.isNotEmpty() }
+}
+
+private fun countHeaderPairsOutsideHunks(text: String): Int {
+    var count = 0
+    var awaitingNewHeader = false
+    var oldLinesRemaining = 0
+    var newLinesRemaining = 0
+    text.lineSequence().forEach { line ->
+        HunkHeader.find(line)?.let { hunk ->
+            oldLinesRemaining = hunk.groupValues[2].toIntOrNull() ?: 1
+            newLinesRemaining = hunk.groupValues[4].toIntOrNull() ?: 1
+            awaitingNewHeader = false
+            return@forEach
+        }
+        if (oldLinesRemaining > 0 || newLinesRemaining > 0) {
+            when (line.firstOrNull()) {
+                ' ' -> {
+                    oldLinesRemaining = (oldLinesRemaining - 1).coerceAtLeast(0)
+                    newLinesRemaining = (newLinesRemaining - 1).coerceAtLeast(0)
+                }
+                '-' -> oldLinesRemaining = (oldLinesRemaining - 1).coerceAtLeast(0)
+                '+' -> newLinesRemaining = (newLinesRemaining - 1).coerceAtLeast(0)
+            }
+            return@forEach
+        }
+        when {
+            line.startsWith("--- ") -> awaitingNewHeader = true
+            awaitingNewHeader && line.startsWith("+++ ") -> {
+                count += 1
+                awaitingNewHeader = false
+            }
+            line.isNotBlank() -> awaitingNewHeader = false
+        }
+    }
+    return count
 }
 
 /** Parses a unified diff into numbered add/delete/context lines for inline review. */
@@ -58,9 +93,9 @@ fun parseUnifiedDiff(text: String, path: String): AgentFileDiff {
             raw.startsWith("diff ") || raw.startsWith("index ") || raw.startsWith("similarity ") -> Unit
             raw.startsWith("new file mode") -> isNewFile = true
             raw.startsWith("deleted file mode") -> Unit
-            raw.startsWith("--- /dev/null") -> isNewFile = true
-            raw.startsWith("--- ") -> Unit
-            raw.startsWith("+++ ") -> Unit
+            !inHunk && raw.startsWith("--- /dev/null") -> isNewFile = true
+            !inHunk && raw.startsWith("--- ") -> Unit
+            !inHunk && raw.startsWith("+++ ") -> Unit
             raw.startsWith("\\ No newline") -> Unit
             else -> {
                 val hunk = HunkHeader.find(raw)

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -245,6 +245,21 @@ object AcpToolCallPresentation {
         return renderJsonMarkdown(element)
     }
 
+    fun displayDetailExcludingPayload(text: String, excluded: String): String {
+        val trimmed = text.trim()
+        if (!looksLikeJson(trimmed)) return trimmed.replace(excluded, "").trim()
+        val element = runCatching { json.parseToJsonElement(trimmed) }.getOrNull() ?: return trimmed
+        return removePayload(element, excluded)?.let(::renderJsonMarkdown).orEmpty()
+    }
+
+    private fun removePayload(element: JsonElement, excluded: String): JsonElement? = when (element) {
+        is JsonObject -> JsonObject(
+            element.mapNotNull { (key, value) -> removePayload(value, excluded)?.let { key to it } }.toMap(),
+        ).takeIf { it.isNotEmpty() }
+        is JsonArray -> JsonArray(element.mapNotNull { removePayload(it, excluded) }).takeIf { it.isNotEmpty() }
+        is JsonPrimitive -> element.takeUnless { it.isString && it.content == excluded }
+    }
+
     /**
      * The command output, file body, or diff a payload wraps, in the order the keys appear. These
      * are the only parts of a payload worth reading in full, so the transcript renders them as

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -10,7 +10,8 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /** Human-readable labels for sparse ACP tool-call metadata (especially Andy MCP). */
 object AcpToolCallPresentation {
-    const val DetailSeparator = "\n--- tool output\n"
+    /** Control-character framing avoids collisions with ordinary edited file or command content. */
+    const val DetailSeparator = "\u001eandy-tool-output\u001f"
 
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     private val genericTitles = setOf("", "tool", "Tool")

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -365,9 +365,13 @@ object AcpToolCallPresentation {
             a.contains(b) -> a
             isRenderedFileDiff(b) -> b
             isRenderedFileDiff(a) -> "$a$DetailSeparator$b"
+            isJsonObject(a) -> "$a$DetailSeparator$b"
             else -> "$a\n$b"
         }
     }
+
+    private fun isJsonObject(text: String): Boolean =
+        text.startsWith("{") && runCatching { json.parseToJsonElement(text) is JsonObject }.getOrDefault(false)
 
     /** ToolCallContent.Diff's stable text shape; it must remain at byte zero for domain parsing. */
     private fun isRenderedFileDiff(text: String): Boolean =

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -365,10 +365,18 @@ object AcpToolCallPresentation {
             b.contains(a) -> b
             a.contains(b) -> a
             isRenderedFileDiff(b) -> detailExtra(a)?.let { "$b$DetailSeparator$it" } ?: b
-            isRenderedFileDiff(a) -> "$a$DetailSeparator$b"
+            isRenderedFileDiff(a) -> appendExtraDetail(a, b)
             isJsonObject(a) -> "$a$DetailSeparator$b"
             else -> "$a\n$b"
         }
+    }
+
+    private fun appendExtraDetail(detail: String, output: String): String {
+        val separatorIndex = detail.indexOf(DetailSeparator)
+        if (separatorIndex < 0) return "$detail$DetailSeparator$output"
+        val primary = detail.substring(0, separatorIndex)
+        val extra = detail.substring(separatorIndex + DetailSeparator.length)
+        return "$primary$DetailSeparator$extra\n$output"
     }
 
     private fun detailExtra(text: String): String? {

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -257,7 +257,15 @@ object AcpToolCallPresentation {
             element.mapNotNull { (key, value) -> removePayload(value, excluded)?.let { key to it } }.toMap(),
         ).takeIf { it.isNotEmpty() }
         is JsonArray -> JsonArray(element.mapNotNull { removePayload(it, excluded) }).takeIf { it.isNotEmpty() }
-        is JsonPrimitive -> element.takeUnless { it.isString && it.content == excluded }
+        is JsonPrimitive -> {
+            if (!element.isString) {
+                element
+            } else {
+                element.content.replace(excluded, "").trim()
+                    .takeIf { it.isNotEmpty() }
+                    ?.let(::JsonPrimitive)
+            }
+        }
     }
 
     /**

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -360,11 +360,11 @@ object AcpToolCallPresentation {
         return when {
             a.isBlank() -> b
             b.isBlank() -> a
-            isRenderedFileDiff(b) -> b
-            isRenderedFileDiff(a) -> "$a$DetailSeparator$b"
             a == b -> a
             b.contains(a) -> b
             a.contains(b) -> a
+            isRenderedFileDiff(b) -> b
+            isRenderedFileDiff(a) -> "$a$DetailSeparator$b"
             else -> "$a\n$b"
         }
     }

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -364,11 +364,17 @@ object AcpToolCallPresentation {
             a == b -> a
             b.contains(a) -> b
             a.contains(b) -> a
-            isRenderedFileDiff(b) -> b
+            isRenderedFileDiff(b) -> detailExtra(a)?.let { "$b$DetailSeparator$it" } ?: b
             isRenderedFileDiff(a) -> "$a$DetailSeparator$b"
             isJsonObject(a) -> "$a$DetailSeparator$b"
             else -> "$a\n$b"
         }
+    }
+
+    private fun detailExtra(text: String): String? {
+        val separatorIndex = text.indexOf(DetailSeparator)
+        if (separatorIndex < 0) return null
+        return text.substring(separatorIndex + DetailSeparator.length).takeIf { it.isNotBlank() }
     }
 
     private fun isJsonObject(text: String): Boolean =

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -1,6 +1,7 @@
 package app.andy.model
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -19,6 +20,10 @@ object AcpToolCallPresentation {
     )
     private val minimalSuccessOutput =
         Regex("""^\{\s*"?success"?\s*[:=]\s*true\s*\}$""", RegexOption.IGNORE_CASE)
+    /** Placeholders some providers send in place of an empty payload; they state nothing. */
+    private val placeholderOutput = setOf("no details", "none", "n/a", "null", "undefined")
+    private val diffHunkHeader = Regex("""(?m)^@@ .+ @@""")
+    private const val InlineValueLimit = 160
     private val embeddedMcpToolName =
         Regex("""\bmcp_(?:andy|emu)_([a-z0-9_]+)\b""", RegexOption.IGNORE_CASE)
     private val fenceMarkerLine = Regex("""^(`{3,}|~{3,})\S*$""")
@@ -133,6 +138,7 @@ object AcpToolCallPresentation {
     fun isMinimalOutput(text: String): Boolean {
         val trimmed = text.trim()
         if (trimmed.isEmpty() || minimalSuccessOutput.matches(trimmed)) return true
+        if (trimmed.lowercase() in placeholderOutput) return true
         if (trimmed == "{}" || trimmed == "[]") return true
         parseJson(trimmed)?.let { obj ->
             if (obj.isEmpty()) return true
@@ -171,15 +177,26 @@ object AcpToolCallPresentation {
     ): Pair<String, String> {
         val content = contentDetails.trim()
         val inputSummary = summarizeArguments(rawInput)
-        val detail = when {
-            content.isNotBlank() -> content
+        val sections = when {
+            content.isNotBlank() -> listOf(null to content)
             rawInput.isNotBlank() && rawOutput.isNotBlank() &&
                 !isMinimalOutput(rawInput) && !isMinimalOutput(rawOutput) ->
-                "$rawInput\n$rawOutput"
-            rawInput.isNotBlank() && !isMinimalOutput(rawInput) -> rawInput
-            rawOutput.isNotBlank() && !isMinimalOutput(rawOutput) -> rawOutput
-            else -> ""
+                listOf("Input" to rawInput, "Output" to rawOutput)
+            rawInput.isNotBlank() && !isMinimalOutput(rawInput) -> listOf(null to rawInput)
+            rawOutput.isNotBlank() && !isMinimalOutput(rawOutput) -> listOf(null to rawOutput)
+            else -> emptyList()
         }
+        // The summary is derived from the payload as sent; only the body is reformatted, so
+        // rendering choices can never change which text is judged minimal or promoted to a headline.
+        val rawDetail = sections.joinToString("\n") { it.second }
+        val detail = sections.joinToString("\n\n") { (label, value) ->
+            val rendered = displayDetail(value)
+            when {
+                rendered.isBlank() -> ""
+                label == null -> rendered
+                else -> "### $label\n$rendered"
+            }
+        }.trim()
         val firstContentLine = firstMeaningfulLine(content)
         val summary = when {
             inputSummary.isNotBlank() -> inputSummary
@@ -187,12 +204,105 @@ object AcpToolCallPresentation {
                 summarizeArguments(firstContentLine).ifBlank {
                     if (looksLikeFilePath(firstContentLine)) shortenPath(firstContentLine) else firstContentLine
                 }
-            rawOutput.isNotBlank() && !isMinimalOutput(rawOutput) -> firstMeaningfulLine(rawOutput)
-            else -> firstMeaningfulLine(detail).let { line ->
+            rawOutput.isNotBlank() && !isMinimalOutput(rawOutput) ->
+                jsonArgumentSummary(rawOutput).ifBlank { firstMeaningfulLine(rawOutput) }
+            else -> firstMeaningfulLine(rawDetail).let { line ->
                 if (looksLikeFilePath(line)) shortenPath(line) else line
             }
         }
         return summary to detail
+    }
+
+    /**
+     * True when [detail] states something [headline] does not. Providers routinely echo their
+     * arguments as the body of a row whose headline was derived from those same arguments, which
+     * makes the row look expandable while revealing nothing.
+     */
+    fun detailAddsInformation(headline: String, detail: String): Boolean {
+        val detailKey = comparisonKey(detail)
+        if (detailKey.isEmpty()) return false
+        return !comparisonKey(headline).contains(detailKey)
+    }
+
+    private fun comparisonKey(text: String): String = text.filter { it.isLetterOrDigit() }.lowercase()
+
+    /** `key=value` summary for a JSON payload only; other text has no arguments to summarize. */
+    private fun jsonArgumentSummary(text: String): String =
+        parseJson(text)?.let { summarizeArguments(text) }.orEmpty()
+
+    /**
+     * Converts a complete JSON payload to compact Markdown so transcript expansion never exposes
+     * transport syntax. Non-JSON content is preserved for Markdown/code/diff rendering in the UI.
+     */
+    fun displayDetail(text: String): String {
+        val trimmed = text.trim()
+        if (!looksLikeJson(trimmed)) return trimmed
+        val element = runCatching { json.parseToJsonElement(trimmed) }.getOrNull() ?: return trimmed
+        // A payload with nothing to say renders as nothing, leaving the row unexpandable.
+        return renderJsonMarkdown(element)
+    }
+
+    /**
+     * The command output, file body, or diff a payload wraps, in the order the keys appear. These
+     * are the only parts of a payload worth reading in full, so the transcript renders them as
+     * blocks — a diff viewer or a highlighted code fence — instead of a truncated `key=value` line.
+     */
+    fun payloadTextValues(text: String): List<String> {
+        val trimmed = text.trim()
+        if (!looksLikeJson(trimmed)) return emptyList()
+        val element = runCatching { json.parseToJsonElement(trimmed) }.getOrNull() ?: return emptyList()
+        return blockTextValues(element)
+    }
+
+    private fun blockTextValues(element: JsonElement): List<String> = when (element) {
+        is JsonObject -> element.values.flatMap { blockTextValues(it) }
+        is JsonArray -> element.flatMap { blockTextValues(it) }
+        is JsonPrimitive -> if (element.isBlockText()) listOf(element.content) else emptyList()
+    }
+
+    /** Long or multi-line strings are content; short ones belong inline next to their key. */
+    private fun JsonPrimitive.isBlockText(): Boolean =
+        isString && (content.contains('\n') || content.length > InlineValueLimit)
+
+    private fun renderJsonMarkdown(element: JsonElement): String = when (element) {
+        is JsonObject -> element.entries.joinToString("\n") { (key, value) ->
+            val label = humanize(key)
+            when {
+                value is JsonPrimitive && value.isBlockText() -> "- **$label:**\n${fencedBlock(value.content)}"
+                value is JsonPrimitive -> "- **$label:** ${renderPrimitive(value)}"
+                else -> {
+                    val nested = renderJsonMarkdown(value)
+                    "- **$label:**\n${nested.prependIndent("  ")}"
+                }
+            }
+        }
+        is JsonArray -> element.joinToString("\n") { value ->
+            when {
+                value is JsonPrimitive && value.isBlockText() -> fencedBlock(value.content)
+                value is JsonPrimitive -> "- ${renderPrimitive(value)}"
+                else -> "-\n${renderJsonMarkdown(value).prependIndent("  ")}"
+            }
+        }
+        is JsonPrimitive -> if (element.isBlockText()) fencedBlock(element.content) else renderPrimitive(element)
+    }
+
+    /** Fence long enough to survive backticks in the body, so Markdown cannot break mid-payload. */
+    private fun fencedBlock(body: String): String {
+        val longestRun = Regex("`+").findAll(body).maxOfOrNull { it.value.length } ?: 0
+        val fence = "`".repeat(maxOf(3, longestRun + 1))
+        return "$fence${payloadLanguage(body)}\n${body.trimEnd()}\n$fence"
+    }
+
+    private fun payloadLanguage(body: String): String =
+        if (body.startsWith("diff --git") || diffHunkHeader.containsMatchIn(body)) "diff" else ""
+
+    private fun renderPrimitive(value: JsonPrimitive): String {
+        val content = value.contentOrNull ?: value.toString()
+        return when {
+            content.contains('\n') -> "\n${content.prependIndent("  ")}"
+            content.isBlank() -> "—"
+            else -> content
+        }
     }
 
     /** "Edit src/Foo.kt" / "Delete `path`" → action verb + remainder for the summary line. */
@@ -241,8 +351,10 @@ object AcpToolCallPresentation {
             .orEmpty()
 
     private fun richerDetail(first: String, second: String): String {
-        val a = first.trim()
-        val b = second.trim()
+        // An empty-arguments placeholder states nothing, and prepending it to real content would
+        // hide the shape of that content — a leading "{}" stops a diff from being recognized.
+        val a = first.trim().takeUnless { isMinimalOutput(it) }.orEmpty()
+        val b = second.trim().takeUnless { isMinimalOutput(it) }.orEmpty()
         return when {
             a.isBlank() -> b
             b.isBlank() -> a

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -364,7 +364,10 @@ object AcpToolCallPresentation {
             a == b -> a
             b.contains(a) -> b
             a.contains(b) -> a
-            isRenderedFileDiff(b) -> detailExtra(a)?.let { "$b$DetailSeparator$it" } ?: b
+            isRenderedFileDiff(b) -> {
+                val extra = detailExtra(a) ?: a.takeUnless { isJsonObject(it) }
+                extra?.let { "$b$DetailSeparator$it" } ?: b
+            }
             isRenderedFileDiff(a) -> appendExtraDetail(a, b)
             isJsonObject(a) -> "$a$DetailSeparator$b"
             else -> "$a\n$b"

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -358,12 +358,18 @@ object AcpToolCallPresentation {
         return when {
             a.isBlank() -> b
             b.isBlank() -> a
+            isRenderedFileDiff(b) -> b
+            isRenderedFileDiff(a) -> a
             a == b -> a
             b.contains(a) -> b
             a.contains(b) -> a
             else -> "$a\n$b"
         }
     }
+
+    /** ToolCallContent.Diff's stable text shape; it must remain at byte zero for domain parsing. */
+    private fun isRenderedFileDiff(text: String): Boolean =
+        text.contains("\n--- old\n") && text.contains("\n+++ new\n")
 
     private fun extractLikelyInput(detail: String): String? {
         val lines = detail.lineSequence().map { it.trim() }.filter { it.isNotBlank() }.toList()

--- a/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /** Human-readable labels for sparse ACP tool-call metadata (especially Andy MCP). */
 object AcpToolCallPresentation {
+    const val DetailSeparator = "\n--- tool output\n"
+
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     private val genericTitles = setOf("", "tool", "Tool")
     /** Provider titles that are only a verb/kind — useful detail lives in args, locations, or a later update. */
@@ -359,7 +361,7 @@ object AcpToolCallPresentation {
             a.isBlank() -> b
             b.isBlank() -> a
             isRenderedFileDiff(b) -> b
-            isRenderedFileDiff(a) -> a
+            isRenderedFileDiff(a) -> "$a$DetailSeparator$b"
             a == b -> a
             b.contains(a) -> b
             a.contains(b) -> a

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -1486,8 +1486,8 @@ private fun ToolBlock(
     val body = remember(rawBody) { AcpToolCallPresentation.displayDetail(rawBody) }
     val expandable = images.isNotEmpty() ||
         AcpToolCallPresentation.detailAddsInformation(headline, body)
-    val fileContent = remember(rawBody) {
-        parseToolCallFileContent(rawBody) ?: parseToolCallFileArguments(rawBody)
+    val fileContent = remember(rawBody, kind) {
+        parseToolCallFileContent(rawBody) ?: parseToolCallFileArguments(rawBody, kind)
     }
     // Command results arrive as {"exitCode":…,"stdout":"<a diff>"}, so the diff worth reviewing is
     // one level inside the payload rather than the payload itself.

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -1586,6 +1586,18 @@ private fun ToolCallDetailBody(
                         .verticalScroll(rememberScrollState()),
                 )
             }
+            fileContent.extraDetail?.takeIf { it.isNotBlank() }?.let { extra ->
+                ChatMarkdown(
+                    toolDetailMarkdown(extra),
+                    density = AndyMarkdownDensity.Thinking,
+                    lineHeight = 16.sp,
+                    preserveLineBreaks = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 220.dp)
+                        .verticalScroll(rememberScrollState()),
+                )
+            }
         }
         return
     }

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -79,6 +79,7 @@ import app.andy.loadImageBitmap
 import app.andy.domain.ToolCallFileContent
 import app.andy.domain.detectUnifiedDiff
 import app.andy.domain.diffFromToolCallFileContent
+import app.andy.domain.extractUnifiedDiffText
 import app.andy.domain.looksLikeFilePath
 import app.andy.domain.parseToolCallFileArguments
 import app.andy.domain.parseToolCallFileContent
@@ -1497,9 +1498,18 @@ private fun ToolBlock(
     }
     // Command results arrive as {"exitCode":…,"stdout":"<a diff>"}, so the diff worth reviewing is
     // one level inside the payload rather than the payload itself.
-    val payloadDiff = remember(rawBody) {
+    val payloadDiffData = remember(rawBody) {
         (AcpToolCallPresentation.payloadTextValues(rawBody) + rawBody)
-            .firstNotNullOfOrNull { detectUnifiedDiff(it) }
+            .firstNotNullOfOrNull { candidate ->
+                val patch = extractUnifiedDiffText(candidate) ?: candidate
+                detectUnifiedDiff(patch)?.let { patch to it }
+            }
+    }
+    val payloadDiff = payloadDiffData?.second
+    val payloadExtraBody = remember(rawBody, payloadDiffData) {
+        payloadDiffData?.first
+            ?.let { AcpToolCallPresentation.displayDetailExcludingPayload(rawBody, it) }
+            .orEmpty()
     }
     val openableContent = fileContent ?: locations.firstOrNull { looksLikeFilePath(it) }?.let {
         ToolCallFileContent(path = it, oldText = null, newText = null)
@@ -1543,6 +1553,7 @@ private fun ToolBlock(
             body = body,
             fileContent = fileContent,
             diff = payloadDiff,
+            diffExtraBody = payloadExtraBody,
             images = images,
             onOpen = onToolFileOpen,
         )
@@ -1554,6 +1565,7 @@ private fun ToolCallDetailBody(
     body: String,
     fileContent: ToolCallFileContent?,
     diff: AgentFileDiff?,
+    diffExtraBody: String = "",
     images: List<AgentToolImage> = emptyList(),
     onOpen: (ToolCallFileContent) -> Unit,
 ) {
@@ -1609,6 +1621,18 @@ private fun ToolCallDetailBody(
     }
     if (diff != null) {
         ToolCallDiff(diff, modifier = Modifier.padding(top = 4.dp))
+        if (diffExtraBody.isNotBlank()) {
+            ChatMarkdown(
+                toolDetailMarkdown(diffExtraBody),
+                density = AndyMarkdownDensity.Thinking,
+                lineHeight = 16.sp,
+                preserveLineBreaks = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 220.dp)
+                    .verticalScroll(rememberScrollState()),
+            )
+        }
         return
     }
     if (body.isBlank()) return

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -90,6 +90,7 @@ import app.andy.model.AgentSpawnPresentation
 import app.andy.model.AgentTask
 import app.andy.model.AgentToolImage
 import app.andy.model.AgentToolKind
+import app.andy.model.AgentToolState
 import app.andy.model.isRetriableConnectionStallMessage
 import app.andy.model.shouldShowConnectionStallBanner
 import app.andy.model.stripDecisionCheckpointMarkup
@@ -691,6 +692,7 @@ private fun TranscriptEvent(
                 locations = event.locations,
                 images = event.images,
                 color = Cyan,
+                forceVisible = event.state == AgentToolState.Failed,
                 onToolFileOpen = onToolFileOpen,
             )
         }
@@ -703,6 +705,7 @@ private fun TranscriptEvent(
                 summary = event.summary,
                 detail = event.detail,
                 color = if (event.isError) Red else TextSecondary,
+                forceVisible = event.isError,
                 onToolFileOpen = onToolFileOpen,
             )
         }
@@ -1286,6 +1289,7 @@ private fun CompactToolCallsBlock(
                             locations = event.locations,
                             images = event.images,
                             color = Cyan,
+                            forceVisible = event.state == AgentToolState.Failed,
                             indent = TranscriptAsideContentIndent,
                             onToolFileOpen = onToolFileOpen,
                         )
@@ -1299,6 +1303,7 @@ private fun CompactToolCallsBlock(
                             summary = event.summary,
                             detail = event.detail,
                             color = if (event.isError) Red else TextSecondary,
+                            forceVisible = event.isError,
                             indent = TranscriptAsideContentIndent,
                             onToolFileOpen = onToolFileOpen,
                         )
@@ -1472,10 +1477,11 @@ private fun ToolBlock(
     locations: List<String> = emptyList(),
     images: List<AgentToolImage> = emptyList(),
     color: Color,
+    forceVisible: Boolean = false,
     indent: Dp = TranscriptAsideIndent,
     onToolFileOpen: (ToolCallFileContent) -> Unit = {},
 ) {
-    if (toolRowShowsNothing(name, summary, detail, locations, images.isNotEmpty())) return
+    if (!forceVisible && toolRowShowsNothing(name, summary, detail, locations, images.isNotEmpty())) return
     val headline = toolBlockHeadline(name, summary, kind, locations)
     val rawBody = detail
         .takeUnless { AcpToolCallPresentation.isMinimalOutput(it) }
@@ -1847,7 +1853,14 @@ internal fun compactToolActivityHeadline(events: List<AgentEvent>): String {
     // Content-free calls are not rendered as rows, so they must not colour the group headline
     // either — but they still happened, so a group made only of them is counted, not named.
     val toolCalls = allCalls.filterNot {
-        toolRowShowsNothing(it.toolName, it.summary, it.detail, it.locations, it.images.isNotEmpty())
+        toolRowShowsNothing(
+            it.toolName,
+            it.summary,
+            it.detail,
+            it.locations,
+            it.images.isNotEmpty(),
+            isFailure = it.state == AgentToolState.Failed,
+        )
     }
     if (toolCalls.isEmpty()) {
         val count = allCalls.size
@@ -1909,8 +1922,9 @@ internal fun toolRowShowsNothing(
     detail: String,
     locations: List<String>,
     hasImages: Boolean,
+    isFailure: Boolean = false,
 ): Boolean {
-    if (hasImages || locations.any { it.isNotBlank() }) return false
+    if (isFailure || hasImages || locations.any { it.isNotBlank() }) return false
     if (!AcpToolCallPresentation.isGenericTitle(name?.trim().orEmpty())) return false
     return AcpToolCallPresentation.isMinimalOutput(summary) &&
         AcpToolCallPresentation.isMinimalOutput(detail)

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -77,10 +77,14 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.andy.loadImageBitmap
 import app.andy.domain.ToolCallFileContent
+import app.andy.domain.detectUnifiedDiff
+import app.andy.domain.diffFromToolCallFileContent
 import app.andy.domain.looksLikeFilePath
+import app.andy.domain.parseToolCallFileArguments
 import app.andy.domain.parseToolCallFileContent
 import app.andy.model.AcpToolCallPresentation
 import app.andy.model.AgentEvent
+import app.andy.model.AgentFileDiff
 import app.andy.model.AgentPlanEntry
 import app.andy.model.AgentSpawnPresentation
 import app.andy.model.AgentTask
@@ -1471,14 +1475,26 @@ private fun ToolBlock(
     indent: Dp = TranscriptAsideIndent,
     onToolFileOpen: (ToolCallFileContent) -> Unit = {},
 ) {
+    if (toolRowShowsNothing(name, summary, detail, locations, images.isNotEmpty())) return
     val headline = toolBlockHeadline(name, summary, kind, locations)
-    val body = detail
+    val rawBody = detail
         .takeUnless { AcpToolCallPresentation.isMinimalOutput(it) }
         .orEmpty()
         .ifBlank { summary.takeUnless { AcpToolCallPresentation.isMinimalOutput(it) }.orEmpty() }
-        .ifBlank { name.orEmpty() }
-    val expandable = images.isNotEmpty() || (body.isNotBlank() && body != headline)
-    val fileContent = remember(body) { parseToolCallFileContent(body) }
+    // Persisted transcripts and the MCP lane both hand back provider payloads verbatim, so the
+    // JSON-to-Markdown conversion has to happen here rather than where events are first mapped.
+    val body = remember(rawBody) { AcpToolCallPresentation.displayDetail(rawBody) }
+    val expandable = images.isNotEmpty() ||
+        AcpToolCallPresentation.detailAddsInformation(headline, body)
+    val fileContent = remember(rawBody) {
+        parseToolCallFileContent(rawBody) ?: parseToolCallFileArguments(rawBody)
+    }
+    // Command results arrive as {"exitCode":…,"stdout":"<a diff>"}, so the diff worth reviewing is
+    // one level inside the payload rather than the payload itself.
+    val payloadDiff = remember(rawBody) {
+        (AcpToolCallPresentation.payloadTextValues(rawBody) + rawBody)
+            .firstNotNullOfOrNull { detectUnifiedDiff(it) }
+    }
     val openableContent = fileContent ?: locations.firstOrNull { looksLikeFilePath(it) }?.let {
         ToolCallFileContent(path = it, oldText = null, newText = null)
     }
@@ -1520,6 +1536,7 @@ private fun ToolBlock(
         ToolCallDetailBody(
             body = body,
             fileContent = fileContent,
+            diff = payloadDiff,
             images = images,
             onOpen = onToolFileOpen,
         )
@@ -1530,6 +1547,7 @@ private fun ToolBlock(
 private fun ToolCallDetailBody(
     body: String,
     fileContent: ToolCallFileContent?,
+    diff: AgentFileDiff?,
     images: List<AgentToolImage> = emptyList(),
     onOpen: (ToolCallFileContent) -> Unit,
 ) {
@@ -1548,23 +1566,17 @@ private fun ToolCallDetailBody(
                     lineHeight = 16.sp,
                 )
             }
-            val preview = when {
-                fileContent.hasDiff -> buildString {
-                    if (!fileContent.oldText.isNullOrBlank()) {
-                        append("--- old\n")
-                        append(fileContent.oldText.orEmpty())
-                    }
-                    if (!fileContent.newText.isNullOrBlank()) {
-                        if (isNotEmpty()) append('\n')
-                        append("+++ new\n")
-                        append(fileContent.newText.orEmpty())
-                    }
-                }
-                else -> fileContent.newText.orEmpty()
+            val fileDiff = if (fileContent.hasDiff) {
+                remember(fileContent) { diffFromToolCallFileContent(fileContent) }
+            } else {
+                diff
             }
-            if (preview.isNotBlank()) {
+            val preview = fileContent.newText.orEmpty()
+            if (fileDiff != null) {
+                ToolCallDiff(fileDiff)
+            } else if (preview.isNotBlank()) {
                 ChatMarkdown(
-                    preview,
+                    toolDetailMarkdown(preview, fileContent.path),
                     density = AndyMarkdownDensity.Thinking,
                     lineHeight = 16.sp,
                     preserveLineBreaks = true,
@@ -1577,9 +1589,13 @@ private fun ToolCallDetailBody(
         }
         return
     }
+    if (diff != null) {
+        ToolCallDiff(diff, modifier = Modifier.padding(top = 4.dp))
+        return
+    }
     if (body.isBlank()) return
     ChatMarkdown(
-        body,
+        toolDetailMarkdown(body),
         density = AndyMarkdownDensity.Thinking,
         lineHeight = 16.sp,
         preserveLineBreaks = true,
@@ -1589,6 +1605,79 @@ private fun ToolCallDetailBody(
             .heightIn(max = 220.dp)
             .verticalScroll(rememberScrollState()),
     )
+}
+
+@Composable
+private fun ToolCallDiff(diff: AgentFileDiff, modifier: Modifier = Modifier) {
+    var viewMode by remember(diff) { mutableStateOf(DiffViewMode.Unified) }
+    AgentFileDiffViewer(
+        diff = diff,
+        viewMode = viewMode,
+        onViewModeChange = { viewMode = it },
+        onCollapse = {},
+        showCollapseControl = false,
+        maxHeight = 220.dp,
+        modifier = modifier.fillMaxWidth(),
+    )
+}
+
+/** Keeps authored Markdown intact while giving plain source/terminal output a highlighted code block. */
+internal fun toolDetailMarkdown(body: String, path: String? = null): String {
+    val trimmed = body.trim()
+    if (trimmed.isEmpty() || looksLikeMarkdown(trimmed)) return trimmed
+    return if (path != null || looksLikeCode(trimmed)) {
+        fencedCodeBlock(trimmed, codeLanguageForPath(path))
+    } else {
+        trimmed
+    }
+}
+
+private fun looksLikeMarkdown(text: String): Boolean = text.lineSequence().any { line ->
+    val trimmed = line.trimStart()
+    trimmed.startsWith("```") ||
+        trimmed.startsWith("~~~") ||
+        Regex("""^#{1,6}\s+""").containsMatchIn(trimmed) ||
+        trimmed.startsWith("> ") ||
+        Regex("""^[-*+]\s+""").containsMatchIn(trimmed) ||
+        Regex("""^\d+[.)]\s+""").containsMatchIn(trimmed) ||
+        Regex("""^\|.+\|$""").containsMatchIn(trimmed)
+}
+
+private fun looksLikeCode(text: String): Boolean =
+    text.contains('\n') && text.lineSequence().any { line ->
+        line.startsWith("    ") ||
+            line.startsWith("\t") ||
+            Regex("""^\s*(fun|class|interface|object|enum|data class|val|var|import|package|def|function|const|let|fn|struct)\b""")
+                .containsMatchIn(line) ||
+            Regex("""^\s*([+>$]|at\s+\S+|[A-Za-z0-9_./-]+:\d+:)""").containsMatchIn(line) ||
+            line.trimEnd().endsWith("{") ||
+            line.trimEnd().endsWith(";")
+    }
+
+private fun codeLanguageForPath(path: String?): String = when (path?.substringAfterLast('.', "").orEmpty().lowercase()) {
+    "kt", "kts" -> "kotlin"
+    "java" -> "java"
+    "js", "mjs", "cjs" -> "javascript"
+    "ts", "tsx" -> "typescript"
+    "py" -> "python"
+    "rs" -> "rust"
+    "go" -> "go"
+    "rb" -> "ruby"
+    "sh", "bash", "zsh" -> "shell"
+    "json" -> "json"
+    "yaml", "yml" -> "yaml"
+    "md", "markdown" -> "markdown"
+    "html" -> "html"
+    "css" -> "css"
+    "sql" -> "sql"
+    else -> ""
+}
+
+/** Wraps [body] in a Markdown fence long enough to survive any backtick runs already inside it. */
+private fun fencedCodeBlock(body: String, language: String = ""): String {
+    val longestRun = Regex("`+").findAll(body).maxOfOrNull { it.value.length } ?: 0
+    val fence = "`".repeat(maxOf(3, longestRun + 1))
+    return "$fence$language\n$body\n$fence"
 }
 
 @Composable
@@ -1738,10 +1827,19 @@ private fun compactActivityHeadline(events: List<AgentEvent>): String {
 }
 
 internal fun compactToolActivityHeadline(events: List<AgentEvent>): String {
-    val toolCalls = events.filterIsInstance<AgentEvent.ToolCall>()
-    if (toolCalls.isEmpty()) {
+    val allCalls = events.filterIsInstance<AgentEvent.ToolCall>()
+    if (allCalls.isEmpty()) {
         val count = events.size
         return "$count tool ${if (count == 1) "result" else "results"}"
+    }
+    // Content-free calls are not rendered as rows, so they must not colour the group headline
+    // either — but they still happened, so a group made only of them is counted, not named.
+    val toolCalls = allCalls.filterNot {
+        toolRowShowsNothing(it.toolName, it.summary, it.detail, it.locations, it.images.isNotEmpty())
+    }
+    if (toolCalls.isEmpty()) {
+        val count = allCalls.size
+        return "$count tool ${if (count == 1) "call" else "calls"}"
     }
     if (toolCalls.size == 1) {
         val call = toolCalls.single()
@@ -1773,7 +1871,47 @@ internal fun compactToolActivityHeadline(events: List<AgentEvent>): String {
     }
 }
 
-private fun toolBlockHeadline(
+private const val ToolHeadlineLimit = 160
+
+/**
+ * A row headline is a label, but the fields it comes from are provider-controlled: a `summary` can
+ * be a whole multi-line command or a 4 KB command result. Collapse it to one short line and leave
+ * the rest to the expanded body.
+ */
+internal fun condenseToolHeadline(text: String): String {
+    val collapsed = text.replace(Regex("""\s+"""), " ").trim()
+    return if (collapsed.length <= ToolHeadlineLimit) {
+        collapsed
+    } else {
+        collapsed.take(ToolHeadlineLimit).trimEnd() + "…"
+    }
+}
+
+/**
+ * ACP lanes emit bookkeeping tool events carrying only a call id — no name, arguments, output, or
+ * location. A row for one of those says nothing at all, so the transcript leaves it out.
+ */
+internal fun toolRowShowsNothing(
+    name: String?,
+    summary: String,
+    detail: String,
+    locations: List<String>,
+    hasImages: Boolean,
+): Boolean {
+    if (hasImages || locations.any { it.isNotBlank() }) return false
+    if (!AcpToolCallPresentation.isGenericTitle(name?.trim().orEmpty())) return false
+    return AcpToolCallPresentation.isMinimalOutput(summary) &&
+        AcpToolCallPresentation.isMinimalOutput(detail)
+}
+
+internal fun toolBlockHeadline(
+    name: String?,
+    summary: String,
+    kind: AgentToolKind?,
+    locations: List<String>,
+): String = condenseToolHeadline(rawToolBlockHeadline(name, summary, kind, locations))
+
+private fun rawToolBlockHeadline(
     name: String?,
     summary: String,
     kind: AgentToolKind?,
@@ -1786,7 +1924,8 @@ private fun toolBlockHeadline(
         .ifBlank { AcpToolCallPresentation.enrichSummary("", kind, locations) }
     // Bare "Edit" / "Terminal" labels read as empty chrome — prefer an action phrase, and
     // when we do have a path/command, lead with Edited/Ran rather than "Edit: path".
-    if (AcpToolCallPresentation.isSparseToolTitle(label) || label.isBlank()) {
+    // A generic "tool" is not a name at all, so it must never prefix the summary.
+    if (AcpToolCallPresentation.isGenericOrSparseTitle(label) || label.isBlank()) {
         return toolActionPhrase(label, detail.ifBlank { summary }, kind, locations)
     }
     return when {
@@ -1798,6 +1937,13 @@ private fun toolBlockHeadline(
 }
 
 private fun toolActionPhrase(
+    toolName: String,
+    summary: String,
+    kind: AgentToolKind? = null,
+    locations: List<String> = emptyList(),
+): String = condenseToolHeadline(rawToolActionPhrase(toolName, summary, kind, locations))
+
+private fun rawToolActionPhrase(
     toolName: String,
     summary: String,
     kind: AgentToolKind? = null,
@@ -1824,9 +1970,22 @@ private fun toolActionPhrase(
         lower in CommandToolNames || kind == AgentToolKind.Execute ->
             trimmedSummary.takeIf { it.isNotBlank() }?.let { "Ran $it" } ?: "Ran command"
         trimmedSummary.isNotBlank() -> trimmedSummary
-        toolName.isNotBlank() -> toolName
-        else -> "Tool call"
+        toolName.isNotBlank() && !AcpToolCallPresentation.isGenericTitle(toolName) -> toolName
+        else -> toolKindPhrase(kind) ?: "Tool call"
     }
+}
+
+/** Last resort when a provider sent neither a usable name nor arguments: name the action by kind. */
+private fun toolKindPhrase(kind: AgentToolKind?): String? = when (kind) {
+    AgentToolKind.Read -> "Read file"
+    AgentToolKind.Edit -> "Edited file"
+    AgentToolKind.Delete -> "Deleted file"
+    AgentToolKind.Move -> "Moved file"
+    AgentToolKind.Search -> "Searched"
+    AgentToolKind.Execute -> "Ran command"
+    AgentToolKind.Think -> "Thought"
+    AgentToolKind.Fetch -> "Fetched a resource"
+    AgentToolKind.Other, null -> null
 }
 
 private val ReadToolNames = setOf(

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -137,6 +137,19 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun structuredArgumentsPreserveEmptyOldSnapshot() {
+        val content = parseToolCallFileArguments(
+            """{"file_path":"new.txt","old_string":"","new_string":"one\ntwo"}""",
+            AgentToolKind.Edit,
+        )
+
+        assertNotNull(content)
+        assertEquals("", content.oldText)
+        assertTrue(content.hasDiff)
+        assertTrue(diffFromToolCallFileContent(content).isNewFile)
+    }
+
+    @Test
     fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
         assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
         assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -44,6 +44,17 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun parseToolCallFileContentKeepsSeparatorLikeFileContent() {
+        val content = parseToolCallFileContent(
+            "README.md\n--- old\nold\n+++ new\nheading\n--- tool output\nbody",
+        )
+
+        assertNotNull(content)
+        assertEquals("heading\n--- tool output\nbody", content.newText)
+        assertNull(content.extraDetail)
+    }
+
+    @Test
     fun parseToolCallFileContentReadsAbsolutePathReadShape() {
         val content = parseToolCallFileContent(
             """

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -1,5 +1,6 @@
 package app.andy.domain
 
+import app.andy.model.AcpToolCallPresentation
 import app.andy.model.AgentToolKind
 import app.andy.model.DiffLineKind
 import kotlin.test.Test
@@ -27,6 +28,19 @@ class ToolCallFileContentTest {
         assertEquals("fun old()", content.oldText)
         assertEquals("fun new()", content.newText)
         assertTrue(content.hasDiff)
+    }
+
+    @Test
+    fun parseToolCallFileContentSeparatesOutputAfterTheDiff() {
+        val content = parseToolCallFileContent(
+            "src/Main.kt\n--- old\nold\n+++ new\nnew" +
+                AcpToolCallPresentation.DetailSeparator +
+                "warning: formatter skipped generated file",
+        )
+
+        assertNotNull(content)
+        assertEquals("new", content.newText)
+        assertEquals("warning: formatter skipped generated file", content.extraDetail)
     }
 
     @Test
@@ -143,5 +157,15 @@ class ToolCallFileContentTest {
         assertEquals(1_100, diff.deletions)
         assertEquals(1_100, diff.additions)
         assertEquals(2_200, diff.lines.size)
+    }
+
+    @Test
+    fun highlySkewedSnapshotsAlsoUseBoundedLinearDiffing() {
+        val oldText = (1..10_001).joinToString("\n") { "old $it" }
+
+        val diff = diffTextLines("skewed.txt", oldText, "new")
+
+        assertEquals(10_001, diff.deletions)
+        assertEquals(1, diff.additions)
     }
 }

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -3,6 +3,7 @@ package app.andy.domain
 import app.andy.model.DiffLineKind
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -40,6 +41,44 @@ class ToolCallFileContentTest {
         assertEquals("/Users/dev/project/Main.kt", content.path)
         assertNull(content.oldText)
         assertEquals("package demo", content.newText)
+        assertFalse(content.hasDiff)
+    }
+
+    @Test
+    fun parseToolCallFileArgumentsReadsJsonEditPayload() {
+        val content = parseToolCallFileArguments(
+            """{"file_path":"src/Main.kt","old_string":"fun old()","new_string":"fun new()"}""",
+        )
+
+        assertNotNull(content)
+        assertEquals("src/Main.kt", content.path)
+        assertEquals("fun old()", content.oldText)
+        assertEquals("fun new()", content.newText)
+        assertTrue(content.hasDiff)
+    }
+
+    @Test
+    fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
+        assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
+        assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))
+        assertNull(parseToolCallFileArguments("not json"))
+    }
+
+    /**
+     * A command result is one long line full of slashes and dots. Treating it as a path rendered the
+     * whole payload as a clickable file name instead of showing the diff it carried.
+     */
+    @Test
+    fun commandResultPayloadIsNeverMistakenForAFilePath() {
+        val payload =
+            """{"exitCode":0,"stdout":"diff --git a/src/Main.kt b/src/Main.kt\n--- a/src/Main.kt\n","stderr":""}"""
+
+        assertNull(parseToolCallFileContent(payload))
+        assertNull(parseToolCallFileArguments(payload))
+        assertFalse(looksLikeFilePath(payload))
+        assertFalse(looksLikeFilePath("- **command:** ls src/Main.kt"))
+        assertTrue(looksLikeFilePath("src/Main.kt"))
+        assertTrue(looksLikeFilePath("/Users/dev/project/Main.kt"))
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -150,6 +150,20 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun pathOnlyDeleteArgumentsRemainOpenableWithOutput() {
+        val arguments = """{"path":"README.md"}"""
+        val content = parseToolCallFileArguments(
+            "$arguments${AcpToolCallPresentation.DetailSeparator}deleted",
+            AgentToolKind.Delete,
+        )
+
+        assertNotNull(content)
+        assertEquals("README.md", content.path)
+        assertFalse(content.hasDiff)
+        assertEquals("deleted", content.extraDetail)
+    }
+
+    @Test
     fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
         assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
         assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -1,5 +1,6 @@
 package app.andy.domain
 
+import app.andy.model.AgentToolKind
 import app.andy.model.DiffLineKind
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -73,6 +74,21 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun structuredEditArgumentsAcceptRootPathsButSearchPayloadsStayArguments() {
+        val edit = parseToolCallFileArguments(
+            """{"file_path":"README.md","old_string":"old","new_string":"new"}""",
+            AgentToolKind.Edit,
+        )
+        val search = parseToolCallFileArguments(
+            """{"path":"src/Main.kt","search":"TODO"}""",
+            AgentToolKind.Search,
+        )
+
+        assertEquals("README.md", assertNotNull(edit).path)
+        assertNull(search)
+    }
+
+    @Test
     fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
         assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
         assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))
@@ -115,5 +131,17 @@ class ToolCallFileContentTest {
         )
         assertEquals("two", diff.lines[1].text)
         assertEquals("three", diff.lines[2].text)
+    }
+
+    @Test
+    fun largeSnapshotsUseBoundedLinearDiffing() {
+        val oldText = (1..1_100).joinToString("\n") { "old $it" }
+        val newText = (1..1_100).joinToString("\n") { "new $it" }
+
+        val diff = diffTextLines("large.txt", oldText, newText)
+
+        assertEquals(1_100, diff.deletions)
+        assertEquals(1_100, diff.additions)
+        assertEquals(2_200, diff.lines.size)
     }
 }

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -58,6 +58,21 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun structuredFilePathsMayContainSpaces() {
+        val diff = parseToolCallFileContent(
+            "/Users/dev/My Project/Main.kt\n--- old\nfun old()\n+++ new\nfun new()",
+        )
+        val arguments = parseToolCallFileArguments(
+            """{"file_path":"/Users/dev/My Project/Main.kt","old_string":"fun old()","new_string":"fun new()"}""",
+        )
+
+        assertEquals("/Users/dev/My Project/Main.kt", assertNotNull(diff).path)
+        assertEquals("/Users/dev/My Project/Main.kt", assertNotNull(arguments).path)
+        assertTrue(looksLikeFilePath("/Users/dev/My Project/Main.kt"))
+        assertTrue(looksLikeFilePath("My Project/Main.kt"))
+    }
+
+    @Test
     fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
         assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
         assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))
@@ -76,6 +91,7 @@ class ToolCallFileContentTest {
         assertNull(parseToolCallFileContent(payload))
         assertNull(parseToolCallFileArguments(payload))
         assertFalse(looksLikeFilePath(payload))
+        assertNull(parseToolCallFileContent("exitCode=0, stdout=diff --git a/src/Main.kt b/src/Main.kt"))
         assertFalse(looksLikeFilePath("- **command:** ls src/Main.kt"))
         assertTrue(looksLikeFilePath("src/Main.kt"))
         assertTrue(looksLikeFilePath("/Users/dev/project/Main.kt"))

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -103,6 +103,29 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun structuredEditArgumentsKeepOutputAfterTheJson() {
+        val arguments = """{"file_path":"README.md","old_string":"old","new_string":"new"}"""
+        val parsed = parseToolCallFileArguments(
+            "$arguments${AcpToolCallPresentation.DetailSeparator}warning: generated file skipped",
+            AgentToolKind.Edit,
+        )
+
+        assertEquals("README.md", parsed?.path)
+        assertEquals("old", parsed?.oldText)
+        assertEquals("new", parsed?.newText)
+        assertEquals("warning: generated file skipped", parsed?.extraDetail)
+    }
+
+    @Test
+    fun emptyOldSnapshotProducesANewFileDiff() {
+        val diff = diffTextLines("new.txt", "", "one\ntwo")
+
+        assertTrue(diff.isNewFile)
+        assertEquals(0, diff.deletions)
+        assertEquals(2, diff.additions)
+    }
+
+    @Test
     fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
         assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
         assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -165,7 +165,8 @@ class ToolCallFileContentTest {
 
         val diff = diffTextLines("skewed.txt", oldText, "new")
 
-        assertEquals(10_001, diff.deletions)
+        assertEquals(2_001, diff.deletions)
         assertEquals(1, diff.additions)
+        assertEquals("… 8001 lines omitted", diff.lines[2_000].text)
     }
 }

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -100,6 +100,19 @@ class UnifiedDiffTest {
     }
 
     @Test
+    fun unifiedDiffPathIgnoresDevNullHeaderTimestamp() {
+        val text = """
+            --- a/deleted.txt	2026-08-14 10:00:00
+            +++ /dev/null	2026-08-14 10:01:00
+            @@ -1 +0,0 @@
+            -gone
+        """.trimIndent()
+
+        assertEquals("deleted.txt", unifiedDiffPath(text))
+        assertEquals("deleted.txt", detectUnifiedDiff(text)?.path)
+    }
+
+    @Test
     fun detectUnifiedDiffDeclinesHeaderOnlyMultiFilePatches() {
         val text = """
             --- a/first.txt

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -63,6 +63,27 @@ class UnifiedDiffTest {
     }
 
     @Test
+    fun detectUnifiedDiffDeclinesMultiFilePatches() {
+        val text = """
+            diff --git a/src/First.kt b/src/First.kt
+            --- a/src/First.kt
+            +++ b/src/First.kt
+            @@ -1 +1 @@
+            -old first
+            +new first
+            diff --git a/src/Second.kt b/src/Second.kt
+            --- a/src/Second.kt
+            +++ b/src/Second.kt
+            @@ -1 +1 @@
+            -old second
+            +new second
+        """.trimIndent()
+
+        assertTrue(looksLikeUnifiedDiff(text))
+        assertEquals(null, detectUnifiedDiff(text))
+    }
+
+    @Test
     fun diffForNewFileMarksEveryLineAsAddition() {
         val diff = diffForNewFile("new.kt", "one\ntwo\n")
         assertTrue(diff.isNewFile)

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -10,8 +10,7 @@ import kotlin.test.assertTrue
 class UnifiedDiffTest {
     @Test
     fun parseUnifiedDiffTracksLineNumbersAndKinds() {
-        val diff = parseUnifiedDiff(
-            """
+        val text = """
             diff --git a/src/Example.kt b/src/Example.kt
             index 111..222 100644
             --- a/src/Example.kt
@@ -23,9 +22,8 @@ class UnifiedDiffTest {
             +import added
             +import also
              import keep
-            """.trimIndent(),
-            "src/Example.kt",
-        )
+            """.trimIndent()
+        val diff = parseUnifiedDiff(text, "src/Example.kt")
 
         assertEquals("src/Example.kt", diff.path)
         assertEquals(2, diff.additions)
@@ -49,6 +47,9 @@ class UnifiedDiffTest {
         assertEquals(null, diff.lines[3].oldLineNumber)
         assertEquals(12, diff.lines[3].newLineNumber)
         assertEquals("import added", diff.lines[3].text)
+        assertTrue(looksLikeUnifiedDiff(text))
+        assertEquals("src/Example.kt", unifiedDiffPath(text))
+        assertEquals(diff, detectUnifiedDiff(text))
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -63,6 +63,22 @@ class UnifiedDiffTest {
     }
 
     @Test
+    fun parseUnifiedDiffDoesNotTreatChangedTextAsBinaryMetadata() {
+        val text = """
+            --- a/message.txt
+            +++ b/message.txt
+            @@ -1 +1 @@
+            -ordinary text
+            +Binary files may differ
+        """.trimIndent()
+
+        val diff = detectUnifiedDiff(text)
+
+        assertFalse(diff?.isBinary == true)
+        assertEquals(listOf("ordinary text", "Binary files may differ"), diff?.lines?.map { it.text })
+    }
+
+    @Test
     fun detectUnifiedDiffDeclinesMultiFilePatches() {
         val text = """
             diff --git a/src/First.kt b/src/First.kt

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -84,6 +84,40 @@ class UnifiedDiffTest {
     }
 
     @Test
+    fun detectUnifiedDiffDoesNotCountAddedSourceAsAFileHeader() {
+        val text = """
+            --- /dev/null
+            +++ b/operators.txt
+            @@ -0,0 +1 @@
+            +++ value
+        """.trimIndent()
+
+        val diff = detectUnifiedDiff(text)
+
+        assertEquals("operators.txt", diff?.path)
+        assertEquals(listOf("++ value"), diff?.lines?.map { it.text })
+        assertTrue(diff?.isNewFile == true)
+    }
+
+    @Test
+    fun detectUnifiedDiffDeclinesHeaderOnlyMultiFilePatches() {
+        val text = """
+            --- a/first.txt
+            +++ b/first.txt
+            @@ -1 +1 @@
+            -old
+            +new
+            --- a/second.txt
+            +++ b/second.txt
+            @@ -1 +1 @@
+            -old
+            +new
+        """.trimIndent()
+
+        assertEquals(null, detectUnifiedDiff(text))
+    }
+
+    @Test
     fun diffForNewFileMarksEveryLineAsAddition() {
         val diff = diffForNewFile("new.kt", "one\ntwo\n")
         assertTrue(diff.isNewFile)

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -154,6 +154,81 @@ class AcpToolCallPresentationTest {
     }
 
     @Test
+    fun jsonToolDetailsBecomeReadableMarkdown() {
+        val presented = AcpToolCallPresentation.present(
+            title = "Search",
+            rawInput = """{"query":"ToolBlock","case_sensitive":false,"paths":["src","test"]}""",
+            rawOutput = null,
+            contentDetails = "",
+        )
+
+        assertEquals(
+            """
+            - **query:** ToolBlock
+            - **case sensitive:** false
+            - **paths:**
+              - src
+              - test
+            """.trimIndent(),
+            presented.detail,
+        )
+        assertFalse(presented.detail.contains("{"))
+        assertFalse(presented.detail.contains("\"query\""))
+    }
+
+    @Test
+    fun echoedArgumentsDoNotCountAsExtraDetail() {
+        val headline = "totalMatches=45, truncated=false"
+        val body = AcpToolCallPresentation.displayDetail("""{"totalMatches":45,"truncated":false}""")
+
+        assertFalse(body.contains("{"))
+        assertFalse(AcpToolCallPresentation.detailAddsInformation(headline, body))
+        assertFalse(AcpToolCallPresentation.detailAddsInformation(headline, ""))
+        assertTrue(
+            AcpToolCallPresentation.detailAddsInformation(headline, "$body\n- **path:** src/Main.kt"),
+        )
+    }
+
+    /** `{"exitCode":0,"stdout":"…"}` is the shape every shell tool returns; the output is the point. */
+    @Test
+    fun commandResultOutputRendersAsABlockNotAnInlineValue() {
+        val payload = """{"exitCode":0,"stdout":"first line\nsecond line","stderr":""}"""
+
+        val body = AcpToolCallPresentation.displayDetail(payload)
+
+        assertFalse(body.contains("{"))
+        assertFalse(body.contains("\"stdout\""))
+        assertEquals(
+            """
+            - **exitCode:** 0
+            - **stdout:**
+            ```
+            first line
+            second line
+            ```
+            - **stderr:** —
+            """.trimIndent(),
+            body,
+        )
+        assertEquals(listOf("first line\nsecond line"), AcpToolCallPresentation.payloadTextValues(payload))
+        assertTrue(AcpToolCallPresentation.payloadTextValues("plain text output").isEmpty())
+    }
+
+    @Test
+    fun placeholderDetailsCountAsNoOutput() {
+        assertTrue(AcpToolCallPresentation.isMinimalOutput("No details"))
+        assertTrue(AcpToolCallPresentation.isMinimalOutput("none"))
+        assertFalse(AcpToolCallPresentation.isMinimalOutput("42 matches"))
+    }
+
+    @Test
+    fun markdownToolDetailsRemainMarkdown() {
+        val detail = "### Matches\n\n- `AgentTranscript.kt`\n- `AgentModels.kt`"
+
+        assertEquals(detail, AcpToolCallPresentation.displayDetail(detail))
+    }
+
+    @Test
     fun mergeKeepsRicherNameAndDoesNotRegressState() {
         val first = AgentEvent.ToolCall(
             atMillis = 1,

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -289,6 +289,18 @@ class AcpToolCallPresentationTest {
                 state = AgentToolState.Completed,
             ),
         )
+        val repeatedOutput = AcpToolCallPresentation.mergeToolCalls(
+            withOutput,
+            AgentEvent.ToolCall(
+                atMillis = 4,
+                toolName = "tool",
+                summary = "warning",
+                detail = "warning: formatter skipped generated file",
+                toolCallId = "call-1",
+                kind = AgentToolKind.Edit,
+                state = AgentToolState.Completed,
+            ),
+        )
 
         assertEquals(diff, merged.detail)
         assertEquals(AgentToolState.Completed, merged.state)
@@ -296,6 +308,7 @@ class AcpToolCallPresentationTest {
             "$diff${AcpToolCallPresentation.DetailSeparator}warning: formatter skipped generated file",
             withOutput.detail,
         )
+        assertEquals(withOutput.detail, repeatedOutput.detail)
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -255,6 +255,34 @@ class AcpToolCallPresentationTest {
     }
 
     @Test
+    fun mergeKeepsStructuredCompletionDiffAtTheStartOfDetail() {
+        val first = AgentEvent.ToolCall(
+            atMillis = 1,
+            toolName = "Edit File",
+            summary = "path=src/Foo.kt, replacement=updated",
+            detail = """{"path":"src/Foo.kt","replacement":"updated"}""",
+            toolCallId = "call-1",
+            kind = AgentToolKind.Edit,
+            state = AgentToolState.Pending,
+        )
+        val diff = "src/Foo.kt\n--- old\nold\n+++ new\nupdated"
+        val update = AgentEvent.ToolCall(
+            atMillis = 2,
+            toolName = "tool",
+            summary = "Foo.kt",
+            detail = diff,
+            toolCallId = "call-1",
+            kind = AgentToolKind.Edit,
+            state = AgentToolState.Completed,
+        )
+
+        val merged = AcpToolCallPresentation.mergeToolCalls(first, update)
+
+        assertEquals(diff, merged.detail)
+        assertEquals(AgentToolState.Completed, merged.state)
+    }
+
+    @Test
     fun mergePrefersActionPathOverSparseEditLabel() {
         val first = AgentEvent.ToolCall(
             atMillis = 1,

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -277,6 +277,14 @@ class AcpToolCallPresentationTest {
         )
 
         val merged = AcpToolCallPresentation.mergeToolCalls(first, update)
+        val preDiffOutput = AcpToolCallPresentation.mergeToolCalls(
+            first.copy(
+                detail = first.detail +
+                    AcpToolCallPresentation.DetailSeparator +
+                    "warning: formatter skipped generated file",
+            ),
+            update,
+        )
         val withOutput = AcpToolCallPresentation.mergeToolCalls(
             merged,
             AgentEvent.ToolCall(
@@ -303,6 +311,10 @@ class AcpToolCallPresentationTest {
         )
 
         assertEquals(diff, merged.detail)
+        assertEquals(
+            "$diff${AcpToolCallPresentation.DetailSeparator}warning: formatter skipped generated file",
+            preDiffOutput.detail,
+        )
         assertEquals(AgentToolState.Completed, merged.state)
         assertEquals(
             "$diff${AcpToolCallPresentation.DetailSeparator}warning: formatter skipped generated file",

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -215,6 +215,18 @@ class AcpToolCallPresentationTest {
     }
 
     @Test
+    fun displayDetailCanExcludeNestedDiffWhileKeepingMetadata() {
+        val diff = "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new"
+        val payload = """{"exitCode":7,"stdout":"${diff.replace("\n", "\\n")}","stderr":"warning"}"""
+
+        val rendered = AcpToolCallPresentation.displayDetailExcludingPayload(payload, diff)
+
+        assertTrue(rendered.contains("exitCode"))
+        assertTrue(rendered.contains("warning"))
+        assertFalse(rendered.contains("--- a/file.txt"))
+    }
+
+    @Test
     fun placeholderDetailsCountAsNoOutput() {
         assertTrue(AcpToolCallPresentation.isMinimalOutput("No details"))
         assertTrue(AcpToolCallPresentation.isMinimalOutput("none"))

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -285,6 +285,10 @@ class AcpToolCallPresentationTest {
             ),
             update,
         )
+        val plainPreDiffOutput = AcpToolCallPresentation.mergeToolCalls(
+            first.copy(detail = "warning: formatter skipped generated file"),
+            update,
+        )
         val withOutput = AcpToolCallPresentation.mergeToolCalls(
             merged,
             AgentEvent.ToolCall(
@@ -327,6 +331,7 @@ class AcpToolCallPresentationTest {
             "$diff${AcpToolCallPresentation.DetailSeparator}warning: formatter skipped generated file",
             preDiffOutput.detail,
         )
+        assertEquals(preDiffOutput.detail, plainPreDiffOutput.detail)
         assertEquals(AgentToolState.Completed, merged.state)
         assertEquals(
             "$diff${AcpToolCallPresentation.DetailSeparator}warning: formatter skipped generated file",

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -312,6 +312,32 @@ class AcpToolCallPresentationTest {
     }
 
     @Test
+    fun mergeKeepsEditArgumentsParseableWhenOutputArrives() {
+        val arguments = """{"file_path":"README.md","old_string":"old","new_string":"new"}"""
+        val pending = AgentEvent.ToolCall(
+            atMillis = 1,
+            toolName = "Edit File",
+            summary = "README.md",
+            detail = arguments,
+            toolCallId = "edit-arguments",
+            kind = AgentToolKind.Edit,
+            state = AgentToolState.Pending,
+        )
+        val completed = pending.copy(
+            atMillis = 2,
+            detail = "warning: formatter skipped generated file",
+            state = AgentToolState.Completed,
+        )
+
+        val merged = AcpToolCallPresentation.mergeToolCalls(pending, completed)
+
+        assertEquals(
+            "$arguments${AcpToolCallPresentation.DetailSeparator}warning: formatter skipped generated file",
+            merged.detail,
+        )
+    }
+
+    @Test
     fun mergePrefersActionPathOverSparseEditLabel() {
         val first = AgentEvent.ToolCall(
             atMillis = 1,

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -277,9 +277,25 @@ class AcpToolCallPresentationTest {
         )
 
         val merged = AcpToolCallPresentation.mergeToolCalls(first, update)
+        val withOutput = AcpToolCallPresentation.mergeToolCalls(
+            merged,
+            AgentEvent.ToolCall(
+                atMillis = 3,
+                toolName = "tool",
+                summary = "warning",
+                detail = "warning: formatter skipped generated file",
+                toolCallId = "call-1",
+                kind = AgentToolKind.Edit,
+                state = AgentToolState.Completed,
+            ),
+        )
 
         assertEquals(diff, merged.detail)
         assertEquals(AgentToolState.Completed, merged.state)
+        assertEquals(
+            "$diff${AcpToolCallPresentation.DetailSeparator}warning: formatter skipped generated file",
+            withOutput.detail,
+        )
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -217,12 +217,14 @@ class AcpToolCallPresentationTest {
     @Test
     fun displayDetailCanExcludeNestedDiffWhileKeepingMetadata() {
         val diff = "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new"
-        val payload = """{"exitCode":7,"stdout":"${diff.replace("\n", "\\n")}","stderr":"warning"}"""
+        val stdout = "warning before patch\n$diff"
+        val payload = """{"exitCode":7,"stdout":"${stdout.replace("\n", "\\n")}","stderr":"warning after patch"}"""
 
         val rendered = AcpToolCallPresentation.displayDetailExcludingPayload(payload, diff)
 
         assertTrue(rendered.contains("exitCode"))
-        assertTrue(rendered.contains("warning"))
+        assertTrue(rendered.contains("warning before patch"))
+        assertTrue(rendered.contains("warning after patch"))
         assertFalse(rendered.contains("--- a/file.txt"))
     }
 

--- a/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -309,6 +309,18 @@ class AcpToolCallPresentationTest {
                 state = AgentToolState.Completed,
             ),
         )
+        val secondOutput = AcpToolCallPresentation.mergeToolCalls(
+            withOutput,
+            AgentEvent.ToolCall(
+                atMillis = 5,
+                toolName = "tool",
+                summary = "result",
+                detail = "formatting completed with warnings",
+                toolCallId = "call-1",
+                kind = AgentToolKind.Edit,
+                state = AgentToolState.Completed,
+            ),
+        )
 
         assertEquals(diff, merged.detail)
         assertEquals(
@@ -321,6 +333,11 @@ class AcpToolCallPresentationTest {
             withOutput.detail,
         )
         assertEquals(withOutput.detail, repeatedOutput.detail)
+        assertEquals(
+            "$diff${AcpToolCallPresentation.DetailSeparator}" +
+                "warning: formatter skipped generated file\nformatting completed with warnings",
+            secondOutput.detail,
+        )
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
+++ b/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
@@ -518,6 +518,94 @@ class AgentTranscriptTest {
     }
 
     @Test
+    fun genericToolNameNeverPrefixesTheHeadline() {
+        assertEquals(
+            "totalMatches=45, truncated=false",
+            toolBlockHeadline(
+                name = "tool",
+                summary = "totalMatches=45, truncated=false",
+                kind = null,
+                locations = emptyList(),
+            ),
+        )
+    }
+
+    @Test
+    fun genericToolNameWithoutArgumentsFallsBackToKindOrCallPhrase() {
+        assertEquals(
+            "Searched",
+            toolBlockHeadline(name = "tool", summary = "", kind = AgentToolKind.Search, locations = emptyList()),
+        )
+        assertEquals(
+            "Tool call",
+            toolBlockHeadline(name = "tool", summary = "", kind = null, locations = emptyList()),
+        )
+    }
+
+    /** Providers put whole command results in `summary`; a headline is a label, not a payload. */
+    @Test
+    fun commandResultHeadlineCollapsesToOneShortLine() {
+        val diff = buildString {
+            appendLine("diff --git a/src/Main.kt b/src/Main.kt")
+            appendLine("--- a/src/Main.kt")
+            appendLine("+++ b/src/Main.kt")
+            appendLine("@@ -1,2 +1,2 @@")
+            appendLine("-    println(\"old\")")
+            appendLine("+    println(\"new\")")
+            repeat(200) { appendLine("+    line $it") }
+        }
+
+        val headline = toolBlockHeadline(
+            name = "tool",
+            summary = "exitCode=0, stdout=$diff",
+            kind = null,
+            locations = emptyList(),
+        )
+
+        assertFalse(headline.contains('\n'))
+        assertTrue(headline.length <= 161, "headline was ${headline.length} chars")
+        assertTrue(headline.startsWith("exitCode=0, stdout=diff --git"))
+        assertTrue(headline.endsWith("…"))
+    }
+
+    @Test
+    fun contentFreeToolRowsAreOmittedAndOnlyCounted() {
+        assertTrue(toolRowShowsNothing("tool", "", "", emptyList(), hasImages = false))
+        assertTrue(toolRowShowsNothing("tool", "No details", "No details", emptyList(), hasImages = false))
+        assertFalse(toolRowShowsNothing("tool", "", "", listOf("src/Main.kt"), hasImages = false))
+        assertFalse(toolRowShowsNothing("tool", "", "", emptyList(), hasImages = true))
+        assertFalse(toolRowShowsNothing("grep", "", "", emptyList(), hasImages = false))
+
+        val bookkeeping = (1..3).map { index ->
+            AgentEvent.ToolCall(atMillis = index.toLong(), toolName = "tool", summary = "", detail = "")
+        }
+        assertEquals("3 tool calls", compactToolActivityHeadline(bookkeeping))
+        assertEquals(
+            "Ran ./gradlew desktopTest",
+            compactToolActivityHeadline(
+                bookkeeping + AgentEvent.ToolCall(
+                    atMillis = 4,
+                    toolName = "Terminal",
+                    summary = "./gradlew desktopTest",
+                    kind = AgentToolKind.Execute,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun toolDetailsPreserveMarkdownAndFencePlainCode() {
+        val markdown = "### Result\n\n- first\n- second"
+        assertEquals(markdown, toolDetailMarkdown(markdown))
+
+        val code = "fun main() {\n    println(\"hello\")\n}"
+        assertEquals(
+            "```kotlin\n$code\n```",
+            toolDetailMarkdown(code, "src/Main.kt"),
+        )
+    }
+
+    @Test
     fun connectionStallErrorsAreHiddenFromTranscriptDisplay() {
         val events = listOf(
             AgentEvent.ToolCall(atMillis = 1, toolName = "read", summary = "gradle"),

--- a/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
+++ b/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
@@ -574,6 +574,7 @@ class AgentTranscriptTest {
         assertTrue(toolRowShowsNothing("tool", "No details", "No details", emptyList(), hasImages = false))
         assertFalse(toolRowShowsNothing("tool", "", "", listOf("src/Main.kt"), hasImages = false))
         assertFalse(toolRowShowsNothing("tool", "", "", emptyList(), hasImages = true))
+        assertFalse(toolRowShowsNothing("tool", "", "", emptyList(), hasImages = false, isFailure = true))
         assertFalse(toolRowShowsNothing("grep", "", "", emptyList(), hasImages = false))
 
         val bookkeeping = (1..3).map { index ->

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
@@ -162,7 +162,8 @@ object AcpEventMapper {
         atMillis: Long,
         terminalOutput: (String) -> String?,
     ): AgentEvent.ToolCall {
-        val details = content.joinToString("\n") { it.render(terminalOutput) }
+        val contentDetails = content.joinToString("\n") { it.render(terminalOutput) }
+        val details = contentDetails
             .ifBlank { listOfNotNull(rawInput, rawOutput).joinToString("\n") }
         val presented = AcpToolCallPresentation.present(title, rawInput, rawOutput, details)
         val summary = AcpToolCallPresentation.enrichSummary(
@@ -173,15 +174,16 @@ object AcpEventMapper {
         // Structured edit calls need their original JSON until the transcript has had a chance to
         // recognize file fields. Attach output separately; ToolBlock formats it after parsing.
         val structuredInput = rawInput?.takeIf {
-            content.isEmpty() &&
+            content.none { item -> item is ToolCallContent.Diff } &&
                 (kind == ToolKind.EDIT || kind == ToolKind.DELETE || kind == ToolKind.MOVE) &&
                 !AcpToolCallPresentation.isMinimalOutput(it)
         }
         val detail = structuredInput?.let { input ->
-            rawOutput
-                ?.takeUnless { AcpToolCallPresentation.isMinimalOutput(it) }
-                ?.let { output -> "$input${AcpToolCallPresentation.DetailSeparator}$output" }
-                ?: input
+            val extra = listOfNotNull(
+                contentDetails.takeIf { it.isNotBlank() },
+                rawOutput?.takeUnless { AcpToolCallPresentation.isMinimalOutput(it) },
+            ).distinct().joinToString("\n")
+            if (extra.isBlank()) input else "$input${AcpToolCallPresentation.DetailSeparator}$extra"
         } ?: presented.detail
         return AgentEvent.ToolCall(
             atMillis = atMillis,

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
@@ -176,6 +176,7 @@ object AcpEventMapper {
             ?.takeIf {
                 content.isEmpty() &&
                     rawOutput.isNullOrBlank() &&
+                    (kind == ToolKind.EDIT || kind == ToolKind.DELETE || kind == ToolKind.MOVE) &&
                     !AcpToolCallPresentation.isMinimalOutput(it)
             }
             ?: presented.detail

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
@@ -170,16 +170,19 @@ object AcpEventMapper {
             kind = kind.toAgentKind(),
             locations = locations,
         )
-        // Argument-only calls need the original JSON until the transcript has had a chance to
-        // recognize structured edit fields. ToolBlock formats it only after that parse attempt.
-        val detail = rawInput
-            ?.takeIf {
-                content.isEmpty() &&
-                    rawOutput.isNullOrBlank() &&
-                    (kind == ToolKind.EDIT || kind == ToolKind.DELETE || kind == ToolKind.MOVE) &&
-                    !AcpToolCallPresentation.isMinimalOutput(it)
-            }
-            ?: presented.detail
+        // Structured edit calls need their original JSON until the transcript has had a chance to
+        // recognize file fields. Attach output separately; ToolBlock formats it after parsing.
+        val structuredInput = rawInput?.takeIf {
+            content.isEmpty() &&
+                (kind == ToolKind.EDIT || kind == ToolKind.DELETE || kind == ToolKind.MOVE) &&
+                !AcpToolCallPresentation.isMinimalOutput(it)
+        }
+        val detail = structuredInput?.let { input ->
+            rawOutput
+                ?.takeUnless { AcpToolCallPresentation.isMinimalOutput(it) }
+                ?.let { output -> "$input${AcpToolCallPresentation.DetailSeparator}$output" }
+                ?: input
+        } ?: presented.detail
         return AgentEvent.ToolCall(
             atMillis = atMillis,
             toolName = presented.toolName,

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
@@ -170,11 +170,20 @@ object AcpEventMapper {
             kind = kind.toAgentKind(),
             locations = locations,
         )
+        // Argument-only calls need the original JSON until the transcript has had a chance to
+        // recognize structured edit fields. ToolBlock formats it only after that parse attempt.
+        val detail = rawInput
+            ?.takeIf {
+                content.isEmpty() &&
+                    rawOutput.isNullOrBlank() &&
+                    !AcpToolCallPresentation.isMinimalOutput(it)
+            }
+            ?: presented.detail
         return AgentEvent.ToolCall(
             atMillis = atMillis,
             toolName = presented.toolName,
             summary = summary,
-            detail = presented.detail,
+            detail = detail,
             toolCallId = id,
             kind = kind.toAgentKind(),
             state = status.toAgentState(),

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpTranscriptStore.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpTranscriptStore.kt
@@ -1,5 +1,6 @@
 package app.andy.desktop.service.agents.acp
 
+import app.andy.model.AcpToolCallPresentation
 import app.andy.model.AgentEvent
 import app.andy.model.AgentPlanEntry
 import app.andy.model.AgentQuotaWindow
@@ -29,15 +30,26 @@ class AcpTranscriptStore(
     }
 
     fun upsert(taskId: String, event: AgentEvent) = synchronized(locks.computeIfAbsent(taskId) { Any() }) {
-        val id = (event as? AgentEvent.ToolCall)?.toolCallId
-        if (id == null) {
+        val incoming = event as? AgentEvent.ToolCall
+        val id = incoming?.toolCallId
+        if (incoming == null || id == null) {
             appendUnlocked(taskId, event)
             return@synchronized
         }
         val file = fileFor(taskId)
         val entries = loadUnlocked(file).toMutableList()
         val index = entries.indexOfLast { (it.toModel() as? AgentEvent.ToolCall)?.toolCallId == id }
-        if (index < 0) entries += event.toDto() else entries[index] = event.toDto()
+        if (index < 0) {
+            entries += incoming.toDto()
+        } else {
+            // A provider update repeats only what changed: cursor-agent sends the title once and
+            // the output later, with no title and often no status. Overwriting the stored row threw
+            // away whichever half arrived first, which is how completed calls persisted as pending
+            // rows with no arguments. Merge exactly as the in-memory transcript does.
+            val previous = entries[index].toModel() as? AgentEvent.ToolCall
+            val merged = previous?.let { AcpToolCallPresentation.mergeToolCalls(it, incoming) } ?: incoming
+            entries[index] = merged.toDto()
+        }
         writeUnlocked(file, entries)
     }
 

--- a/src/desktopMain/resources/webchat/app.js
+++ b/src/desktopMain/resources/webchat/app.js
@@ -443,6 +443,55 @@
     }
   }
 
+  const TOOL_KIND_PHRASES = {
+    read: "Read file",
+    edit: "Edited file",
+    delete: "Deleted file",
+    move: "Moved file",
+    search: "Searched",
+    execute: "Ran command",
+    think: "Thought",
+    fetch: "Fetched a resource",
+  };
+
+  function summarizeJsonValue(value) {
+    if (value === null || value === undefined) return "";
+    if (Array.isArray(value)) return value.map(summarizeJsonValue).filter(Boolean).join(", ");
+    if (typeof value === "object") {
+      return Object.entries(value)
+        .map(([key, entry]) => {
+          const text = summarizeJsonValue(entry);
+          return text ? `${key}=${text}` : "";
+        })
+        .filter(Boolean)
+        .join(", ");
+    }
+    return String(value);
+  }
+
+  // Agents often echo their arguments back as a JSON payload. A key=value line is readable on a
+  // phone; a wall of braces is not.
+  function toolDetailText(text) {
+    const trimmed = (text || "").trim();
+    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return trimmed;
+    try {
+      return summarizeJsonValue(JSON.parse(trimmed));
+    } catch (_) {
+      return trimmed;
+    }
+  }
+
+  function toolBubbleText(ev) {
+    const detail = toolDetailText(ev.summary) || toolDetailText(ev.detail) || (ev.locations || [])[0] || "";
+    const name = (ev.toolName || "").trim();
+    // "tool" is a placeholder the agent sends when it has no name to give, so it must never
+    // stand in as one.
+    const label = name.toLowerCase() === "tool" ? "" : name;
+    const fallback = TOOL_KIND_PHRASES[(ev.kind || "").toLowerCase()] || "Tool call";
+    const text = label && detail ? `${label} — ${detail}` : label || detail || fallback;
+    return text.length > 240 ? `${text.slice(0, 240)}…` : text;
+  }
+
   function renderTranscript() {
     const root = $("transcript");
     if (!root || chatLoading) return;
@@ -464,7 +513,7 @@
         el.textContent = `thinking: ${(ev.text || "").slice(0, 240)}`;
       } else if (type === "tool" || type === "tool-result") {
         el.className = "bubble tool";
-        el.textContent = `${ev.toolName || "tool"} — ${ev.summary || ev.detail || type}`;
+        el.textContent = toolBubbleText(ev);
       } else if (type === "permission") {
         el.className = "bubble meta";
         el.textContent = `permission: ${ev.question || ev.toolName || ""}`;

--- a/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentEvidenceHandoffTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentEvidenceHandoffTest.kt
@@ -281,8 +281,13 @@ private suspend fun callRawTool(
         writer.write("\n")
         writer.flush()
 
-        val line = reader.readLine() ?: error("no response for $name")
-        val root = json.parseToJsonElement(line).jsonObject
+        // The SDK may emit a notification (for example tools/list_changed) before the call
+        // response. Linux CI exposed this ordering more often than macOS, so match by request id
+        // instead of assuming the next line is our response.
+        val root = generateSequence { reader.readLine() }
+            .map { json.parseToJsonElement(it).jsonObject }
+            .firstOrNull { it["id"]?.jsonPrimitive?.contentOrNull == "2" }
+            ?: error("no response for $name")
         val rpcError = root["error"]?.jsonObject
         if (rpcError != null) {
             return@use true to (rpcError["message"]?.jsonPrimitive?.contentOrNull ?: rpcError.toString())

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
@@ -195,6 +195,26 @@ class AcpLaneTest {
         assertEquals("README.md", parsed.path)
         assertEquals("old", parsed.oldText)
         assertEquals("new", parsed.newText)
+
+        val bundled = assertIs<AgentEvent.ToolCall>(
+            AcpEventMapper.map(
+                SessionUpdate.ToolCall(
+                    toolCallId = com.agentclientprotocol.model.ToolCallId("edit-json-output"),
+                    title = "Edit File",
+                    kind = ToolKind.EDIT,
+                    status = ToolCallStatus.COMPLETED,
+                    content = emptyList(),
+                    rawInput = buildJsonObject {
+                        put("file_path", "README.md")
+                        put("old_string", "old")
+                        put("new_string", "new")
+                    },
+                    rawOutput = buildJsonObject { put("success", true) },
+                ),
+                atMillis = 2,
+            ),
+        )
+        assertEquals(mapped.detail, bundled.detail)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
@@ -381,6 +381,105 @@ class AcpLaneTest {
         }
     }
 
+    /**
+     * cursor-agent announces a call with its title and empty arguments, then reports completion in a
+     * separate update carrying only status and output. Replacing the stored row erased the title and
+     * left finished calls persisted as pending rows with nothing in them.
+     */
+    @Test
+    fun transcriptStoreMergesSparseToolCallUpdatesInsteadOfOverwriting() {
+        val root = createTempDirectory("andy-acp-tool-merge").toFile()
+        try {
+            val store = AcpTranscriptStore(fileFor = { id -> root.resolve(id).resolve("transcript.jsonl") })
+            store.upsert(
+                "task-1",
+                AgentEvent.ToolCall(
+                    atMillis = 1,
+                    toolName = "Read File",
+                    summary = "",
+                    detail = "{}",
+                    toolCallId = "call-1",
+                    kind = AgentToolKind.Read,
+                    state = AgentToolState.Pending,
+                ),
+            )
+            store.upsert(
+                "task-1",
+                AgentEvent.ToolCall(
+                    atMillis = 2,
+                    toolName = "tool",
+                    summary = "content=alpha line",
+                    detail = """{"content":"alpha line"}""",
+                    toolCallId = "call-1",
+                    kind = AgentToolKind.Read,
+                    state = AgentToolState.Completed,
+                ),
+            )
+
+            val row = assertIs<AgentEvent.ToolCall>(store.load("task-1").single())
+            assertEquals("Read File", row.toolName)
+            assertEquals(AgentToolState.Completed, row.state)
+            assertTrue(row.detail.contains("alpha line"), "lost the output: ${row.detail}")
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    /**
+     * The real cursor-agent sequence for an edit: a pending row with a bare title and no arguments,
+     * then a completing update whose `content` carries the path plus before/after text. The stored
+     * row has to end up with both, and in the shape the transcript's diff viewer parses.
+     */
+    @Test
+    fun editToolCallKeepsItsPathAndDiffAcrossUpdates() {
+        val root = createTempDirectory("andy-acp-edit-diff").toFile()
+        try {
+            val store = AcpTranscriptStore(fileFor = { id -> root.resolve(id).resolve("transcript.jsonl") })
+            val callId = "call-b6cc1564-0"
+            store.upsert(
+                "task-1",
+                AcpEventMapper.map(
+                    SessionUpdate.ToolCall(
+                        toolCallId = com.agentclientprotocol.model.ToolCallId(callId),
+                        title = "Edit File",
+                        kind = ToolKind.EDIT,
+                        status = ToolCallStatus.PENDING,
+                        rawInput = buildJsonObject { },
+                    ),
+                )!!,
+            )
+            store.upsert(
+                "task-1",
+                AcpEventMapper.map(
+                    SessionUpdate.ToolCallUpdate(
+                        toolCallId = com.agentclientprotocol.model.ToolCallId(callId),
+                        status = ToolCallStatus.COMPLETED,
+                        content = listOf(
+                            com.agentclientprotocol.model.ToolCallContent.Diff(
+                                path = "/tmp/probe/notes.txt",
+                                oldText = "alpha line\n",
+                                newText = "ALPHA line\n",
+                            ),
+                        ),
+                    ),
+                )!!,
+            )
+
+            val row = assertIs<AgentEvent.ToolCall>(store.load("task-1").single())
+            assertEquals("Edit File", row.toolName)
+            assertEquals(AgentToolState.Completed, row.state)
+            val parsed = assertIs<app.andy.domain.ToolCallFileContent>(
+                app.andy.domain.parseToolCallFileContent(row.detail),
+            )
+            assertEquals("/tmp/probe/notes.txt", parsed.path)
+            assertEquals("alpha line", parsed.oldText?.trim())
+            assertEquals("ALPHA line", parsed.newText?.trim())
+            assertTrue(parsed.hasDiff)
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
     @Test
     fun stopReasonsProduceConfidentTurnBoundaries() {
         assertEquals(app.andy.model.AgentStatus.Done, AcpStatusModel.fromStopReason("end_turn").status)

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
@@ -215,6 +215,33 @@ class AcpLaneTest {
             ),
         )
         assertEquals(mapped.detail, bundled.detail)
+
+        val withContent = assertIs<AgentEvent.ToolCall>(
+            AcpEventMapper.map(
+                SessionUpdate.ToolCall(
+                    toolCallId = com.agentclientprotocol.model.ToolCallId("edit-json-content"),
+                    title = "Edit File",
+                    kind = ToolKind.EDIT,
+                    status = ToolCallStatus.COMPLETED,
+                    content = listOf(
+                        com.agentclientprotocol.model.ToolCallContent.Content(
+                            content = ContentBlock.Text("warning: formatter skipped generated file"),
+                        ),
+                    ),
+                    rawInput = buildJsonObject {
+                        put("file_path", "README.md")
+                        put("old_string", "old")
+                        put("new_string", "new")
+                    },
+                ),
+                atMillis = 3,
+            ),
+        )
+        val withContentParsed = assertIs<app.andy.domain.ToolCallFileContent>(
+            app.andy.domain.parseToolCallFileArguments(withContent.detail, withContent.kind),
+        )
+        assertEquals("README.md", withContentParsed.path)
+        assertEquals("warning: formatter skipped generated file", withContentParsed.extraDetail)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
@@ -169,6 +169,35 @@ class AcpLaneTest {
     }
 
     @Test
+    fun mapperKeepsArgumentOnlyEditJsonUntilStructuredParsing() {
+        val mapped = assertIs<AgentEvent.ToolCall>(
+            AcpEventMapper.map(
+                SessionUpdate.ToolCall(
+                    toolCallId = com.agentclientprotocol.model.ToolCallId("edit-json"),
+                    title = "Edit File",
+                    kind = ToolKind.EDIT,
+                    status = ToolCallStatus.PENDING,
+                    content = emptyList(),
+                    rawInput = buildJsonObject {
+                        put("file_path", "README.md")
+                        put("old_string", "old")
+                        put("new_string", "new")
+                    },
+                ),
+                atMillis = 1,
+            ),
+        )
+
+        assertTrue(mapped.detail.startsWith("{"))
+        val parsed = assertIs<app.andy.domain.ToolCallFileContent>(
+            app.andy.domain.parseToolCallFileArguments(mapped.detail, mapped.kind),
+        )
+        assertEquals("README.md", parsed.path)
+        assertEquals("old", parsed.oldText)
+        assertEquals("new", parsed.newText)
+    }
+
+    @Test
     fun mapperPreservesAssistantTextAndToolState() {
         val assistant = AcpEventMapper.map(
             SessionUpdate.AgentMessageChunk(ContentBlock.Text("hello")),

--- a/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
@@ -300,8 +300,9 @@ class AgentTranscriptUiTest {
                 +    println("new output")
                  }
             """.trimIndent()
+            val stdout = "warning before patch\n$diffText"
             val payload =
-                """{"exitCode":7,"stdout":"${diffText.replace("\n", "\\n").replace("\"", "\\\"")}","stderr":"formatter warning"}"""
+                """{"exitCode":7,"stdout":"${stdout.replace("\n", "\\n").replace("\"", "\\\"")}","stderr":"formatter warning"}"""
 
             setContent {
                 AndyTheme {
@@ -327,6 +328,7 @@ class AgentTranscriptUiTest {
                 .fetchSemanticsNodes()
                 .let { assertTrue(it.isNotEmpty(), "diff body was not rendered") }
             assertTrue(onAllNodesWithText("\"stdout\"", substring = true).fetchSemanticsNodes().isEmpty())
+            onNodeWithText("warning before patch", substring = true).assertExists()
             onNodeWithText("formatter warning", substring = true).assertExists()
             onNodeWithText("exitCode:", substring = true).assertExists()
             // The row used to render the entire payload as one 4 KB line of text.

--- a/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
@@ -7,10 +7,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -241,6 +244,95 @@ class AgentTranscriptUiTest {
             assertEquals(0, restored.index)
             assertEquals(0, restored.offset)
             onNodeWithTag("transcript-row-UserMessage-41-41").assertIsDisplayed()
+        }
+
+    /** Persisted rows keep the provider's raw payload, so the transcript must format it on render. */
+    @Test
+    fun toolRowsShowNeitherRawJsonNorTheGenericToolLabel() =
+        runTranscriptUiTest {
+            setContent {
+                AndyTheme {
+                    AgentTranscript(
+                        events = listOf(
+                            AgentEvent.UserMessage(atMillis = 1, text = "search the repo"),
+                            AgentEvent.ToolResult(
+                                atMillis = 2,
+                                toolName = "tool",
+                                summary = "totalMatches=45, truncated=false",
+                                detail = """{"totalMatches":45,"truncated":false}""",
+                                isError = false,
+                            ),
+                            AgentEvent.ToolResult(
+                                atMillis = 3,
+                                toolName = "tool",
+                                summary = "",
+                                detail = "",
+                                isError = false,
+                            ),
+                        ),
+                        isActive = false,
+                        autoExpandActivitySections = true,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+            waitForIdle()
+
+            onNodeWithText("totalMatches=45, truncated=false").assertIsDisplayed()
+            // A call carrying only an id has nothing to say, so it gets no row at all.
+            assertTrue(onAllNodesWithText("Tool call", substring = true).fetchSemanticsNodes().isEmpty())
+            assertTrue(onAllNodesWithText("{", substring = true).fetchSemanticsNodes().isEmpty())
+            assertTrue(onAllNodesWithText("tool:", substring = true).fetchSemanticsNodes().isEmpty())
+        }
+
+    /** A shell result wraps its diff in JSON; the row must show the diff, not the transport. */
+    @Test
+    fun commandResultDiffRendersInTheDiffViewer() =
+        runTranscriptUiTest {
+            val diffText = """
+                diff --git a/src/Main.kt b/src/Main.kt
+                index c0fcac9..7b39bbc 100644
+                --- a/src/Main.kt
+                +++ b/src/Main.kt
+                @@ -1,3 +1,3 @@
+                 fun main() {
+                -    println("old output")
+                +    println("new output")
+                 }
+            """.trimIndent()
+            val payload = """{"exitCode":0,"stdout":"${diffText.replace("\n", "\\n").replace("\"", "\\\"")}","stderr":""}"""
+
+            setContent {
+                AndyTheme {
+                    AgentTranscript(
+                        events = listOf(
+                            AgentEvent.UserMessage(atMillis = 1, text = "show me the diff"),
+                            AgentEvent.ToolCall(
+                                atMillis = 2,
+                                toolName = "tool",
+                                summary = "exitCode=0, stdout=$diffText",
+                                detail = payload,
+                            ),
+                        ),
+                        isActive = false,
+                        autoExpandActivitySections = true,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+            waitForIdle()
+
+            onAllNodesWithText("println(\"new output\")", substring = true)
+                .fetchSemanticsNodes()
+                .let { assertTrue(it.isNotEmpty(), "diff body was not rendered") }
+            assertTrue(onAllNodesWithText("\"stdout\"", substring = true).fetchSemanticsNodes().isEmpty())
+            // The row used to render the entire payload as one 4 KB line of text.
+            val longestRendered = onAllNodesWithText("", substring = true)
+                .fetchSemanticsNodes()
+                .flatMap { node -> node.config.getOrNull(SemanticsProperties.Text).orEmpty() }
+                .maxOfOrNull { it.text.length }
+                ?: 0
+            assertTrue(longestRendered <= 200, "rendered a $longestRendered-character blob")
         }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
@@ -300,7 +300,8 @@ class AgentTranscriptUiTest {
                 +    println("new output")
                  }
             """.trimIndent()
-            val payload = """{"exitCode":0,"stdout":"${diffText.replace("\n", "\\n").replace("\"", "\\\"")}","stderr":""}"""
+            val payload =
+                """{"exitCode":7,"stdout":"${diffText.replace("\n", "\\n").replace("\"", "\\\"")}","stderr":"formatter warning"}"""
 
             setContent {
                 AndyTheme {
@@ -326,6 +327,8 @@ class AgentTranscriptUiTest {
                 .fetchSemanticsNodes()
                 .let { assertTrue(it.isNotEmpty(), "diff body was not rendered") }
             assertTrue(onAllNodesWithText("\"stdout\"", substring = true).fetchSemanticsNodes().isEmpty())
+            onNodeWithText("formatter warning", substring = true).assertExists()
+            onNodeWithText("exitCode:", substring = true).assertExists()
             // The row used to render the entire payload as one 4 KB line of text.
             val longestRendered = onAllNodesWithText("", substring = true)
                 .fetchSemanticsNodes()


### PR DESCRIPTION
## Summary
- render tool payloads as concise Markdown, highlighted code, or inline diffs instead of raw JSON
- replace generic tool labels with useful action phrases and omit content-free bookkeeping rows
- merge sparse ACP updates during persistence so edit paths, before/after content, output, and final state are retained
- apply equivalent formatting to the web chat transcript

## Test plan
- `./gradlew desktopTest --tests 'app.andy.desktop.service.agents.acp.AcpLaneTest' --tests 'app.andy.model.AcpToolCallPresentationTest' --tests 'app.andy.ui.agents.AgentTranscriptTest'`
- targeted domain and transcript UI suites passed
- `verifyRoborazziDesktop`: all 16 screenshot comparisons passed; full desktop suite still reports pre-existing local Claude binary, GPU mirror flake, and one suite-load timeout that passes in isolation

Made with [Cursor](https://cursor.com)