### PR TITLE
Match connection stalls on whole RetriableError lines

### DIFF
--- a/src/commonMain/kotlin/app/andy/model/AgentConnectionRecovery.kt
+++ b/src/commonMain/kotlin/app/andy/model/AgentConnectionRecovery.kt
@@ -12,23 +12,49 @@ const val CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS = 1_000L
 /** Follow-up Andy sends when the user accepts a plan-mode turn and asks to implement. */
 const val IMPLEMENT_PLAN_PROMPT = "Implement the plan."
 
-private val RETRIABLE_CONNECTION_ERROR_PATTERNS = listOf(
-    Regex("""(?i)(?:error:\s*)?(?:retriableerror:\s*)?connection\s+stalled(?:\s+repeatedly)?"""),
-    Regex(
-        """(?i)(?:error:\s*)?(?:retriableerror:\s*)?(?:\[canceled\]\s*)?http/2\s+stream\s+closed""",
-    ),
+/**
+ * Cursor (and some other ACP adapters) surface a transport drop as a standalone
+ * `RetriableError` assistant/error line — not as an ACP stop reason. `cancelled` is also
+ * used for user stop, so text matching is the only reliable signal.
+ *
+ * Match a whole line with the `RetriableError:` prefix. Substring mentions, source quotes,
+ * and stream chunks like `" stalled"` must not count.
+ */
+private val RETRIABLE_STALL_LINE = Regex(
+    """(?i)^(?:error:\s*)?retriableerror:\s+(?:connection\s+stalled(?:\s+repeatedly)?|\[canceled\]\s+http/2\s+stream\s+closed(?:\b.*)?)\s*$""",
 )
 
-/** True when [text] is a Cursor/provider transport failure surfaced in chat output. */
-fun CharSequence.isRetriableConnectionStallMessage(): Boolean =
-    RETRIABLE_CONNECTION_ERROR_PATTERNS.any { it.containsMatchIn(this) }
+private fun CharSequence.nonEmptyLines(): List<String> =
+    lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.toList()
+
+/** True when [text] is only a provider stall error (blank lines allowed). */
+fun CharSequence.isRetriableConnectionStallMessage(): Boolean {
+    val lines = nonEmptyLines()
+    return lines.isNotEmpty() && lines.all { RETRIABLE_STALL_LINE.matches(it) }
+}
+
+/** True when the last non-empty line is a provider stall error. */
+fun CharSequence.hasRetriableConnectionStallError(): Boolean {
+    val last = nonEmptyLines().lastOrNull() ?: return false
+    return RETRIABLE_STALL_LINE.matches(last)
+}
+
+/** Drops a trailing stall error so partial output before the drop stays visible. */
+fun CharSequence.stripTrailingConnectionStallError(): String {
+    val lines = toString().split('\n')
+    val last = lines.indexOfLast { it.trim().isNotEmpty() }
+    if (last < 0 || !RETRIABLE_STALL_LINE.matches(lines[last].trim())) return toString()
+    var end = last
+    while (end > 0 && lines[end - 1].isBlank()) end--
+    return lines.take(end).joinToString("\n").trimEnd()
+}
 
 fun List<AgentEvent>.hasRetriableConnectionStall(): Boolean =
-    latestTurnEvents().any { event ->
+    coalesceAcpTranscriptEvents(latestTurnEvents()).any { event ->
         when (event) {
-            is AgentEvent.AssistantText -> event.text.isRetriableConnectionStallMessage()
-            is AgentEvent.TaskError -> event.message.isRetriableConnectionStallMessage()
-            is AgentEvent.ToolResult -> event.isError && event.detail.isRetriableConnectionStallMessage()
+            is AgentEvent.AssistantText -> event.text.hasRetriableConnectionStallError()
+            is AgentEvent.TaskError -> event.message.hasRetriableConnectionStallError()
+            is AgentEvent.ToolResult -> event.isError && event.detail.hasRetriableConnectionStallError()
             else -> false
         }
     }

--- a/src/commonMain/kotlin/app/andy/model/AgentConnectionRecovery.kt
+++ b/src/commonMain/kotlin/app/andy/model/AgentConnectionRecovery.kt
@@ -24,26 +24,32 @@ private val RETRIABLE_STALL_LINE = Regex(
     """(?i)^(?:error:\s*)?retriableerror:\s+(?:connection\s+stalled(?:\s+repeatedly)?|\[canceled\]\s+http/2\s+stream\s+closed(?:\b.*)?)\s*$""",
 )
 
-private fun CharSequence.nonEmptyLines(): List<String> =
-    lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.toList()
+private fun CharSequence.rawNonEmptyLines(): List<String> =
+    lineSequence().map { it.trimEnd() }.filter { it.isNotBlank() }.toList()
+
+/** Provider stall lines are flush-left. Indented or `>`-quoted examples are not. */
+private fun String.isProviderStallLine(): Boolean {
+    if (isEmpty()) return false
+    val first = first()
+    if (first == ' ' || first == '\t' || first == '>') return false
+    return RETRIABLE_STALL_LINE.matches(trim())
+}
 
 /** True when [text] is only a provider stall error (blank lines allowed). */
 fun CharSequence.isRetriableConnectionStallMessage(): Boolean {
-    val lines = nonEmptyLines()
-    return lines.isNotEmpty() && lines.all { RETRIABLE_STALL_LINE.matches(it) }
+    val lines = rawNonEmptyLines()
+    return lines.isNotEmpty() && lines.all { it.isProviderStallLine() }
 }
 
 /** True when the last non-empty line is a provider stall error. */
-fun CharSequence.hasRetriableConnectionStallError(): Boolean {
-    val last = nonEmptyLines().lastOrNull() ?: return false
-    return RETRIABLE_STALL_LINE.matches(last)
-}
+fun CharSequence.hasRetriableConnectionStallError(): Boolean =
+    rawNonEmptyLines().lastOrNull()?.isProviderStallLine() == true
 
 /** Drops a trailing stall error so partial output before the drop stays visible. */
 fun CharSequence.stripTrailingConnectionStallError(): String {
     val lines = toString().split('\n')
     val last = lines.indexOfLast { it.trim().isNotEmpty() }
-    if (last < 0 || !RETRIABLE_STALL_LINE.matches(lines[last].trim())) return toString()
+    if (last < 0 || !lines[last].trimEnd().isProviderStallLine()) return toString()
     var end = last
     while (end > 0 && lines[end - 1].isBlank()) end--
     return lines.take(end).joinToString("\n").trimEnd()

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -93,7 +93,7 @@ import app.andy.model.AgentToolImage
 import app.andy.model.AgentToolKind
 import app.andy.model.AgentToolState
 import app.andy.model.isRetriableConnectionStallMessage
-import app.andy.model.shouldShowConnectionStallBanner
+import app.andy.model.stripTrailingConnectionStallError
 import app.andy.model.stripDecisionCheckpointMarkup
 import app.andy.model.AgentSkill
 import app.andy.model.coalesceAcpTranscriptEvents
@@ -542,10 +542,20 @@ private fun LazyListState.firstVisibleAnchorKey(): String? = layoutInfo.visibleI
  */
 internal fun transcriptDisplayEvents(events: List<AgentEvent>): List<AgentEvent> {
     val coalesced = coalesceAcpTranscriptEvents(events)
-    val displayable = coalesced.filterNot { event ->
-        event is AgentEvent.AvailableCommands ||
-            event is AgentEvent.Raw ||
-            event.isHiddenConnectionStallMessage()
+    val displayable = coalesced.mapNotNull { event ->
+        when {
+            event is AgentEvent.AvailableCommands || event is AgentEvent.Raw -> null
+            event is AgentEvent.AssistantText -> {
+                val stripped = event.text.stripTrailingConnectionStallError()
+                when {
+                    stripped.isBlank() -> null
+                    stripped == event.text -> event
+                    else -> event.copy(text = stripped)
+                }
+            }
+            event.isHiddenConnectionStallMessage() -> null
+            else -> event
+        }
     }
     return displayable.filterIndexed { index, event ->
         val completion = displayable.getOrNull(index + 1) as? AgentEvent.TaskResult
@@ -634,7 +644,9 @@ private fun TranscriptEvent(
     when (event) {
         is AgentEvent.SessionStarted -> Unit
         is AgentEvent.AssistantText -> {
-            val visibleText = stripDecisionCheckpointMarkup(event.text)
+            val visibleText = stripDecisionCheckpointMarkup(
+                event.text.stripTrailingConnectionStallError(),
+            )
             if (visibleText.isBlank() || visibleText.isRetriableConnectionStallMessage()) return
             AgentResponse {
                 ChatMarkdown(visibleText, lineHeight = 21.sp)

--- a/src/commonTest/kotlin/app/andy/model/AgentConnectionRecoveryTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AgentConnectionRecoveryTest.kt
@@ -50,6 +50,21 @@ class AgentConnectionRecoveryTest {
             The regex matches connection stalled as a substring, which is the bug.
             """.trimIndent().hasRetriableConnectionStallError(),
         )
+        assertFalse(
+            """
+            The error looks like:
+                Error: RetriableError: Connection stalled
+            """.trimIndent().hasRetriableConnectionStallError(),
+        )
+        assertFalse(
+            "Here is the quoted form:\n> Error: RetriableError: Connection stalled"
+                .hasRetriableConnectionStallError(),
+        )
+        val indentedQuote = """
+            The error looks like:
+                Error: RetriableError: Connection stalled
+        """.trimIndent()
+        assertEquals(indentedQuote, indentedQuote.stripTrailingConnectionStallError())
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/model/AgentConnectionRecoveryTest.kt
+++ b/src/commonTest/kotlin/app/andy/model/AgentConnectionRecoveryTest.kt
@@ -17,7 +17,9 @@ class AgentConnectionRecoveryTest {
     fun detectsCursorProviderStallMessages() {
         assertTrue("Error: RetriableError: Connection stalled".isRetriableConnectionStallMessage())
         assertTrue("RetriableError: Connection stalled repeatedly".isRetriableConnectionStallMessage())
-        assertTrue("connection stalled".isRetriableConnectionStallMessage())
+        assertTrue(
+            "\n\nError: RetriableError: Connection stalled\n".isRetriableConnectionStallMessage(),
+        )
         assertTrue(
             "Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)"
                 .isRetriableConnectionStallMessage(),
@@ -29,9 +31,33 @@ class AgentConnectionRecoveryTest {
     }
 
     @Test
-    fun ignoresUnrelatedErrors() {
+    fun ignoresMentionsAndUnrelatedErrors() {
+        assertFalse("connection stalled".isRetriableConnectionStallMessage())
+        assertFalse("http/2 stream closed".isRetriableConnectionStallMessage())
+        assertFalse(" stalled".isRetriableConnectionStallMessage())
+        assertFalse(
+            "connection stalled is a known, named failure mode".isRetriableConnectionStallMessage(),
+        )
+        assertFalse(
+            "If you see literal `connection stalled` or `http/2 stream closed`, that's the provider"
+                .isRetriableConnectionStallMessage(),
+        )
         assertFalse("Error: ENOENT: no such file".isRetriableConnectionStallMessage())
         assertFalse("ACP prompt failed".isRetriableConnectionStallMessage())
+        assertFalse(
+            """
+            Andy auto-retries by sending Continue where you left off.
+            The regex matches connection stalled as a substring, which is the bug.
+            """.trimIndent().hasRetriableConnectionStallError(),
+        )
+    }
+
+    @Test
+    fun trailingStallLineCountsAsTransportDrop() {
+        val partial = "Here is the patch.\n\nError: RetriableError: Connection stalled"
+        assertFalse(partial.isRetriableConnectionStallMessage())
+        assertTrue(partial.hasRetriableConnectionStallError())
+        assertEquals("Here is the patch.", partial.stripTrailingConnectionStallError())
     }
 
     @Test
@@ -43,6 +69,32 @@ class AgentConnectionRecoveryTest {
         assertTrue(events.hasRetriableConnectionStall())
         assertTrue(shouldShowConnectionStallBanner(events, isActive = false))
         assertFalse(shouldShowConnectionStallBanner(events, isActive = true))
+    }
+
+    @Test
+    fun coalescesStreamDeltasBeforeDetectingStalls() {
+        val events = listOf(
+            AgentEvent.AssistantText(1, "Error: RetriableError: ", isStreamDelta = true),
+            AgentEvent.AssistantText(2, "Connection stalled", isStreamDelta = true),
+        )
+        assertTrue(events.hasRetriableConnectionStall())
+        assertFalse(
+            listOf(AgentEvent.AssistantText(1, " stalled", isStreamDelta = true))
+                .hasRetriableConnectionStall(),
+        )
+    }
+
+    @Test
+    fun mentionsInAssistantTextDoNotCountAsStalls() {
+        val events = listOf(
+            AgentEvent.UserMessage(1, "why am I getting connection stalled situations?"),
+            AgentEvent.AssistantText(
+                2,
+                "connection stalled is a known failure mode. Andy matches `http/2 stream closed`.",
+            ),
+        )
+        assertFalse(events.hasRetriableConnectionStall())
+        assertFalse(shouldShowConnectionStallBanner(events, isActive = false))
     }
 
     @Test

--- a/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
+++ b/src/commonTest/kotlin/app/andy/ui/agents/AgentTranscriptTest.kt
@@ -620,6 +620,34 @@ class AgentTranscriptTest {
     }
 
     @Test
+    fun stallMentionsStayVisibleInTranscriptDisplay() {
+        val events = listOf(
+            AgentEvent.AssistantText(
+                atMillis = 1,
+                text = "connection stalled is a known failure mode, including `http/2 stream closed`.",
+            ),
+        )
+
+        val displayed = transcriptDisplayEvents(events)
+        assertEquals(1, displayed.size)
+        assertEquals(events.single(), displayed.single())
+    }
+
+    @Test
+    fun trailingStallLineIsStrippedButPriorOutputStays() {
+        val events = listOf(
+            AgentEvent.AssistantText(
+                atMillis = 1,
+                text = "Here is the patch.\n\nError: RetriableError: Connection stalled",
+            ),
+        )
+
+        val displayed = transcriptDisplayEvents(events)
+        val text = displayed.single() as AgentEvent.AssistantText
+        assertEquals("Here is the patch.", text.text)
+    }
+
+    @Test
     fun http2CancelErrorsAreHiddenFromTranscriptDisplay() {
         val events = listOf(
             AgentEvent.ToolCall(atMillis = 1, toolName = "read", summary = "gradle"),

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -2564,7 +2564,8 @@ class DesktopAgentRunService(
                 else -> outcome.error ?: "ACP prompt failed"
             },
             resumable = acpManager.isAlive(taskId) && (recovered || resumableAfterStall),
-            statusConfident = true,
+            // A stall is not a finished turn. Confident Done/Error is what dings.
+            statusConfident = !stillStalled,
             stopReason = outcome.stopReason,
         )
         return recovered || resumableAfterStall

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpSession.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpSession.kt
@@ -211,7 +211,9 @@ class AcpSession(
                     is Event.PromptResponseEvent -> {
                         stopReason = event.response.stopReason.name.lowercase()
                         lastStopReason = stopReason
-                        onStatus(AcpStatusModel.fromStopReason(stopReason))
+                        // Do not publish Done here. The run service decides after it inspects
+                        // the transcript for a real RetriableError stall — otherwise a mention
+                        // or a dropped stream both ding as a finished turn before retry.
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Stall recovery now matches whole `RetriableError:` provider error lines after coalescing stream chunks, instead of substring hits like `connection stalled`.
- Mentions and source quotes no longer hide the reply, auto-retry, or ding. A real trailing stall line is stripped so partial output stays visible.
- ACP no longer publishes confident Done at prompt-stop; a stall is not a finished turn.

## Test plan
- [ ] `./gradlew desktopTest --tests 'app.andy.model.AgentConnectionRecoveryTest' --tests 'app.andy.ui.agents.AgentTranscriptTest'`
- [ ] In an ACP chat, mention "connection stalled" / `http/2 stream closed` and confirm no banner, retry, or ding
- [ ] Confirm a real `Error: RetriableError: Connection stalled` (or http/2 cancel) still shows the stall banner and retry


Made with [Cursor](https://cursor.com)