### PR TITLE
Fix release artifact paths after composeApp modularization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-artifacts
-          deb="$(find build -name '*.deb' -print -quit)"
+          deb="$(find composeApp/build -name '*.deb' -print -quit)"
           if [[ -z "${deb}" ]]; then
             echo "::error::Could not find Linux DEB release artifact"
             exit 1
@@ -399,7 +399,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path "release-artifacts" | Out-Null
-          $msi = Get-ChildItem -Path "build" -Recurse -Filter "*.msi" | Select-Object -First 1
+          $msi = Get-ChildItem -Path "composeApp/build" -Recurse -Filter "*.msi" | Select-Object -First 1
           if (-not $msi) {
             throw "Could not find Windows MSI release artifact"
           }
@@ -543,7 +543,7 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          log_dir="build/compose/logs"
+          log_dir="composeApp/build/compose/logs"
           if [[ ! -d "${log_dir}" ]]; then
             echo "No Compose packaging logs found."
             exit 0
@@ -560,7 +560,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-artifacts
-          dmg="$(find build -name '*.dmg' -print -quit)"
+          dmg="$(find composeApp/build -name '*.dmg' -print -quit)"
           if [[ -z "${dmg}" ]]; then
             echo "::error::Could not find macOS DMG release artifact"
             exit 1

--- a/flatpak/com.joetr.andy.yml
+++ b/flatpak/com.joetr.andy.yml
@@ -34,7 +34,7 @@ modules:
       - install -Dm644 com.joetr.andy.png /app/share/icons/hicolor/512x512/apps/com.joetr.andy.png
     sources:
       - type: dir
-        path: ../build/compose/binaries/main-release/app/Andy
+        path: ../composeApp/build/compose/binaries/main-release/app/Andy
         dest: andy
       - type: file
         path: com.joetr.andy.desktop


### PR DESCRIPTION
## Summary
- Point Linux, Windows, and macOS release collection steps at `composeApp/build` instead of root `build/`
- Update the Flatpak manifest source path to the modularized distributable location

PR #114 moved desktop packaging into the `composeApp` module, so release artifacts are written under `composeApp/build/compose/binaries/...`. The latest release failed because the workflow still searched the old root `build/` tree.

## Test plan
- [x] Verified failed release logs show MSI/DMG/DEB/Flatpak outputs under `composeApp/build`
- [ ] Merge to `main` and confirm the Release workflow completes and publishes artifacts


Made with [Cursor](https://cursor.com)