### PR TITLE
Preserve trailing tool diff diagnostics

### DIFF
--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -109,8 +109,12 @@ private fun JsonObject.stringValue(key: String, allowEmpty: Boolean = false): St
 fun diffFromToolCallFileContent(content: ToolCallFileContent): AgentFileDiff =
     diffTextLines(content.path, content.oldText, content.newText)
 
-private val WindowsDriveLetter = Regex("""^[A-Za-z]:\\""")
+private val WindowsDriveLetter = Regex("""^[A-Za-z]:[\\/]""")
 private val ProviderAssignment = Regex("""^[A-Za-z][A-Za-z0-9 _-]*\s*=""")
+private val DiagnosticPrefix = Regex(
+    """^(?:failed|failure|error|warning|permission|unable|could|cannot|can't|did not|edit(?:ed)?|moved?|deleted?|completed|success)\b""",
+    RegexOption.IGNORE_CASE,
+)
 private val ConventionalExtensionlessFiles = setOf(
     "BUILD",
     "CMakeLists",
@@ -151,6 +155,9 @@ private fun looksLikePrimitiveFilePath(text: String): Boolean {
     if (trimmed.any { it == '\t' || it == '\r' }) return false
     if (trimmed.any { it in "{}[]\"'<>|?*" }) return false
     if (':' in trimmed && !WindowsDriveLetter.containsMatchIn(trimmed)) return false
+    if (DiagnosticPrefix.containsMatchIn(trimmed)) return false
+    val hasSeparator = trimmed.contains('/') || trimmed.contains('\\')
+    if (trimmed.any { it.isWhitespace() } && hasSeparator) return false
     return trimmed.contains('/') ||
         trimmed.contains('\\') ||
         trimmed.substringAfterLast('/').substringAfterLast('\\').contains('.') ||

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -148,7 +148,7 @@ private fun looksLikeStructuredFilePath(text: String): Boolean {
 private fun looksLikePrimitiveFilePath(text: String): Boolean {
     val trimmed = text.trim()
     if (!looksLikeStructuredFilePath(trimmed)) return false
-    if (trimmed.any { it.isWhitespace() }) return false
+    if (trimmed.any { it == '\t' || it == '\r' }) return false
     if (trimmed.any { it in "{}[]\"'<>|?*" }) return false
     if (':' in trimmed && !WindowsDriveLetter.containsMatchIn(trimmed)) return false
     return trimmed.contains('/') ||

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -84,7 +84,7 @@ fun parseToolCallFileArguments(text: String, kind: AgentToolKind? = null): ToolC
     }
     if (!arguments.startsWith("{")) {
         val fileMutation = kind == AgentToolKind.Edit || kind == AgentToolKind.Delete || kind == AgentToolKind.Move
-        return arguments.takeIf { fileMutation && looksLikeStructuredFilePath(it) }
+        return arguments.takeIf { fileMutation && looksLikePrimitiveFilePath(it) }
             ?.let { ToolCallFileContent(path = it, oldText = null, newText = null, extraDetail = extraDetail) }
     }
     val obj = runCatching { toolArgumentJson.parseToJsonElement(arguments) }.getOrNull() as? JsonObject ?: return null
@@ -126,6 +126,14 @@ private fun looksLikeStructuredFilePath(text: String): Boolean {
         trimmed.length <= 512 &&
         !trimmed.contains('\n') &&
         !looksLikeProviderPayload(trimmed)
+}
+
+private fun looksLikePrimitiveFilePath(text: String): Boolean {
+    val trimmed = text.trim()
+    if (!looksLikeStructuredFilePath(trimmed)) return false
+    return trimmed.contains('/') ||
+        trimmed.contains('\\') ||
+        trimmed.substringAfterLast('/').substringAfterLast('\\').contains('.')
 }
 
 internal fun looksLikeFilePath(text: String): Boolean {

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -131,6 +131,9 @@ private fun looksLikeStructuredFilePath(text: String): Boolean {
 private fun looksLikePrimitiveFilePath(text: String): Boolean {
     val trimmed = text.trim()
     if (!looksLikeStructuredFilePath(trimmed)) return false
+    if (trimmed.any { it.isWhitespace() }) return false
+    if (trimmed.any { it in "{}[]\"'<>|?*" }) return false
+    if (':' in trimmed && !WindowsDriveLetter.containsMatchIn(trimmed)) return false
     return trimmed.contains('/') ||
         trimmed.contains('\\') ||
         trimmed.substringAfterLast('/').substringAfterLast('\\').contains('.')

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -82,7 +82,11 @@ fun parseToolCallFileArguments(text: String, kind: AgentToolKind? = null): ToolC
     } else {
         null
     }
-    if (!arguments.startsWith("{")) return null
+    if (!arguments.startsWith("{")) {
+        val fileMutation = kind == AgentToolKind.Edit || kind == AgentToolKind.Delete || kind == AgentToolKind.Move
+        return arguments.takeIf { fileMutation && looksLikeStructuredFilePath(it) }
+            ?.let { ToolCallFileContent(path = it, oldText = null, newText = null, extraDetail = extraDetail) }
+    }
     val obj = runCatching { toolArgumentJson.parseToJsonElement(arguments) }.getOrNull() as? JsonObject ?: return null
     val path = PathArgumentKeys.firstNotNullOfOrNull { obj.stringValue(it) }
         ?.takeIf { looksLikeStructuredFilePath(it) }

--- a/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
+++ b/src/commonMain/kotlin/app/andy/domain/ToolCallFileContent.kt
@@ -111,6 +111,23 @@ fun diffFromToolCallFileContent(content: ToolCallFileContent): AgentFileDiff =
 
 private val WindowsDriveLetter = Regex("""^[A-Za-z]:\\""")
 private val ProviderAssignment = Regex("""^[A-Za-z][A-Za-z0-9 _-]*\s*=""")
+private val ConventionalExtensionlessFiles = setOf(
+    "BUILD",
+    "CMakeLists",
+    "COPYING",
+    "Dockerfile",
+    "Gemfile",
+    "Jenkinsfile",
+    "Justfile",
+    "LICENSE",
+    "Makefile",
+    "NOTICE",
+    "Procfile",
+    "Rakefile",
+    "README",
+    "Vagrantfile",
+    "WORKSPACE",
+)
 
 private fun looksLikeProviderPayload(text: String): Boolean {
     val firstLine = text.lineSequence().firstOrNull { it.isNotBlank() }?.trim().orEmpty()
@@ -136,7 +153,8 @@ private fun looksLikePrimitiveFilePath(text: String): Boolean {
     if (':' in trimmed && !WindowsDriveLetter.containsMatchIn(trimmed)) return false
     return trimmed.contains('/') ||
         trimmed.contains('\\') ||
-        trimmed.substringAfterLast('/').substringAfterLast('\\').contains('.')
+        trimmed.substringAfterLast('/').substringAfterLast('\\').contains('.') ||
+        trimmed in ConventionalExtensionlessFiles
 }
 
 internal fun looksLikeFilePath(text: String): Boolean {

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -44,6 +44,11 @@ fun extractUnifiedDiffText(text: String): String? {
             continue
         }
         if (oldLinesRemaining == 0 && newLinesRemaining == 0) {
+            if (line.startsWith("diff --git ") || line.startsWith("--- ")) {
+                endLine = index
+                sawHunk = false
+                continue
+            }
             if (line.startsWith("\\ No newline at end of file")) {
                 endLine = index
                 continue

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -22,7 +22,47 @@ fun looksLikeUnifiedDiff(text: String): Boolean {
 /** Returns the patch portion while leaving any leading command diagnostics outside it. */
 fun extractUnifiedDiffText(text: String): String? {
     val start = Regex("""(?m)^(?:diff --git |--- )""").find(text)?.range?.first ?: return null
-    return text.substring(start).takeIf(::looksLikeUnifiedDiff)
+    val suffix = text.substring(start)
+    if (!looksLikeUnifiedDiff(suffix)) return null
+    val lines = suffix.split('\n')
+    var endLine = -1
+    var sawHunk = false
+    var oldLinesRemaining = 0
+    var newLinesRemaining = 0
+    for ((index, line) in lines.withIndex()) {
+        val hunk = HunkHeader.find(line)
+        if (hunk != null) {
+            sawHunk = true
+            oldLinesRemaining = hunk.groupValues[2].toIntOrNull() ?: 1
+            newLinesRemaining = hunk.groupValues[4].toIntOrNull() ?: 1
+            endLine = index
+            continue
+        }
+        if (!sawHunk) {
+            endLine = index
+            if (line.startsWith("Binary files ") && line.endsWith(" differ")) break
+            continue
+        }
+        if (oldLinesRemaining == 0 && newLinesRemaining == 0) {
+            if (line.startsWith("\\ No newline at end of file")) {
+                endLine = index
+                continue
+            }
+            break
+        }
+        when (line.firstOrNull()) {
+            ' ' -> {
+                oldLinesRemaining = (oldLinesRemaining - 1).coerceAtLeast(0)
+                newLinesRemaining = (newLinesRemaining - 1).coerceAtLeast(0)
+            }
+            '-' -> oldLinesRemaining = (oldLinesRemaining - 1).coerceAtLeast(0)
+            '+' -> newLinesRemaining = (newLinesRemaining - 1).coerceAtLeast(0)
+            '\\' -> Unit
+            else -> break
+        }
+        endLine = index
+    }
+    return lines.take(endLine + 1).joinToString("\n").takeIf { it.isNotBlank() }
 }
 
 /** Path referenced by the diff's `+++`/`---` headers, stripping the `a/`/`b/` prefixes git adds. */

--- a/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
+++ b/src/commonMain/kotlin/app/andy/domain/UnifiedDiff.kt
@@ -44,7 +44,9 @@ fun extractUnifiedDiffText(text: String): String? {
             continue
         }
         if (oldLinesRemaining == 0 && newLinesRemaining == 0) {
-            if (line.startsWith("diff --git ") || line.startsWith("--- ")) {
+            val startsNextFile = line.startsWith("diff --git ") ||
+                (line.startsWith("--- ") && lines.getOrNull(index + 1)?.startsWith("+++ ") == true)
+            if (startsNextFile) {
                 endLine = index
                 sawHunk = false
                 continue

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -188,6 +188,10 @@ class ToolCallFileContentTest {
             "My File.kt",
             parseToolCallFileArguments("My File.kt", AgentToolKind.Edit)?.path,
         )
+        assertEquals(
+            "C:/src/Main.kt",
+            parseToolCallFileArguments("C:/src/Main.kt", AgentToolKind.Edit)?.path,
+        )
     }
 
     @Test
@@ -195,6 +199,7 @@ class ToolCallFileContentTest {
         assertNull(parseToolCallFileArguments("permission denied", AgentToolKind.Delete))
         assertNull(parseToolCallFileArguments("edit completed", AgentToolKind.Edit))
         assertNull(parseToolCallFileArguments("permission denied: src/Main.kt", AgentToolKind.Edit))
+        assertNull(parseToolCallFileArguments("failed to edit src/Main.kt", AgentToolKind.Edit))
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -164,6 +164,18 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun primitiveMovePathRemainsOpenableWithOutput() {
+        val content = parseToolCallFileArguments(
+            "README.md${AcpToolCallPresentation.DetailSeparator}moved",
+            AgentToolKind.Move,
+        )
+
+        assertNotNull(content)
+        assertEquals("README.md", content.path)
+        assertEquals("moved", content.extraDetail)
+    }
+
+    @Test
     fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
         assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
         assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -179,6 +179,7 @@ class ToolCallFileContentTest {
     fun primitiveMutationStatusIsNotTreatedAsAPath() {
         assertNull(parseToolCallFileArguments("permission denied", AgentToolKind.Delete))
         assertNull(parseToolCallFileArguments("edit completed", AgentToolKind.Edit))
+        assertNull(parseToolCallFileArguments("permission denied: src/Main.kt", AgentToolKind.Edit))
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -176,6 +176,12 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun primitiveMutationStatusIsNotTreatedAsAPath() {
+        assertNull(parseToolCallFileArguments("permission denied", AgentToolKind.Delete))
+        assertNull(parseToolCallFileArguments("edit completed", AgentToolKind.Edit))
+    }
+
+    @Test
     fun parseToolCallFileArgumentsIgnoresUnrelatedJson() {
         assertNull(parseToolCallFileArguments("""{"totalMatches":45,"truncated":false}"""))
         assertNull(parseToolCallFileArguments("""{"path":"src/Main.kt"}"""))

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -183,6 +183,14 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun primitivePathsMayContainSpaces() {
+        assertEquals(
+            "My File.kt",
+            parseToolCallFileArguments("My File.kt", AgentToolKind.Edit)?.path,
+        )
+    }
+
+    @Test
     fun primitiveMutationStatusIsNotTreatedAsAPath() {
         assertNull(parseToolCallFileArguments("permission denied", AgentToolKind.Delete))
         assertNull(parseToolCallFileArguments("edit completed", AgentToolKind.Edit))

--- a/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/ToolCallFileContentTest.kt
@@ -176,6 +176,13 @@ class ToolCallFileContentTest {
     }
 
     @Test
+    fun conventionalExtensionlessPrimitivePathsRemainOpenable() {
+        listOf("Dockerfile", "Makefile", "LICENSE").forEach { path ->
+            assertEquals(path, parseToolCallFileArguments(path, AgentToolKind.Move)?.path)
+        }
+    }
+
+    @Test
     fun primitiveMutationStatusIsNotTreatedAsAPath() {
         assertNull(parseToolCallFileArguments("permission denied", AgentToolKind.Delete))
         assertNull(parseToolCallFileArguments("edit completed", AgentToolKind.Edit))

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -79,6 +79,26 @@ class UnifiedDiffTest {
     }
 
     @Test
+    fun extractedUnifiedDiffLeavesSurroundingDiagnosticsOutside() {
+        val text = """
+            warning before patch
+            --- a/message.txt
+            +++ b/message.txt
+            @@ -1 +1 @@
+            -old
+            +new
+            warning after patch
+        """.trimIndent()
+
+        val patch = extractUnifiedDiffText(text)
+
+        assertEquals(
+            "--- a/message.txt\n+++ b/message.txt\n@@ -1 +1 @@\n-old\n+new",
+            patch,
+        )
+    }
+
+    @Test
     fun detectUnifiedDiffDeclinesMultiFilePatches() {
         val text = """
             diff --git a/src/First.kt b/src/First.kt

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -123,6 +123,21 @@ class UnifiedDiffTest {
     }
 
     @Test
+    fun extractedUnifiedDiffDoesNotConsumeDiagnosticSeparator() {
+        val patch = """
+            --- a/one.txt
+            +++ b/one.txt
+            @@ -1 +1 @@
+            -one
+            +ONE
+        """.trimIndent()
+
+        val extracted = extractUnifiedDiffText("$patch\n--- stderr ---\nwarning")
+
+        assertEquals(patch, extracted)
+    }
+
+    @Test
     fun detectUnifiedDiffDeclinesMultiFilePatches() {
         val text = """
             diff --git a/src/First.kt b/src/First.kt

--- a/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
+++ b/src/commonTest/kotlin/app/andy/domain/UnifiedDiffTest.kt
@@ -5,6 +5,7 @@ import app.andy.model.DiffLineKind
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class UnifiedDiffTest {
@@ -96,6 +97,29 @@ class UnifiedDiffTest {
             "--- a/message.txt\n+++ b/message.txt\n@@ -1 +1 @@\n-old\n+new",
             patch,
         )
+    }
+
+    @Test
+    fun extractedUnifiedDiffKeepsAllFilesForMultiFileRejection() {
+        val patch = """
+            diff --git a/one.txt b/one.txt
+            --- a/one.txt
+            +++ b/one.txt
+            @@ -1 +1 @@
+            -one
+            +ONE
+            diff --git a/two.txt b/two.txt
+            --- a/two.txt
+            +++ b/two.txt
+            @@ -1 +1 @@
+            -two
+            +TWO
+        """.trimIndent()
+
+        val extracted = extractUnifiedDiffText("$patch\nwarning after patch")
+
+        assertEquals(patch, extracted)
+        assertNull(detectUnifiedDiff(extracted.orEmpty()))
     }
 
     @Test

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpEventMapper.kt
@@ -18,6 +18,7 @@ import app.andy.model.AgentToolImage
 import app.andy.model.AgentToolKind
 import app.andy.model.AgentToolState
 import app.andy.model.AgentUserInputOption
+import app.andy.domain.parseToolCallFileArguments
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
@@ -176,7 +177,8 @@ object AcpEventMapper {
         val structuredInput = rawInput?.takeIf {
             content.none { item -> item is ToolCallContent.Diff } &&
                 (kind == ToolKind.EDIT || kind == ToolKind.DELETE || kind == ToolKind.MOVE) &&
-                !AcpToolCallPresentation.isMinimalOutput(it)
+                !AcpToolCallPresentation.isMinimalOutput(it) &&
+                parseToolCallFileArguments(it, kind.toAgentKind()) != null
         }
         val detail = structuredInput?.let { input ->
             val extra = listOfNotNull(

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpLaneTest.kt
@@ -242,6 +242,26 @@ class AcpLaneTest {
         )
         assertEquals("README.md", withContentParsed.path)
         assertEquals("warning: formatter skipped generated file", withContentParsed.extraDetail)
+
+        val primitiveMove = assertIs<AgentEvent.ToolCall>(
+            AcpEventMapper.map(
+                SessionUpdate.ToolCall(
+                    toolCallId = com.agentclientprotocol.model.ToolCallId("move-primitive-input"),
+                    title = "Move File",
+                    kind = ToolKind.MOVE,
+                    status = ToolCallStatus.COMPLETED,
+                    content = emptyList(),
+                    rawInput = kotlinx.serialization.json.JsonPrimitive("README.md"),
+                    rawOutput = buildJsonObject { put("moved", true) },
+                ),
+                atMillis = 4,
+            ),
+        )
+        val primitiveMoveParsed = assertIs<app.andy.domain.ToolCallFileContent>(
+            app.andy.domain.parseToolCallFileArguments(primitiveMove.detail, primitiveMove.kind),
+        )
+        assertEquals("README.md", primitiveMoveParsed.path)
+        assertEquals("""{"moved":true}""", primitiveMoveParsed.extraDetail)
     }
 
     @Test

--- a/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
+++ b/src/desktopTest/kotlin/app/andy/ui/agents/AgentTranscriptUiTest.kt
@@ -300,7 +300,7 @@ class AgentTranscriptUiTest {
                 +    println("new output")
                  }
             """.trimIndent()
-            val stdout = "warning before patch\n$diffText"
+            val stdout = "warning before patch\n$diffText\nwarning after patch"
             val payload =
                 """{"exitCode":7,"stdout":"${stdout.replace("\n", "\\n").replace("\"", "\\\"")}","stderr":"formatter warning"}"""
 
@@ -329,6 +329,7 @@ class AgentTranscriptUiTest {
                 .let { assertTrue(it.isNotEmpty(), "diff body was not rendered") }
             assertTrue(onAllNodesWithText("\"stdout\"", substring = true).fetchSemanticsNodes().isEmpty())
             onNodeWithText("warning before patch", substring = true).assertExists()
+            onNodeWithText("warning after patch", substring = true).assertExists()
             onNodeWithText("formatter warning", substring = true).assertExists()
             onNodeWithText("exitCode:", substring = true).assertExists()
             // The row used to render the entire payload as one 4 KB line of text.


### PR DESCRIPTION
## Summary
- bound extracted unified diffs using declared hunk lengths so trailing diagnostics remain visible
- keep primitive edit/delete/move file paths parser-compatible and openable
- add domain, ACP mapper, and transcript UI regressions

## Test plan
- [x] `./gradlew desktopTest --tests 'app.andy.domain.UnifiedDiffTest' --tests 'app.andy.domain.ToolCallFileContentTest' --tests 'app.andy.desktop.service.agents.acp.AcpLaneTest' --tests 'app.andy.ui.agents.AgentTranscriptUiTest'`

Made with [Cursor](https://cursor.com)