### PR TITLE
Start project action terminals off the UI thread with a spinner

### DIFF
--- a/src/commonMain/kotlin/app/andy/model/ActionModels.kt
+++ b/src/commonMain/kotlin/app/andy/model/ActionModels.kt
@@ -35,7 +35,7 @@ data class ActionsConfig(
     val projects: List<ActionProject> = emptyList(),
 )
 
-enum class ActionRunStatus { Running, Exited, Failed, Stopped }
+enum class ActionRunStatus { Starting, Running, Exited, Failed, Stopped }
 
 data class RunningAction(
     val runId: String,

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentDiffViewer.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentDiffViewer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -108,6 +109,7 @@ internal fun AgentFileDiffViewer(
     onViewModeChange: (DiffViewMode) -> Unit,
     onCollapse: () -> Unit,
     showCollapseControl: Boolean = true,
+    showPath: Boolean = true,
     maxHeight: androidx.compose.ui.unit.Dp? = 420.dp,
     modifier: Modifier = Modifier,
 ) {
@@ -134,16 +136,20 @@ internal fun AgentFileDiffViewer(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text(
-                diff.path,
-                color = TextPrimary,
-                fontFamily = MonoFont,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 11.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
+            if (showPath) {
+                Text(
+                    diff.path,
+                    color = TextPrimary,
+                    fontFamily = MonoFont,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            } else {
+                Spacer(Modifier.weight(1f))
+            }
             FilterPill("unified", viewMode == DiffViewMode.Unified, Cyan) {
                 onViewModeChange(DiffViewMode.Unified)
             }

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -122,6 +122,7 @@ import app.andy.ui.components.FilterPill
 import app.andy.service.OpenInvestigationRequest
 import app.andy.ui.components.OutlinedButton
 import app.andy.ui.components.PanelCard
+import app.andy.ui.components.PaneDivider
 import app.andy.ui.shell.LocalOpenInvestigation
 import app.andy.ui.components.StatusTag
 import app.andy.ui.components.FieldChromeStyle
@@ -191,6 +192,7 @@ internal fun AgentTaskDetail(
     var diffViewMode by remember(task.id) { mutableStateOf(DiffViewMode.Unified) }
     var toolDiffPane by remember(task.id) { mutableStateOf<AgentFileDiff?>(null) }
     var filePreviewPane by remember(task.id) { mutableStateOf<FileLinkPreviewState?>(null) }
+    var toolSidePaneWidth by remember(task.id) { mutableStateOf(420f) }
     val fileLinkRoots = remember(task.worktreePath, task.cwd, task.originDir) {
         listOfNotNull(task.worktreePath, task.cwd, task.originDir).distinct()
     }
@@ -567,7 +569,7 @@ internal fun AgentTaskDetail(
                 val pendingPermissionId = task.userInputRequest
                     ?.takeIf { it.origin == AgentUserInputOrigin.AcpPermission }
                     ?.id
-                Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(Modifier.fillMaxSize()) {
                     AgentTranscript(
                         events = transcriptEvents,
                         isActive = task.isActive,
@@ -615,13 +617,20 @@ internal fun AgentTaskDetail(
                         currentTaskId = task.id,
                         modifier = Modifier.weight(1f).fillMaxHeight(),
                     )
+                    if (filePreviewPane != null || toolDiffPane != null) {
+                        PaneDivider(
+                            onDrag = { dragX ->
+                                toolSidePaneWidth = (toolSidePaneWidth - dragX).coerceIn(280f, 900f)
+                            },
+                        )
+                    }
                     filePreviewPane?.let { preview ->
                         FileLinkPreviewPane(
                             state = preview,
                             onTextChange = { _, text -> filePreviewPane = filePreviewPane?.copy(draft = text) },
                             onSave = ::saveFilePreview,
                             onClose = { filePreviewPane = null },
-                            modifier = Modifier.width(420.dp).fillMaxHeight(),
+                            modifier = Modifier.width(toolSidePaneWidth.dp).fillMaxHeight(),
                         )
                     } ?: toolDiffPane?.let { diff ->
                         AgentToolDiffSidePane(
@@ -629,7 +638,7 @@ internal fun AgentTaskDetail(
                             viewMode = diffViewMode,
                             onViewModeChange = { diffViewMode = it },
                             onClose = { toolDiffPane = null },
-                            modifier = Modifier.width(420.dp).fillMaxHeight(),
+                            modifier = Modifier.width(toolSidePaneWidth.dp).fillMaxHeight(),
                         )
                     }
                 }

--- a/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -1670,6 +1670,7 @@ private fun ToolCallDiff(diff: AgentFileDiff, modifier: Modifier = Modifier) {
         onViewModeChange = { viewMode = it },
         onCollapse = {},
         showCollapseControl = false,
+        showPath = false,
         maxHeight = 220.dp,
         modifier = modifier.fillMaxWidth(),
     )

--- a/src/commonMain/kotlin/app/andy/ui/components/Tabs.kt
+++ b/src/commonMain/kotlin/app/andy/ui/components/Tabs.kt
@@ -37,9 +37,11 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.andy.ui.theme.AndyShape
@@ -168,7 +170,7 @@ internal fun TabBarItem(
     val interactionSource = remember { MutableInteractionSource() }
     val hovered by interactionSource.collectIsHoveredAsState()
     var editing by remember { mutableStateOf(false) }
-    var draft by remember(label) { mutableStateOf(label) }
+    var draft by remember(label) { mutableStateOf(TextFieldValue(label)) }
     var editorHadFocus by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
     val textColor = when {
@@ -178,9 +180,9 @@ internal fun TabBarItem(
     }
     fun finishEditing() {
         if (!editing) return
-        val updated = draft.trim()
+        val updated = draft.text.trim()
         if (updated.isNotEmpty() && updated != label) onRename?.invoke(updated)
-        draft = updated.ifEmpty { label }
+        draft = TextFieldValue(updated.ifEmpty { label })
         editing = false
         editorHadFocus = false
     }
@@ -196,7 +198,7 @@ internal fun TabBarItem(
                 onClick = onClick,
                 onLongClick = onRename?.let {
                     {
-                        draft = label
+                        draft = TextFieldValue(text = label, selection = TextRange(label.length))
                         editing = true
                     }
                 },

--- a/src/commonMain/kotlin/app/andy/ui/shell/ShellDocks.kt
+++ b/src/commonMain/kotlin/app/andy/ui/shell/ShellDocks.kt
@@ -76,9 +76,13 @@ import app.andy.ui.theme.Red
 import app.andy.ui.theme.Rust
 import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
+import app.andy.ui.theme.Yellow
 
 /** Where an auxiliary surface docks relative to the main workspace. */
 internal enum class DockPlacement { Right, Bottom }
+
+/** Breathing room under dock content so the card's rounded bottom never clips it. */
+private val DockContentCornerInset = AndySpace.Space2
 private enum class PaneToggleEdge { Left, Right, Bottom }
 
 /** Kind of surface shown inside a dock tab. */
@@ -460,16 +464,24 @@ internal fun ShellDockDrawer(
     val terminalBackground = remember(terminalThemeId) {
         Color(TerminalThemePreset.fromId(terminalThemeId).palette().background)
     }
-    // Pad the tab strip only. Content is flush to the card bottom so the right/bottom
-    // dock shares a baseline with the project composer (PanelCard's default 20dp bottom
-    // padding was leaving a visible shelf under Live).
+    // Live has no theme of its own to borrow, so the strip drops to the canvas the dock sits
+    // on — the pane then reads as the device surface floating on the shell, not as chrome.
+    val liveHeader = active?.kind == DockTabKind.Live
+    val headerBackground = when {
+        terminalHeader -> terminalBackground
+        liveHeader -> AndyColors.ContentBg
+        else -> AndyColors.SurfaceRaised
+    }
+    // Pad the tab strip only; the content below manages its own insets so Live/Terminal can
+    // bleed to the card's side edges (PanelCard's default 20dp padding was leaving a visible
+    // shelf under Live).
     PanelCard(
         modifier.graphicsLayer {
             alpha = 0.72f + reveal.value * 0.28f
             if (placement == DockPlacement.Right) translationX = (1f - reveal.value) * 28f
             else translationY = (1f - reveal.value) * 28f
         },
-        background = if (terminalHeader) terminalBackground else AndyColors.SurfaceRaised,
+        background = headerBackground,
         borderColor = Color.Transparent,
         contentPadding = PaddingValues(0.dp),
         verticalArrangement = Arrangement.Top,
@@ -491,7 +503,7 @@ internal fun ShellDockDrawer(
                         DockChromeButton(
                             glyph = "+",
                             label = "Add pane tab",
-                            onTerminalSurface = terminalHeader,
+                            onBleedSurface = terminalHeader || liveHeader,
                             onClick = {
                                 if (!addMenuExpanded) {
                                     HeavyweightOverlayRegistry.push()
@@ -511,7 +523,7 @@ internal fun ShellDockDrawer(
                     DockChromeButton(
                         glyph = "×",
                         label = if (placement == DockPlacement.Right) "Close right pane" else "Close bottom pane",
-                        onTerminalSurface = terminalHeader,
+                        onBleedSurface = terminalHeader || liveHeader,
                         onClick = onClose,
                     )
                 }
@@ -583,10 +595,18 @@ internal fun ShellDockDrawer(
             Modifier
                 .weight(1f)
                 .fillMaxWidth()
+                // Terminal owns its theme color, so carry it under the corner inset too —
+                // otherwise the strip below the last text row exposes the chrome surface.
+                .then(
+                    if (active?.kind == DockTabKind.Terminal) Modifier.background(terminalBackground)
+                    else Modifier,
+                )
                 .padding(
                     start = if (edgeToEdge) 0.dp else AndySpace.Space5,
                     end = if (edgeToEdge) 0.dp else AndySpace.Space5,
                     top = if (edgeToEdge) 0.dp else AndySpace.Space4,
+                    // Keeps the last row clear of the card's rounded bottom corners.
+                    bottom = DockContentCornerInset,
                 ),
         ) {
             when (active?.kind) {
@@ -642,12 +662,18 @@ private fun DockChromeButton(
     glyph: String,
     label: String,
     onClick: () -> Unit,
-    onTerminalSurface: Boolean = false,
+    onBleedSurface: Boolean = false,
 ) {
-    // Over a terminal-tinted header the neutral chrome fill would read as a patch of a
-    // different theme, so lift the button off the terminal color instead of replacing it.
-    val fill = if (onTerminalSurface) Color.White.copy(alpha = 0.06f) else AndyColors.Neutral850
-    val stroke = if (onTerminalSurface) Color.White.copy(alpha = 0.12f) else Border
+    // On a header that has taken on the terminal theme or the shell canvas, the neutral chrome
+    // fill either reads as a patch of a different theme or vanishes into the background, so lift
+    // the button off whatever it sits on instead of replacing the color.
+    val lifted = onBleedSurface && !AndyColors.isLight
+    val fill = when {
+        lifted -> Color.White.copy(alpha = 0.06f)
+        onBleedSurface -> AndyColors.SurfaceRaised
+        else -> AndyColors.Neutral850
+    }
+    val stroke = if (lifted) Color.White.copy(alpha = 0.12f) else Border
     Box(
         Modifier
             .size(28.dp)
@@ -679,6 +705,7 @@ private fun dockTerminalTabLabel(
 }
 
 private fun dockActionStatusColor(status: ActionRunStatus?): Color = when (status) {
+    ActionRunStatus.Starting -> Yellow
     ActionRunStatus.Running -> Green
     ActionRunStatus.Exited -> Cyan
     ActionRunStatus.Failed -> Red

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -22,9 +22,26 @@ import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
+/** Creates (and starts) a run's PTY backend. Injectable so tests can gate spawn timing. */
+internal typealias SpawnSession =
+    (runId: String, argv: List<String>, cwd: String, env: Map<String, String>) -> RustTerminalBackend
+
 class DesktopActionRunService(
     private val scope: CoroutineScope,
     private val terminalAppearance: () -> TerminalAppearanceSnapshot = { TerminalAppearanceSnapshot() },
+    internal val spawnSession: SpawnSession = { runId, argv, cwd, env ->
+        val session = TerminalSessions.create(
+            TerminalLaunchRequest(
+                sessionId = runId,
+                argv = argv,
+                cwd = cwd,
+                env = env,
+                appearance = terminalAppearance(),
+            ),
+        )
+        session as? RustTerminalBackend
+            ?: error("terminal view missing after start: ${session::class.simpleName}")
+    },
 ) : ActionRunService {
     private data class RunHandle(
         val session: TerminalSession?,
@@ -33,6 +50,11 @@ class DesktopActionRunService(
 
     private val nextRun = AtomicInteger(1)
     private val handles = ConcurrentHashMap<String, RunHandle>()
+
+    // Serializes the spawn handshake (status check + handle registration) against stop()/clear(),
+    // so a run cancelled while its PTY is still spawning never publishes a live backend afterwards.
+    private val lifecycleLock = Any()
+
     private val _running = MutableStateFlow<List<RunningAction>>(emptyList())
     override val running: StateFlow<List<RunningAction>> = _running
 
@@ -88,37 +110,33 @@ class DesktopActionRunService(
                 val environment = buildTerminalLaunchEnvironment(
                     project.env + action.env,
                 )
-                val session = TerminalSessions.create(
-                    TerminalLaunchRequest(
-                        sessionId = runId,
-                        argv = command,
-                        cwd = cwd,
-                        env = environment,
-                        appearance = terminalAppearance(),
-                    ),
-                )
-                session as? RustTerminalBackend
-                    ?: error("terminal view missing after start: ${session::class.simpleName}")
+                spawnSession(runId, command, cwd, environment)
             }.fold(
                 onSuccess = { rustTerminal ->
-                    val stillStarting = _running.value
-                        .firstOrNull { it.runId == runId }
-                        ?.status == ActionRunStatus.Starting
-                    if (!stillStarting) {
+                    val registered = synchronized(lifecycleLock) {
+                        val stillStarting = _running.value
+                            .firstOrNull { it.runId == runId }
+                            ?.status == ActionRunStatus.Starting
+                        if (!stillStarting) {
+                            false
+                        } else {
+                            handles[runId] = RunHandle(rustTerminal, rustTerminal)
+                            _running.update { runs ->
+                                runs.map { run ->
+                                    if (run.runId == runId && run.status == ActionRunStatus.Starting) {
+                                        run.copy(status = ActionRunStatus.Running)
+                                    } else {
+                                        run
+                                    }
+                                }
+                            }
+                            true
+                        }
+                    }
+                    if (!registered) {
                         // Tab was closed/stopped while the PTY was still spawning; don't orphan it.
                         runCatching { rustTerminal.close() }
                         return@launch
-                    }
-                    val handle = RunHandle(rustTerminal, rustTerminal)
-                    handles[runId] = handle
-                    _running.update { runs ->
-                        runs.map { run ->
-                            if (run.runId == runId && run.status == ActionRunStatus.Starting) {
-                                run.copy(status = ActionRunStatus.Running)
-                            } else {
-                                run
-                            }
-                        }
                     }
                     initialCommand?.let { command ->
                         runCatching { rustTerminal.writeText("$command\r") }
@@ -134,7 +152,13 @@ class DesktopActionRunService(
                 },
                 onFailure = {
                     markComplete(runId, ActionRunStatus.Failed, null)
-                    handles[runId] = RunHandle(null, null)
+                    synchronized(lifecycleLock) {
+                        // Publish a tombstone only if the run wasn't already cleared, so a
+                        // cancelled run doesn't leak a stale map entry.
+                        if (_running.value.any { it.runId == runId }) {
+                            handles[runId] = RunHandle(null, null)
+                        }
+                    }
                 },
             )
         }
@@ -142,25 +166,32 @@ class DesktopActionRunService(
     }
 
     override fun stop(runId: String) {
-        val handle = handles[runId]
-        if (handle == null) {
-            // PTY may still be spawning; marking it Stopped now makes start() close it
-            // instead of registering a handle once the spawn finishes.
-            markComplete(runId, ActionRunStatus.Stopped, null)
-            return
+        val handle = synchronized(lifecycleLock) {
+            val handle = handles[runId]
+            if (handle == null) {
+                // PTY may still be spawning; marking it Stopped now makes start() close it
+                // instead of registering a handle once the spawn finishes.
+                markComplete(runId, ActionRunStatus.Stopped, null)
+            }
+            handle
         }
-        scope.launch(Dispatchers.IO) {
-            runCatching { handle.session?.close() }
-            markComplete(runId, ActionRunStatus.Stopped, null)
+        if (handle != null) {
+            scope.launch(Dispatchers.IO) {
+                runCatching { handle.session?.close() }
+                markComplete(runId, ActionRunStatus.Stopped, null)
+            }
         }
     }
 
     override fun clear(runId: String) {
-        val handle = handles.remove(runId)
+        val handle = synchronized(lifecycleLock) {
+            val handle = handles.remove(runId)
+            _running.update { runs -> runs.filterNot { it.runId == runId } }
+            handle
+        }
         scope.launch(Dispatchers.IO) {
             runCatching { handle?.session?.close() }
         }
-        _running.update { runs -> runs.filterNot { it.runId == runId } }
     }
 
     internal fun rustTerminal(runId: String): RustTerminalBackend? = handles[runId]?.rustTerminal

--- a/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -75,37 +75,54 @@ class DesktopActionRunService(
             icon = action.icon,
             command = action.command,
             cwd = cwd,
-            status = ActionRunStatus.Running,
+            status = ActionRunStatus.Starting,
             startedAtMillis = System.currentTimeMillis(),
         )
         _running.update { it + snapshot }
 
-        runCatching {
-            val command = persistentShellCommand()
-            val environment = buildTerminalLaunchEnvironment(
-                project.env + action.env,
-            )
-            val session = TerminalSessions.create(
-                TerminalLaunchRequest(
-                    sessionId = runId,
-                    argv = command,
-                    cwd = cwd,
-                    env = environment,
-                    appearance = terminalAppearance(),
-                ),
-            )
-            session as? RustTerminalBackend
-                ?: error("terminal view missing after start: ${session::class.simpleName}")
-        }.fold(
-            onSuccess = { rustTerminal ->
-                val handle = RunHandle(rustTerminal, rustTerminal)
-                handles[runId] = handle
-                initialCommand?.let { command ->
-                    scope.launch(Dispatchers.IO) {
+        // PTY spawn does synchronous shell/native-library work (login shell capture, native
+        // lib load), so it runs off the UI thread and the dock tab appears before it finishes.
+        scope.launch(Dispatchers.IO) {
+            runCatching {
+                val command = persistentShellCommand()
+                val environment = buildTerminalLaunchEnvironment(
+                    project.env + action.env,
+                )
+                val session = TerminalSessions.create(
+                    TerminalLaunchRequest(
+                        sessionId = runId,
+                        argv = command,
+                        cwd = cwd,
+                        env = environment,
+                        appearance = terminalAppearance(),
+                    ),
+                )
+                session as? RustTerminalBackend
+                    ?: error("terminal view missing after start: ${session::class.simpleName}")
+            }.fold(
+                onSuccess = { rustTerminal ->
+                    val stillStarting = _running.value
+                        .firstOrNull { it.runId == runId }
+                        ?.status == ActionRunStatus.Starting
+                    if (!stillStarting) {
+                        // Tab was closed/stopped while the PTY was still spawning; don't orphan it.
+                        runCatching { rustTerminal.close() }
+                        return@launch
+                    }
+                    val handle = RunHandle(rustTerminal, rustTerminal)
+                    handles[runId] = handle
+                    _running.update { runs ->
+                        runs.map { run ->
+                            if (run.runId == runId && run.status == ActionRunStatus.Starting) {
+                                run.copy(status = ActionRunStatus.Running)
+                            } else {
+                                run
+                            }
+                        }
+                    }
+                    initialCommand?.let { command ->
                         runCatching { rustTerminal.writeText("$command\r") }
                     }
-                }
-                scope.launch(Dispatchers.IO) {
                     val exitCode = runCatching {
                         rustTerminal.exitCode.first { it != null }
                     }.getOrNull() ?: -1
@@ -114,18 +131,24 @@ class DesktopActionRunService(
                         if (exitCode == 0) ActionRunStatus.Exited else ActionRunStatus.Failed,
                         exitCode,
                     )
-                }
-            },
-            onFailure = {
-                markComplete(runId, ActionRunStatus.Failed, null)
-                handles[runId] = RunHandle(null, null)
-            },
-        )
+                },
+                onFailure = {
+                    markComplete(runId, ActionRunStatus.Failed, null)
+                    handles[runId] = RunHandle(null, null)
+                },
+            )
+        }
         return runId
     }
 
     override fun stop(runId: String) {
-        val handle = handles[runId] ?: return
+        val handle = handles[runId]
+        if (handle == null) {
+            // PTY may still be spawning; marking it Stopped now makes start() close it
+            // instead of registering a handle once the spawn finishes.
+            markComplete(runId, ActionRunStatus.Stopped, null)
+            return
+        }
         scope.launch(Dispatchers.IO) {
             runCatching { handle.session?.close() }
             markComplete(runId, ActionRunStatus.Stopped, null)
@@ -164,9 +187,10 @@ class DesktopActionRunService(
     }
 
     private fun markComplete(runId: String, status: ActionRunStatus, exitCode: Int?) {
+        val active = setOf(ActionRunStatus.Starting, ActionRunStatus.Running)
         _running.update { runs ->
             runs.map { run ->
-                if (run.runId == runId && run.status == ActionRunStatus.Running) {
+                if (run.runId == runId && run.status in active) {
                     run.copy(status = status, exitCode = exitCode)
                 } else {
                     run

--- a/src/desktopMain/kotlin/app/andy/ui/actions/ProjectTerminalSurface.desktop.kt
+++ b/src/desktopMain/kotlin/app/andy/ui/actions/ProjectTerminalSurface.desktop.kt
@@ -1,25 +1,39 @@
 package app.andy.ui.actions
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import app.andy.desktop.service.DesktopActionRunService
 import app.andy.desktop.service.DesktopWorkspaceStore
+import app.andy.model.ActionRunStatus
+import app.andy.model.RunningAction
 import app.andy.model.WorkspaceState
 import app.andy.model.panelBackgroundArgb
 import app.andy.model.toTerminalAppearance
 import app.andy.service.AndyServices
 import app.andy.terminal.rust.RustTerminalCanvas
+import app.andy.ui.theme.MonoFont
+import app.andy.ui.theme.Rust
+import app.andy.ui.theme.TextSecondary
 import kotlinx.coroutines.flow.MutableStateFlow
 
 private val NoWorkspace = MutableStateFlow(WorkspaceState())
+private val NoRunning = MutableStateFlow(emptyList<RunningAction>())
 
 @Composable
 actual fun ProjectTerminalSurface(
@@ -28,7 +42,11 @@ actual fun ProjectTerminalSurface(
     modifier: Modifier,
 ) {
     val actionRuns = services.actionRuns as? DesktopActionRunService
-    val rustBackend = actionRuns?.rustTerminal(runId) ?: return
+    // Observed (not a one-shot lookup) so this recomposes once the PTY finishes spawning
+    // in the background and the backend becomes available.
+    val runningFlow = remember(actionRuns) { actionRuns?.running ?: NoRunning }
+    val running by runningFlow.collectAsState()
+    val rustBackend = actionRuns?.rustTerminal(runId)
 
     val workspaceStore = services.workspaceStore as? DesktopWorkspaceStore
     val workspaceFlow = remember(workspaceStore) { workspaceStore?.state ?: NoWorkspace }
@@ -41,13 +59,33 @@ actual fun ProjectTerminalSurface(
     }
 
     Box(modifier.background(terminalPanelBackground)) {
-        key(runId, "rust") {
-            RustTerminalCanvas(
-                backend = rustBackend,
-                appearance = appearance,
-                autoFocus = true,
-                modifier = Modifier.fillMaxSize(),
-            )
+        if (rustBackend == null) {
+            val starting = running.firstOrNull { it.runId == runId }?.status == ActionRunStatus.Starting
+            if (starting) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        CircularProgressIndicator(Modifier.size(28.dp), strokeWidth = 2.dp, color = Rust)
+                        Text(
+                            "Starting terminal…",
+                            color = TextSecondary,
+                            fontFamily = MonoFont,
+                            fontSize = 12.sp,
+                        )
+                    }
+                }
+            }
+        } else {
+            key(runId, "rust") {
+                RustTerminalCanvas(
+                    backend = rustBackend,
+                    appearance = appearance,
+                    autoFocus = true,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
     }
 }

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
@@ -28,7 +28,7 @@ class DesktopActionRunServiceTest {
 
         try {
             assertEquals("Terminal", service.running.value.single().actionName)
-            assertNotNull(service.rustTerminal(runId))
+            awaitRustTerminal(service, runId)
             service.writeToTerminal(runId, "echo ready\r")
             awaitTerminalText(service, runId, "ready")
         } finally {
@@ -50,7 +50,7 @@ class DesktopActionRunServiceTest {
         )
 
         try {
-            assertNotNull(service.rustTerminal(runId))
+            awaitRustTerminal(service, runId)
             awaitTerminalText(service, runId, "initial")
             assertEquals(ActionRunStatus.Running, service.running.value.single().status)
 
@@ -85,11 +85,18 @@ class DesktopActionRunServiceTest {
             val secondRunId = service.run(project, action)
             assertTrue(firstRunId != secondRunId)
             assertEquals(listOf(secondRunId), service.running.value.map { it.runId })
-            assertNotNull(service.rustTerminal(secondRunId))
+            awaitRustTerminal(service, secondRunId)
             awaitTerminalText(service, secondRunId, "first")
         } finally {
             service.running.value.forEach { service.stop(it.runId) }
         }
+    }
+
+    private suspend fun awaitRustTerminal(service: DesktopActionRunService, runId: String) {
+        withTimeout(5_000) {
+            while (service.rustTerminal(runId) == null) delay(25)
+        }
+        assertNotNull(service.rustTerminal(runId))
     }
 
     private suspend fun awaitTerminalText(service: DesktopActionRunService, runId: String, text: String) {

--- a/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
+++ b/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
@@ -3,15 +3,21 @@ package app.andy.desktop.service
 import app.andy.model.ActionProject
 import app.andy.model.ActionRunStatus
 import app.andy.model.ProjectAction
+import app.andy.terminal.TerminalLaunchRequest
+import app.andy.terminal.TerminalSessions
+import app.andy.terminal.rust.RustTerminalBackend
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -104,5 +110,88 @@ class DesktopActionRunServiceTest {
             while (!service.bufferSnapshot(runId).contains(text)) delay(25)
         }
         assertTrue(service.bufferSnapshot(runId).contains(text))
+    }
+
+    @Test
+    fun stoppingWhileSpawningNeverPublishesTheBackendOrRunsTheCommand() = runBlocking {
+        val spawnGate = CountDownLatch(1)
+        val spawned = AtomicReference<RustTerminalBackend?>()
+        val service = gatedService(spawnGate, spawned)
+        val project = ActionProject(
+            id = "project",
+            name = "Project",
+            contextDir = createTempDirectory("andy-stop-while-spawning").toString(),
+        )
+        val runId = service.run(
+            project,
+            ProjectAction(id = "run", name = "Run", command = "echo must-not-run"),
+        )
+
+        service.stop(runId)
+        // stop() ran while the PTY was still spawning: the run must settle Stopped and
+        // must never transition to Running or register a live backend afterwards.
+        assertEquals(
+            ActionRunStatus.Stopped,
+            service.running.value.firstOrNull { it.runId == runId }?.status,
+        )
+        spawnGate.countDown()
+
+        awaitBackendClosed(spawned)
+        assertEquals(ActionRunStatus.Stopped, service.running.value.single().status)
+        assertNull(service.rustTerminal(runId))
+        assertTrue(service.bufferSnapshot(runId).isEmpty())
+    }
+
+    @Test
+    fun clearingWhileSpawningNeverPublishesTheBackend() = runBlocking {
+        val spawnGate = CountDownLatch(1)
+        val spawned = AtomicReference<RustTerminalBackend?>()
+        val service = gatedService(spawnGate, spawned)
+        val project = ActionProject(
+            id = "project",
+            name = "Project",
+            contextDir = createTempDirectory("andy-clear-while-spawning").toString(),
+        )
+        val runId = service.run(
+            project,
+            ProjectAction(id = "run", name = "Run", command = "echo must-not-run"),
+        )
+
+        service.clear(runId)
+        // clear() ran while the PTY was still spawning: the run must be gone and no
+        // live backend may appear in its place once the spawn finishes.
+        assertEquals(emptyList(), service.running.value)
+        spawnGate.countDown()
+
+        awaitBackendClosed(spawned)
+        assertEquals(emptyList(), service.running.value)
+        assertNull(service.rustTerminal(runId))
+    }
+
+    private fun gatedService(
+        spawnGate: CountDownLatch,
+        spawned: AtomicReference<RustTerminalBackend?>,
+    ): DesktopActionRunService = DesktopActionRunService(
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        spawnSession = { runId, argv, cwd, env ->
+            spawnGate.await()
+            val backend = TerminalSessions.create(
+                TerminalLaunchRequest(
+                    sessionId = runId,
+                    argv = argv,
+                    cwd = cwd,
+                    env = env,
+                ),
+            ) as RustTerminalBackend
+            spawned.set(backend)
+            backend
+        },
+    )
+
+    private suspend fun awaitBackendClosed(spawned: AtomicReference<RustTerminalBackend?>) {
+        withTimeout(5_000) {
+            while (spawned.get()?.exitCode?.value == null) delay(25)
+        }
+        assertTrue(spawned.get()?.exitCode?.value != null)
     }
 }


### PR DESCRIPTION
## Summary
- PTY spawn does synchronous shell/native-library work (login shell capture, native lib load) that previously blocked the caller; runs now register immediately in a new **Starting** state, spawn on an IO dispatcher, and flip to **Running** only once the backend exists
- The terminal dock tab appears right away and shows a spinner instead of leaving the caller frozen; stopping a run during spawn closes the PTY instead of orphaning it
- Dock polish: corner-inset breathing room for dock content, Live reads as a floating device surface, terminal-tinted headers lift chrome buttons, and a Starting status tints the dock status dot yellow
- The agent tool/file side pane is now drag-resizable instead of a fixed 420dp; inline tool-call diffs drop the redundant path header
- Tab rename keeps the caret at the end of the label on long-press

## Test plan
- [x] `./gradlew :desktopTest --tests 'app.andy.desktop.service.DesktopActionRunServiceTest'`
- [x] `./gradlew cleanDesktopTest recordRoborazziDesktop --tests 'app.andy.AndyDesktopScreenshotTest'` (no baseline changes — UI scenarios render identically)
- [ ] Manually run a project action and confirm the dock tab shows the starting spinner before the shell appears
- [ ] Stop a project action while its terminal is still spawning and confirm it closes cleanly

Known pre-existing (not introduced here): `keepsTheProjectShellOpenForAdditionalCommands` flakes (reproduced on main, 1/5), and `AgentTranscriptUiTest.commandResultDiffRendersInTheDiffViewer` fails on this machine but not on CI.