### PR TITLE
Fix Flatpak icon source path after composeApp modularization

### DIFF
--- a/flatpak/com.joetr.andy.yml
+++ b/flatpak/com.joetr.andy.yml
@@ -41,5 +41,5 @@ modules:
       - type: file
         path: com.joetr.andy.metainfo.xml
       - type: file
-        path: ../src/desktopMain/resources/icons/andy.png
+        path: ../composeApp/src/desktopMain/resources/icons/andy.png
         dest-filename: com.joetr.andy.png


### PR DESCRIPTION
## Summary
- Update the Flatpak manifest icon source to `composeApp/src/desktopMain/resources/icons/andy.png`

The Linux release job passed packaging and artifact collection for DEB/MSI/DMG after #115, but Flatpak still failed because the icon path was not updated during modularization.

## Test plan
- [x] Verified icon exists at the new composeApp path
- [ ] Merge to `main` and confirm Release workflow completes Flatpak + GitHub release


Made with [Cursor](https://cursor.com)