### PR TITLE
Scope agent change summaries to files the task actually edited

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ developers. Use it to manage devices and emulators, manage projects with AI, mir
 apps, and drive day-to-day mobile workflows from one place. The desktop app is
 the recommended experience and includes the full feature set. A smaller subset
 of Andy is also available on the web at
-[andy.joetr.com](https://www.andy.joetr.com).
+[andy.joetr.com](https://andy.joetr.com).
 
 **Basic iOS Simulator support** is available on macOS: discover simulators,
 boot and shut them down, open Simulator.app, and stream a live mirror with
@@ -165,7 +165,7 @@ Browse the host filesystem from multi-root folders, open files in a syntax-theme
 
 ### Andy for web
 
-The browser build at [andy.joetr.com](https://www.andy.joetr.com) provides a
+The browser build at [andy.joetr.com](https://andy.joetr.com) provides a
 smaller subset of Andy's functionality. For the complete experience, use the
 desktop app. The browser build can connect directly with WebUSB or through
 Andy's pinned tracebox distribution. The bridge keeps ADB on loopback and
@@ -316,6 +316,20 @@ PR CI runs `./gradlew desktopTest` on Linux/macOS/Windows, plus macOS-only
 `verifyRoborazziDesktop`. Opt-in suites that need a device, Simulator, or live
 agent CLI — and how to run them locally — are documented in
 [docs/TESTS.md](docs/TESTS.md).
+
+## Building from source
+
+`./gradlew run` and `./gradlew runDistributable` compile Andy's native terminal
+engine with Cargo, so **Rust** (stable) must be installed and on your `PATH`.
+Java 21+ is also required.
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+./gradlew run
+```
+
+Open a new terminal after install if `cargo` is still not found.
 
 ## Runtime Requirements
 

--- a/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreen.kt
+++ b/src/commonMain/kotlin/app/andy/ui/devices/DevicesScreen.kt
@@ -644,11 +644,16 @@ private fun AndroidDevicesTab(
         }
         if (allowWifiPairing && disconnectedPairedWifi.isNotEmpty()) {
             item {
-                PanelCard {
-                    Text("Wireless devices", color = TextPrimary, fontWeight = FontWeight.Bold)
-                    if (state.wifiStatus.isNotBlank()) {
-                        Text(state.wifiStatus, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
-                    }
+                Text(
+                    "Wireless devices",
+                    color = TextPrimary,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+            if (state.wifiStatus.isNotBlank()) {
+                item {
+                    Text(state.wifiStatus, color = TextSecondary, fontFamily = FontFamily.Monospace, fontSize = 12.sp)
                 }
             }
             items(disconnectedPairedWifi, key = { it.id }) { paired ->

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -24,6 +24,7 @@ import app.andy.model.AgentSkill
 import app.andy.model.AgentSlashCommand
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskDraft
+import app.andy.model.AgentToolKind
 import app.andy.model.WorktreeBaseOption
 import app.andy.model.WorktreeDeleteOutcome
 import app.andy.model.WorktreeMergeOutcome
@@ -3141,17 +3142,35 @@ class DesktopAgentRunService(
 
     override suspend fun changeSummary(taskId: String): AgentChangeSummary? = withContext(Dispatchers.IO) {
         val task = currentTask(taskId) ?: return@withContext null
-        task.completedChanges?.let { return@withContext it.summary }
         val baseline = task.changeBaselineTree ?: return@withContext null
         val cwd = task.cwd ?: return@withContext null
-        worktrees.changeSummary(cwd, baseline)
+        worktrees.changeSummary(cwd, baseline, touchedPaths(taskId, cwd).takeIf { it.isNotEmpty() })
     }
 
     override suspend fun fileDiff(taskId: String, relativePath: String): AgentFileDiff? = withContext(Dispatchers.IO) {
         val task = currentTask(taskId) ?: return@withContext null
-        task.completedChanges?.diffs?.get(relativePath)?.let { return@withContext it }
         val cwd = task.cwd ?: return@withContext null
         worktrees.fileDiff(cwd, relativePath, task.changeBaselineTree)
+    }
+
+    /**
+     * Repo-relative paths this task's own tool calls edited/deleted/moved, per its transcript —
+     * used to scope [changeSummary] to the agent's actual work instead of the whole working tree.
+     * Empty when the task has no structured tool-call locations yet (e.g. the Terminal lane),
+     * in which case the caller falls back to a whole-directory diff.
+     */
+    private fun touchedPaths(taskId: String, cwd: String): Set<String> {
+        val root = runCatching { File(cwd).canonicalFile }.getOrNull() ?: return emptySet()
+        return loadAcpEventsForDisplay(taskId)
+            .filterIsInstance<AgentEvent.ToolCall>()
+            .filter { it.kind == AgentToolKind.Edit || it.kind == AgentToolKind.Delete || it.kind == AgentToolKind.Move }
+            .flatMap { it.locations }
+            .mapNotNullTo(mutableSetOf()) { location ->
+                val file = File(location).let { if (it.isAbsolute) it else File(root, location) }
+                val canonical = runCatching { file.canonicalFile }.getOrNull() ?: return@mapNotNullTo null
+                val relative = runCatching { canonical.relativeTo(root) }.getOrNull() ?: return@mapNotNullTo null
+                relative.path.takeUnless { it.startsWith("..") }
+            }
     }
 
     override suspend fun refreshCliStatuses() {

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -3169,7 +3169,7 @@ class DesktopAgentRunService(
                 val file = File(location).let { if (it.isAbsolute) it else File(root, location) }
                 val canonical = runCatching { file.canonicalFile }.getOrNull() ?: return@mapNotNullTo null
                 val relative = runCatching { canonical.relativeTo(root) }.getOrNull() ?: return@mapNotNullTo null
-                relative.path.takeUnless { it.startsWith("..") }
+                relative.invariantSeparatorsPath.takeUnless { it.startsWith("..") }
             }
     }
 
@@ -5007,7 +5007,7 @@ class DesktopAgentRunService(
         val completedChanges = currentTask(taskId)?.let { task ->
             val baseline = task.changeBaselineTree
             task.cwd?.takeIf { baseline != null }?.let { cwd ->
-                worktrees.changeSnapshot(cwd, baseline)
+                worktrees.changeSnapshot(cwd, baseline, touchedPaths(taskId, cwd).takeIf { it.isNotEmpty() })
             }
         }
         updateTask(taskId) { task ->

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/WorktreeManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/WorktreeManager.kt
@@ -185,9 +185,16 @@ class WorktreeManager(
         return AgentChangeSummary(changes)
     }
 
-    /** Captures a task's completed change set before later work in the repository can alter it. */
-    fun changeSnapshot(dir: String, baselineTree: String?): AgentThreadChangeSnapshot? {
-        val summary = changeSummary(dir, baselineTree) ?: return null
+    /**
+     * Captures a task's completed change set before later work in the repository can alter it.
+     * [paths] is forwarded to [changeSummary] so the frozen snapshot matches the live scoped view.
+     */
+    fun changeSnapshot(
+        dir: String,
+        baselineTree: String?,
+        paths: Collection<String>? = null,
+    ): AgentThreadChangeSnapshot? {
+        val summary = changeSummary(dir, baselineTree, paths) ?: return null
         val diffs = summary.files.associate { change ->
             change.path to (fileDiff(dir, change.path, baselineTree) ?: AgentFileDiff(path = change.path, lines = emptyList()))
         }

--- a/src/desktopMain/kotlin/app/andy/desktop/service/agents/WorktreeManager.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/agents/WorktreeManager.kt
@@ -155,11 +155,23 @@ class WorktreeManager(
         return snapshotTree(dir)
     }
 
-    fun changeSummary(dir: String, baselineTree: String?): AgentChangeSummary? {
+    /**
+     * [paths], when non-null, restricts the diff to those repo-relative paths (e.g. the files an
+     * agent's tool calls actually touched) so unrelated changes elsewhere in the working directory
+     * — from another concurrent task, a build step, a manual edit — aren't attributed to this task.
+     * A non-null empty collection short-circuits to "no changes" without shelling out to git.
+     */
+    fun changeSummary(dir: String, baselineTree: String?, paths: Collection<String>? = null): AgentChangeSummary? {
         if (!isGitRepo(dir) || baselineTree == null) return null
+        if (paths != null && paths.isEmpty()) return AgentChangeSummary(emptyList())
         val currentTree = snapshotTree(dir) ?: return null
         if (currentTree == baselineTree) return AgentChangeSummary(emptyList())
-        val numstat = git(dir, "diff", "--numstat", "--no-renames", baselineTree, currentTree)
+        val args = mutableListOf("diff", "--numstat", "--no-renames", baselineTree, currentTree)
+        if (paths != null) {
+            args += "--"
+            args += paths
+        }
+        val numstat = git(dir, args, emptyMap())
         if (numstat.exitCode != 0) return null
         val changes = numstat.output.lineSequence().mapNotNull { line ->
             val fields = line.split('\t', limit = 3)

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/WorktreeManagerTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/WorktreeManagerTest.kt
@@ -325,6 +325,12 @@ class WorktreeManagerTest {
 
             val unscoped = assertNotNull(manager.changeSummary(repo.absolutePath, baseline))
             assertEquals(listOf("other.kt", "touched.kt", "unrelated.kt"), unscoped.files.map { it.path })
+
+            val scopedSnapshot = assertNotNull(
+                manager.changeSnapshot(repo.absolutePath, baseline, listOf("touched.kt")),
+            )
+            assertEquals(listOf("touched.kt"), scopedSnapshot.summary.files.map { it.path })
+            assertEquals(setOf("touched.kt"), scopedSnapshot.diffs.keys)
         } finally {
             repo.deleteRecursively()
         }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/agents/WorktreeManagerTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/agents/WorktreeManagerTest.kt
@@ -294,6 +294,42 @@ class WorktreeManagerTest {
         }
     }
 
+    @Test
+    fun changeSummaryRestrictsToProvidedPaths() {
+        val repo = File.createTempFile("andy-change-summary-paths", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        try {
+            git(repo, "init")
+            git(repo, "config", "user.email", "andy@example.test")
+            git(repo, "config", "user.name", "Andy Test")
+            File(repo, "touched.kt").writeText("one\n")
+            File(repo, "other.kt").writeText("one\n")
+            git(repo, "add", ".")
+            git(repo, "commit", "-m", "initial")
+            val manager = WorktreeManager(File(repo, "worktrees"))
+            val baseline = assertNotNull(manager.captureChangeBaseline(repo.absolutePath))
+
+            File(repo, "touched.kt").writeText("one\ntwo\n")
+            File(repo, "other.kt").writeText("one\ntwo\n")
+            File(repo, "unrelated.kt").writeText("new\n")
+
+            val scoped = assertNotNull(
+                manager.changeSummary(repo.absolutePath, baseline, listOf("touched.kt")),
+            )
+            assertEquals(listOf("touched.kt"), scoped.files.map { it.path })
+
+            val empty = assertNotNull(manager.changeSummary(repo.absolutePath, baseline, emptyList()))
+            assertTrue(empty.files.isEmpty())
+
+            val unscoped = assertNotNull(manager.changeSummary(repo.absolutePath, baseline))
+            assertEquals(listOf("other.kt", "touched.kt", "unrelated.kt"), unscoped.files.map { it.path })
+        } finally {
+            repo.deleteRecursively()
+        }
+    }
+
     private fun git(dir: File, vararg args: String) {
         val process = ProcessBuilder(listOf("git", "-C", dir.absolutePath) + args)
             .redirectErrorStream(true)


### PR DESCRIPTION
## Summary
- Agent task change summaries now restrict `git diff` to paths the task's own edit/delete/move tool calls touched, so concurrent work, builds, or manual edits elsewhere in the working tree are not attributed to that chat. Tasks without structured tool locations (e.g. Terminal) still fall back to a whole-directory diff.
- Wireless devices on the Devices screen use a plain section header instead of a wrapping card.
- README documents Rust as a `./gradlew run` requirement and points web links at `andy.joetr.com` (no `www`).

## Test plan
- [x] `./gradlew desktopTest --tests 'app.andy.desktop.service.agents.WorktreeManagerTest'`
- [ ] Confirm a chat that edits a few files does not list unrelated dirty files in the change summary
- [ ] Confirm Terminal-lane tasks still show a whole-directory summary
- [ ] Confirm wireless-paired devices still list under the un-carded header
- [ ] Confirm README build-from-source steps match a fresh machine with Rust + Java 21


Made with [Cursor](https://cursor.com)