### PR TITLE
Add CLI loading screens, per-project actions, and run/enrichment fixes

### DIFF
--- a/cli/andy/src/daemon.rs
+++ b/cli/andy/src/daemon.rs
@@ -21,11 +21,22 @@ pub fn pid_path() -> PathBuf {
 }
 
 pub async fn ensure_running(socket: &Path) -> Result<()> {
+    ensure_running_with_feedback(socket, |_, _| Ok(())).await
+}
+
+/// Like [ensure_running], but invokes `on_wait(message, frame)` on each poll so
+/// callers (e.g. the TUI) can redraw a loading screen while andyd starts.
+pub async fn ensure_running_with_feedback(
+    socket: &Path,
+    mut on_wait: impl FnMut(&str, u8) -> Result<()>,
+) -> Result<()> {
     if is_socket_live(socket).await {
         return Ok(());
     }
     remove_stale_artifacts(socket);
-    if pid_alive() && wait_for_socket(socket, Duration::from_secs(15)).await {
+    if pid_alive()
+        && wait_for_socket_with_feedback(socket, Duration::from_secs(15), &mut on_wait).await
+    {
         return Ok(());
     }
     if !try_launch()? {
@@ -35,7 +46,7 @@ pub async fn ensure_running(socket: &Path) -> Result<()> {
              or launch the Andy desktop app."
         );
     }
-    if !wait_for_socket(socket, Duration::from_secs(15)).await {
+    if !wait_for_socket_with_feedback(socket, Duration::from_secs(15), &mut on_wait).await {
         bail!(
             "andyd did not become ready at {} within 15s — check ~/.andy/logs/andyd.err.log",
             socket.display()
@@ -94,12 +105,36 @@ fn process_alive(pid: u32) -> bool {
         .unwrap_or(false)
 }
 
-async fn wait_for_socket(socket: &Path, timeout: Duration) -> bool {
+/// Poll until the socket accepts connections (no launch). Used for SSH-tunneled remotes.
+pub async fn wait_until_live_with_feedback(
+    socket: &Path,
+    timeout: Duration,
+    mut on_wait: impl FnMut(&str, u8) -> Result<()>,
+) -> Result<()> {
+    if wait_for_socket_with_feedback(socket, timeout, &mut on_wait).await {
+        Ok(())
+    } else {
+        bail!(
+            "andyd socket at {} did not become ready within {}s",
+            socket.display(),
+            timeout.as_secs()
+        )
+    }
+}
+
+async fn wait_for_socket_with_feedback(
+    socket: &Path,
+    timeout: Duration,
+    on_wait: &mut impl FnMut(&str, u8) -> Result<()>,
+) -> bool {
     let deadline = Instant::now() + timeout;
+    let mut frame = 0u8;
     while Instant::now() < deadline {
         if is_socket_live(socket).await {
             return true;
         }
+        let _ = on_wait("Connecting to andyd…", frame);
+        frame = frame.wrapping_add(1);
         thread::sleep(Duration::from_millis(100));
     }
     is_socket_live(socket).await

--- a/cli/andy/src/lib.rs
+++ b/cli/andy/src/lib.rs
@@ -16,6 +16,7 @@ pub mod device_map;
 pub mod dispatch;
 pub mod events;
 pub mod file_picker;
+pub mod loading;
 pub mod mcp;
 pub mod skills;
 pub mod slash;

--- a/cli/andy/src/loading.rs
+++ b/cli/andy/src/loading.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+pub fn spinner(frame: u8) -> &'static str {
+    SPINNER[(frame as usize) % SPINNER.len()]
+}
+
+/// Full-screen loading panel with an animated spinner.
+pub fn draw_loading_screen(
+    terminal: &mut Terminal<impl Backend>,
+    title: &str,
+    message: &str,
+    frame: u8,
+) -> Result<()> {
+    let spin = spinner(frame);
+    terminal.draw(|f| {
+        let area = f.area();
+        let text = format!("\n  {spin}  {message}\n");
+        f.render_widget(
+            Paragraph::new(text).block(
+                Block::default()
+                    .title(format!(" {title} "))
+                    .borders(Borders::ALL),
+            ),
+            area,
+        );
+    })?;
+    Ok(())
+}

--- a/cli/andy/src/main.rs
+++ b/cli/andy/src/main.rs
@@ -131,15 +131,25 @@ async fn main() -> Result<()> {
     daemon::ensure_unix_platform()?;
     let cli = Cli::parse();
     let socket = resolve_socket(&cli).await?;
-    if cli.remote.is_none() {
-        daemon::ensure_running(&socket).await?;
-    }
-    let mut client = McpClient::new(socket);
     let json_out = cli.json;
+    let ensure_local_daemon = cli.remote.is_none();
 
     match cli.command {
-        Commands::Tui => tui::run_dashboard(client).await?,
-        Commands::Attach { task_id } => attach::attach_or_reattach(&mut client, &task_id).await?,
+        Commands::Tui => tui::run_dashboard(socket, ensure_local_daemon).await?,
+        cmd => {
+            if ensure_local_daemon {
+                daemon::ensure_running(&socket).await?;
+            }
+            let mut client = McpClient::new(socket);
+            dispatch_command(cmd, &mut client, json_out).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn dispatch_command(cmd: Commands, client: &mut McpClient, json_out: bool) -> Result<()> {
+    match cmd {
+        Commands::Attach { task_id } => attach::attach_or_reattach(client, &task_id).await?,
         Commands::Chat(ChatCmd::List) => {
             let raw = client
                 .call_tool("chat.list", Value::Object(Default::default()))
@@ -202,7 +212,7 @@ async fn main() -> Result<()> {
                 .get("id")
                 .and_then(|id| id.as_str())
                 .with_context(|| format!("unexpected chat.start response: {raw}"))?;
-            if let Err(err) = attach::attach_or_reattach(&mut client, task_id).await {
+            if let Err(err) = attach::attach_or_reattach(client, task_id).await {
                 eprintln!("started {task_id} but attach failed: {err:#}");
                 println!("{raw}");
             }
@@ -234,19 +244,18 @@ async fn main() -> Result<()> {
                 .await?;
             println!("{raw}");
         }
-        Commands::Device(cmd) => device_cli::run_device(&mut client, cmd, json_out).await?,
-        Commands::Emulator(cmd) => device_cli::run_emulator(&mut client, cmd, json_out).await?,
-        Commands::Avd(cmd) => device_cli::run_avd(&mut client, cmd, json_out).await?,
-        Commands::SystemImage(cmd) => {
-            device_cli::run_system_image(&mut client, cmd, json_out).await?
-        }
-        Commands::Snapshot(cmd) => device_cli::run_snapshot(&mut client, cmd, json_out).await?,
-        Commands::Input(cmd) => device_cli::run_input(&mut client, cmd, json_out).await?,
-        Commands::App(cmd) => device_cli::run_app(&mut client, cmd, json_out).await?,
-        Commands::Intent(cmd) => device_cli::run_intent(&mut client, cmd, json_out).await?,
-        Commands::File(cmd) => device_cli::run_file(&mut client, cmd, json_out).await?,
-        Commands::Network(cmd) => device_cli::run_network(&mut client, cmd, json_out).await?,
-        Commands::Tool(cmd) => tool_cmd::run_tool(&mut client, cmd, json_out).await?,
+        Commands::Device(cmd) => device_cli::run_device(client, cmd, json_out).await?,
+        Commands::Emulator(cmd) => device_cli::run_emulator(client, cmd, json_out).await?,
+        Commands::Avd(cmd) => device_cli::run_avd(client, cmd, json_out).await?,
+        Commands::SystemImage(cmd) => device_cli::run_system_image(client, cmd, json_out).await?,
+        Commands::Snapshot(cmd) => device_cli::run_snapshot(client, cmd, json_out).await?,
+        Commands::Input(cmd) => device_cli::run_input(client, cmd, json_out).await?,
+        Commands::App(cmd) => device_cli::run_app(client, cmd, json_out).await?,
+        Commands::Intent(cmd) => device_cli::run_intent(client, cmd, json_out).await?,
+        Commands::File(cmd) => device_cli::run_file(client, cmd, json_out).await?,
+        Commands::Network(cmd) => device_cli::run_network(client, cmd, json_out).await?,
+        Commands::Tool(cmd) => tool_cmd::run_tool(client, cmd, json_out).await?,
+        Commands::Tui => unreachable!("handled in main"),
     }
     Ok(())
 }

--- a/cli/andy/src/tui.rs
+++ b/cli/andy/src/tui.rs
@@ -24,11 +24,31 @@ use crate::mcp::McpClient;
 use crate::tmux;
 use std::path::PathBuf;
 
+/// Restores the terminal on every exit path (including startup failures).
+struct TerminalGuard(Terminal<CrosstermBackend<Stdout>>);
+
+impl TerminalGuard {
+    fn setup() -> Result<Self> {
+        enable_raw_mode()?;
+        stdout().execute(EnterAlternateScreen)?;
+        stdout().execute(EnableMouseCapture)?;
+        Ok(Self(Terminal::new(CrosstermBackend::new(stdout()))?))
+    }
+
+    fn terminal(&mut self) -> &mut Terminal<CrosstermBackend<Stdout>> {
+        &mut self.0
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = restore_terminal(&mut self.0);
+    }
+}
+
 pub async fn run_dashboard(socket: PathBuf, ensure_local_daemon: bool) -> Result<()> {
-    enable_raw_mode()?;
-    stdout().execute(EnterAlternateScreen)?;
-    stdout().execute(EnableMouseCapture)?;
-    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    let mut guard = TerminalGuard::setup()?;
+    let mut terminal = guard.terminal();
 
     if ensure_local_daemon {
         daemon::ensure_running_with_feedback(&socket, |message, tick| {
@@ -297,7 +317,6 @@ pub async fn run_dashboard(socket: PathBuf, ensure_local_daemon: bool) -> Result
         }
     }
 
-    restore_terminal(&mut terminal)?;
     Ok(())
 }
 

--- a/cli/andy/src/tui.rs
+++ b/cli/andy/src/tui.rs
@@ -18,14 +18,32 @@ use crate::acp_view;
 use crate::attach;
 use crate::chats::{self, ListEntry, ProjectGroup};
 use crate::compose;
+use crate::daemon;
+use crate::loading;
 use crate::mcp::McpClient;
 use crate::tmux;
+use std::path::PathBuf;
 
-pub async fn run_dashboard(mut client: McpClient) -> Result<()> {
+pub async fn run_dashboard(socket: PathBuf, ensure_local_daemon: bool) -> Result<()> {
     enable_raw_mode()?;
     stdout().execute(EnterAlternateScreen)?;
     stdout().execute(EnableMouseCapture)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+
+    if ensure_local_daemon {
+        daemon::ensure_running_with_feedback(&socket, |message, tick| {
+            loading::draw_loading_screen(&mut terminal, " Andy ", message, tick)
+        })
+        .await?;
+    } else {
+        daemon::wait_until_live_with_feedback(
+            &socket,
+            std::time::Duration::from_secs(15),
+            |message, tick| loading::draw_loading_screen(&mut terminal, " Andy ", message, tick),
+        )
+        .await?;
+    }
+    let mut client = McpClient::new(socket);
 
     let mut selected: usize = 0;
     let mut list_state = ListState::default();
@@ -468,13 +486,21 @@ async fn refresh(
     list_state: &mut ListState,
     status: &mut String,
 ) -> Result<()> {
-    *status = "Loading chats…".into();
-    draw_dashboard(terminal, entries, list_state, *selected, status)?;
+    *status = "Loading chats…".to_string();
+    let mut frame = 0u8;
+    let list_fut = client.call_tool("chat.list", Value::Object(Default::default()));
+    tokio::pin!(list_fut);
 
-    match client
-        .call_tool("chat.list", Value::Object(Default::default()))
-        .await
-    {
+    let raw = loop {
+        loading::draw_loading_screen(terminal, " Andy chats ", status, frame)?;
+        frame = frame.wrapping_add(1);
+        tokio::select! {
+            result = &mut list_fut => break result,
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+    };
+
+    match raw {
         Ok(raw) => {
             let chats = chats::parse_chats(&raw);
             let chat_count = chats.len();

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1091,6 +1091,7 @@ tasks.register("installAndyd") {
         println("Installed ${launcherDest.absolutePath}")
         println("Installed ${jarDest.absolutePath}")
         println("Recorded ${releaseMeta.absolutePath}")
+        println("Restart the Andy desktop app (or quit Andy) so the running andyd loads the new JAR.")
         println("Add ~/.andy/bin to PATH permanently if needed:")
         println("  echo 'export PATH=\"\$HOME/.andy/bin:\$PATH\"' >> ~/.zshrc   # zsh")
         println("  echo 'export PATH=\"\$HOME/.andy/bin:\$PATH\"' >> ~/.bashrc  # bash")

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -51,6 +51,8 @@ class DesktopActionRunService(
     private val nextRun = AtomicInteger(1)
     private val handles = ConcurrentHashMap<String, RunHandle>()
     private val pendingAppends = ConcurrentHashMap<String, MutableList<String>>()
+    /** Runs whose PTY is live but the spawn handshake has not yet sent [initialCommand]. */
+    private val awaitingInitialCommand = ConcurrentHashMap.newKeySet<String>()
 
     // Serializes the spawn handshake (status check + handle registration) against stop()/clear(),
     // so a run cancelled while its PTY is still spawning never publishes a live backend afterwards.
@@ -86,7 +88,7 @@ class DesktopActionRunService(
                     it.actionId == action.id &&
                     it.status in ACTIVE_STATUSES
             }
-            if (existing != null && isAppendable(existing.runId)) {
+            if (existing != null) {
                 if (command != null) appendCommand(existing.runId, command)
                 return existing.runId
             }
@@ -134,6 +136,7 @@ class DesktopActionRunService(
                             false
                         } else {
                             handles[runId] = RunHandle(rustTerminal, rustTerminal)
+                            awaitingInitialCommand.add(runId)
                             _running.update { runs ->
                                 runs.map { run ->
                                     if (run.runId == runId && run.status == ActionRunStatus.Starting) {
@@ -155,6 +158,7 @@ class DesktopActionRunService(
                         runCatching { rustTerminal.writeText("$command\r") }
                     }
                     drainPendingAppends(runId, rustTerminal)
+                    awaitingInitialCommand.remove(runId)
                     val exitCode = runCatching {
                         rustTerminal.exitCode.first { it != null }
                     }.getOrNull() ?: -1
@@ -165,6 +169,7 @@ class DesktopActionRunService(
                     )
                 },
                 onFailure = {
+                    awaitingInitialCommand.remove(runId)
                     markComplete(runId, ActionRunStatus.Failed, null)
                     synchronized(lifecycleLock) {
                         // Publish a tombstone only if the run wasn't already cleared, so a
@@ -203,6 +208,7 @@ class DesktopActionRunService(
     override fun clear(runId: String) {
         val handle = synchronized(lifecycleLock) {
             pendingAppends.remove(runId)
+            awaitingInitialCommand.remove(runId)
             val handle = handles.remove(runId)
             _running.update { runs -> runs.filterNot { it.runId == runId } }
             handle
@@ -235,14 +241,9 @@ class DesktopActionRunService(
             .forEach { clear(it.runId) }
     }
 
-    private fun isAppendable(runId: String): Boolean {
-        val terminal = handles[runId]?.rustTerminal ?: return true
-        return terminal.isAlive
-    }
-
     private fun appendCommand(runId: String, command: String) {
         val terminal = handles[runId]?.rustTerminal
-        if (terminal != null && terminal.isAlive) {
+        if (terminal != null && terminal.isAlive && runId !in awaitingInitialCommand) {
             runCatching { terminal.writeText("$command\r") }
         } else {
             pendingAppends.computeIfAbsent(runId) { mutableListOf() }.add(command)

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -50,6 +50,7 @@ class DesktopActionRunService(
 
     private val nextRun = AtomicInteger(1)
     private val handles = ConcurrentHashMap<String, RunHandle>()
+    private val pendingAppends = ConcurrentHashMap<String, MutableList<String>>()
 
     // Serializes the spawn handshake (status check + handle registration) against stop()/clear(),
     // so a run cancelled while its PTY is still spawning never publishes a live backend afterwards.
@@ -78,11 +79,23 @@ class DesktopActionRunService(
     )
 
     override fun run(project: ActionProject, action: ProjectAction): String {
+        val command = action.command.takeIf { it.isNotBlank() }
+        synchronized(lifecycleLock) {
+            val existing = _running.value.lastOrNull {
+                it.projectId == project.id &&
+                    it.actionId == action.id &&
+                    it.status in ACTIVE_STATUSES
+            }
+            if (existing != null && isAppendable(existing.runId)) {
+                if (command != null) appendCommand(existing.runId, command)
+                return existing.runId
+            }
+        }
         clearExistingRuns(project.id, action.id)
         return start(
             project = project,
             action = action,
-            initialCommand = action.command.takeIf { it.isNotBlank() },
+            initialCommand = command,
         )
     }
 
@@ -141,6 +154,7 @@ class DesktopActionRunService(
                     initialCommand?.let { command ->
                         runCatching { rustTerminal.writeText("$command\r") }
                     }
+                    drainPendingAppends(runId, rustTerminal)
                     val exitCode = runCatching {
                         rustTerminal.exitCode.first { it != null }
                     }.getOrNull() ?: -1
@@ -188,6 +202,7 @@ class DesktopActionRunService(
 
     override fun clear(runId: String) {
         val handle = synchronized(lifecycleLock) {
+            pendingAppends.remove(runId)
             val handle = handles.remove(runId)
             _running.update { runs -> runs.filterNot { it.runId == runId } }
             handle
@@ -218,6 +233,30 @@ class DesktopActionRunService(
         _running.value
             .filter { it.projectId == projectId && it.actionId == actionId }
             .forEach { clear(it.runId) }
+    }
+
+    private fun isAppendable(runId: String): Boolean {
+        val terminal = handles[runId]?.rustTerminal ?: return true
+        return terminal.isAlive
+    }
+
+    private fun appendCommand(runId: String, command: String) {
+        val terminal = handles[runId]?.rustTerminal
+        if (terminal != null && terminal.isAlive) {
+            runCatching { terminal.writeText("$command\r") }
+        } else {
+            pendingAppends.computeIfAbsent(runId) { mutableListOf() }.add(command)
+        }
+    }
+
+    private fun drainPendingAppends(runId: String, terminal: RustTerminalBackend) {
+        pendingAppends.remove(runId)?.forEach { command ->
+            runCatching { terminal.writeText("$command\r") }
+        }
+    }
+
+    private companion object {
+        private val ACTIVE_STATUSES = setOf(ActionRunStatus.Starting, ActionRunStatus.Running)
     }
 
     private fun markComplete(runId: String, status: ActionRunStatus, exitCode: Int?) {

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
@@ -162,6 +162,9 @@ fun Server.registerAgentProjectTools(
         // Temporary chats are desktop-session-local; another agent must not be able to
         // enumerate or inspect one.
         val tasks = agentRuns.tasks.value.excludingTemporary()
+        val tmuxAvailable = TmuxAndy.isAvailable()
+        // One `list-sessions` answers liveness for every row — not N `has-session` forks.
+        val liveTmuxSessions = if (tmuxAvailable) TmuxAndy.listSessions().toSet() else emptySet()
         val arr = buildJsonArray {
             tasks.forEach { task ->
                 add(
@@ -238,7 +241,10 @@ fun Server.registerAgentProjectTools(
                             )
                         }
                         put("tmuxSession", TmuxAndy.sessionName(task.id))
-                        put("tmuxAlive", TmuxAndy.isAvailable() && TmuxAndy.hasSession(task.id))
+                        put(
+                            "tmuxAlive",
+                            tmuxAvailable && TmuxAndy.sessionName(task.id) in liveTmuxSessions,
+                        )
                     },
                 )
             }

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -3410,9 +3410,12 @@ class DesktopAgentRunService(
     override fun events(taskId: String): StateFlow<List<AgentEvent>> {
         currentTask(taskId) ?: return emptyEvents
         return eventFlows.computeIfAbsent(taskId) {
+            val isAcp = currentTask(taskId)?.lane == AgentLaneKind.Acp
             MutableStateFlow(
-                if (currentTask(taskId)?.lane == AgentLaneKind.Acp) loadAcpEventsFromStore(taskId) else emptyList(),
-            ).also { scheduleFileChangesEnrichment(taskId) }
+                if (isAcp) loadAcpEventsForInitialDisplay(taskId) else emptyList(),
+            ).also {
+                if (isAcp) enqueueImmediateAcpDisplayEnrichment(taskId)
+            }
         }
     }
 
@@ -5391,6 +5394,29 @@ class DesktopAgentRunService(
         coalesceAcpTranscriptEvents(acpTranscriptStore.load(taskId))
 
     /**
+     * Raw ACP rows may include persisted [AgentEvent.FileChanges] that enrichment later
+     * strips (committed edits) or replaces (synthesized cards). Never publish them on first
+     * paint — messages and tool activity can render while enrichment runs on IO.
+     */
+    private fun loadAcpEventsForInitialDisplay(taskId: String): List<AgentEvent> =
+        loadAcpEventsFromStore(taskId).filter { it !is AgentEvent.FileChanges }
+
+    private fun enqueueImmediateAcpDisplayEnrichment(
+        taskId: String,
+        flushBatch: Boolean = false,
+        atMillis: Long = System.currentTimeMillis(),
+    ) {
+        val task = currentTask(taskId) ?: return
+        if (task.lane != AgentLaneKind.Acp || task.status == AgentStatus.Blocked) return
+        fileChangesEnrichmentJobs[taskId]?.cancel()
+        fileChangesEnrichmentJobs[taskId] = scope.launch {
+            fileChangesEnrichmentMutex.computeIfAbsent(taskId) { Mutex() }.withLock {
+                runFileChangesEnrichment(taskId, flushBatch, synthesizeTurn = false, atMillis)
+            }
+        }
+    }
+
+    /**
      * Older transcripts may have mutating tool calls but no persisted file-changes rows
      * (before batch tracking landed). Synthesize one inline card per turn segment on IO only.
      */
@@ -5463,7 +5489,7 @@ class DesktopAgentRunService(
                     acpTranscriptStore.load(taskId),
                 ).display
             }
-            eventFlows[taskId]?.update { current ->
+            eventFlows.computeIfAbsent(taskId) { MutableStateFlow(emptyList()) }.update { current ->
                 if (AgentFileChangesEnrichment.displayEventsEqual(current, display)) current else display
             }
         }
@@ -5505,12 +5531,18 @@ class DesktopAgentRunService(
     private fun refreshAcpTranscriptFromDisk(taskId: String) {
         val task = currentTask(taskId) ?: return
         if (task.lane != AgentLaneKind.Acp) return
-        scope.launch(Dispatchers.IO) {
-            val loaded = loadAcpEventsFromStore(taskId)
-            eventFlows.computeIfAbsent(taskId) { MutableStateFlow(loaded) }.value = loaded
-            if (task.status != AgentStatus.Blocked) {
-                scheduleFileChangesEnrichment(taskId)
+        eventFlows.computeIfAbsent(taskId) {
+            MutableStateFlow(loadAcpEventsForInitialDisplay(taskId))
+        }
+        if (task.status != AgentStatus.Blocked) {
+            enqueueImmediateAcpDisplayEnrichment(taskId)
+        } else {
+            scope.launch(Dispatchers.IO) {
+                val loaded = loadAcpEventsFromStore(taskId)
+                eventFlows[taskId]?.value = loaded
             }
+        }
+        scope.launch(Dispatchers.IO) {
             if (task.planMode && task.status == AgentStatus.Done && task.completedPlanText.isNullOrBlank()) {
                 resolveCompletedPlanText(taskId, task)?.let { plan ->
                     updateTask(taskId) { current ->
@@ -5545,7 +5577,7 @@ class DesktopAgentRunService(
         val task = currentTask(taskId)
         val isAcp = task?.lane == AgentLaneKind.Acp
         val flow = eventFlows.computeIfAbsent(taskId) {
-            MutableStateFlow(if (isAcp) loadAcpEventsFromStore(taskId) else emptyList())
+            MutableStateFlow(if (isAcp) loadAcpEventsForInitialDisplay(taskId) else emptyList())
         }
         val filterReplay = taskId in acpSuppressProviderReplay
         val replayScratch = if (filterReplay) {
@@ -5736,10 +5768,13 @@ class DesktopAgentRunService(
                 terminals.clearForeground()
             }
             viewing -> {
+                val alreadyViewing = taskId in viewingTaskIds
                 viewingTaskIds.add(taskId)
                 terminals.setOnlyForeground(taskId)
                 markRead(taskId)
-                refreshAcpTranscriptFromDisk(taskId)
+                if (!alreadyViewing) {
+                    refreshAcpTranscriptFromDisk(taskId)
+                }
             }
             else -> {
                 viewingTaskIds.remove(taskId)

--- a/data/agents/src/desktopMain/kotlin/app/andy/terminal/rust/RustTerminalKeys.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/terminal/rust/RustTerminalKeys.kt
@@ -32,10 +32,21 @@ internal fun isTerminalPasteChord(event: KeyEvent): Boolean =
         (event.isMetaPressed || event.isCtrlPressed) &&
         event.key == Key.V
 
+private val modifierOnlyKeys = setOf(
+    Key.CtrlLeft, Key.CtrlRight,
+    Key.AltLeft, Key.AltRight,
+    Key.ShiftLeft, Key.ShiftRight,
+    Key.MetaLeft, Key.MetaRight,
+)
+
+/** AWT `KeyEvent.KEY_CHAR_UNDEFINED` — sent for modifier-only KEY_PRESSED events. */
+private const val KEY_CHAR_UNDEFINED = 0xFFFF
+
 internal fun encodeTerminalKey(event: KeyEvent): ByteArray? {
     if (event.type != KeyEventType.KeyDown) return null
     // Cmd/Meta chords are handled by the canvas (copy/paste) or dropped — never encoded.
     if (event.isMetaPressed) return null
+    if (event.key in modifierOnlyKeys) return null
 
     if (event.isCtrlPressed) {
         encodeCtrl(event)?.let { return it }
@@ -59,7 +70,12 @@ internal fun encodeTerminalKey(event: KeyEvent): ByteArray? {
     }
 
     val codePoint = event.utf16CodePoint
-    if (codePoint != 0 && Character.isValidCodePoint(codePoint) && !Character.isISOControl(codePoint)) {
+    if (
+        codePoint != 0 &&
+            codePoint != KEY_CHAR_UNDEFINED &&
+            Character.isValidCodePoint(codePoint) &&
+            !Character.isISOControl(codePoint)
+    ) {
         return String(Character.toChars(codePoint)).toByteArray(Charsets.UTF_8)
     }
     return null

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
@@ -76,29 +76,29 @@ class DesktopActionRunServiceTest {
     }
 
     @Test
-    fun rerunningAnActionStopsThePreviousShellAndStartsFresh() = runBlocking {
+    fun rerunningAnActionAppendsToTheExistingShell() = runBlocking {
         val service = DesktopActionRunService(CoroutineScope(SupervisorJob() + Dispatchers.IO))
         val project = ActionProject(
             id = "project",
             name = "Project",
             contextDir = createTempDirectory("andy-rerun-action").toString(),
         )
-        val action = ProjectAction(id = "run", name = "Run", command = "echo first")
+        val firstAction = ProjectAction(id = "run", name = "Run", command = "echo first")
+        val secondAction = firstAction.copy(command = "echo second")
 
-        val firstRunId = service.run(project, action)
+        val runId = service.run(project, firstAction)
         try {
-            awaitTerminalText(service, firstRunId, "first")
+            awaitTerminalText(service, runId, "first")
             assertEquals(ActionRunStatus.Running, service.running.value.single().status)
 
-            val secondRunId = service.run(project, action)
-            assertTrue(firstRunId != secondRunId)
-            assertEquals(listOf(secondRunId), service.running.value.map { it.runId })
-            awaitRustTerminal(service, secondRunId)
-            awaitTerminalText(service, secondRunId, "first")
+            val secondRunId = service.run(project, secondAction)
+            assertEquals(runId, secondRunId)
+            assertEquals(listOf(runId), service.running.value.map { it.runId })
+            awaitTerminalText(service, runId, "second")
+            assertTrue(service.bufferSnapshot(runId).contains("first"))
         } finally {
-            val runIds = service.running.value.map { it.runId }
-            runIds.forEach { service.stop(it) }
-            runIds.forEach { awaitRunFinished(service, it) }
+            service.stop(runId)
+            awaitRunFinished(service, runId)
         }
     }
 

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/FileChangesEnrichmentTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/FileChangesEnrichmentTest.kt
@@ -75,6 +75,7 @@ class FileChangesEnrichmentTest {
             WorktreeManager.resetChangeSnapshotInvocationCount()
 
             service.testRunFileChangesEnrichmentNow(taskId, synthesizeTurn = true)
+            service.testAwaitFileChangesEnrichmentJobs()
 
             val fileChanges = service.events(taskId).value.filterIsInstance<AgentEvent.FileChanges>()
             assertEquals(1, fileChanges.size)
@@ -200,6 +201,79 @@ class FileChangesEnrichmentTest {
                 WorktreeManager.changeSnapshotInvocations.get() <= 2,
                 "expected debounced enrichment, got ${WorktreeManager.changeSnapshotInvocations.get()} git snapshots",
             )
+        }
+    }
+
+    @Test
+    fun eventsInitialDisplayOmitsFileChangesUntilEnrichment() = runBlocking {
+        withGitService(status = AgentStatus.Done) { service, repo, taskId, baseline ->
+            val store = AcpTranscriptStore(fileFor = { service.testTranscriptFile(it) })
+            store.append(
+                taskId,
+                AgentEvent.FileChanges(
+                    atMillis = 1,
+                    batchId = "batch-stale",
+                    baselineTree = baseline,
+                    snapshot = AgentThreadChangeSnapshot(
+                        summary = AgentChangeSummary(listOf(AgentFileChange("src/Main.kt", 1, 0))),
+                        diffs = emptyMap(),
+                    ),
+                ),
+            )
+            git(repo, "add", "src/Main.kt")
+            git(repo, "commit", "-m", "committed edits")
+
+            assertFalse(service.events(taskId).value.any { it is AgentEvent.FileChanges })
+
+            service.testAwaitFileChangesEnrichmentJobs()
+
+            assertFalse(service.events(taskId).value.any { it is AgentEvent.FileChanges })
+        }
+    }
+
+    @Test
+    fun eventsAddsValidFileChangesAfterImmediateEnrichment() = runBlocking {
+        withGitService(status = AgentStatus.Working) { service, _, taskId, _ ->
+            seedLegacyEditSegment(service, taskId, repoFile = "src/Main.kt")
+
+            assertFalse(service.events(taskId).value.any { it is AgentEvent.FileChanges })
+
+            service.testAwaitFileChangesEnrichmentJobs()
+
+            assertTrue(service.events(taskId).value.any { it is AgentEvent.FileChanges })
+        }
+    }
+
+    @Test
+    fun reclickingSameChatDoesNotResurrectStaleFileChangesCard() = runBlocking {
+        withGitService(status = AgentStatus.Done) { service, repo, taskId, baseline ->
+            val store = AcpTranscriptStore(fileFor = { service.testTranscriptFile(it) })
+            store.append(
+                taskId,
+                AgentEvent.FileChanges(
+                    atMillis = 1,
+                    batchId = "batch-stale",
+                    baselineTree = baseline,
+                    snapshot = AgentThreadChangeSnapshot(
+                        summary = AgentChangeSummary(listOf(AgentFileChange("src/Main.kt", 1, 0))),
+                        diffs = emptyMap(),
+                    ),
+                ),
+            )
+            // withGitService leaves src/Main.kt dirty ("one\ntwo\n"); commit so the card is stale.
+            git(repo, "add", "src/Main.kt")
+            git(repo, "commit", "-m", "committed edits")
+
+            service.events(taskId)
+            service.setChatViewing(taskId, viewing = true)
+            service.testAwaitFileChangesEnrichmentJobs()
+
+            assertFalse(service.events(taskId).value.any { it is AgentEvent.FileChanges })
+
+            service.setChatViewing(taskId, viewing = true)
+            service.testAwaitFileChangesEnrichmentJobs()
+
+            assertFalse(service.events(taskId).value.any { it is AgentEvent.FileChanges })
         }
     }
 

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/FileChangesEnrichmentTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/FileChangesEnrichmentTest.kt
@@ -108,6 +108,8 @@ class FileChangesEnrichmentTest {
             assertTrue(WorktreeManager.changeSnapshotInvocations.get() >= 1)
             val store = AcpTranscriptStore(fileFor = { service.testTranscriptFile(it) })
             assertTrue(store.load(taskId).any { it is AgentEvent.FileChanges })
+            service.events(taskId)
+            service.testAwaitFileChangesEnrichmentJobs()
             assertTrue(service.events(taskId).value.any { it is AgentEvent.FileChanges })
         }
     }

--- a/data/agents/src/desktopTest/kotlin/app/andy/terminal/rust/RustTerminalCanvasSupportTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/terminal/rust/RustTerminalCanvasSupportTest.kt
@@ -29,6 +29,28 @@ class RustTerminalCanvasSupportTest {
     }
 
     @Test
+    fun modifierOnlyKeysAreNotEncoded() {
+        assertNull(encodeTerminalKey(keyEvent(Key.ShiftLeft)))
+        assertNull(encodeTerminalKey(keyEvent(Key.ShiftRight)))
+        assertNull(encodeTerminalKey(keyEvent(Key.CtrlLeft)))
+        assertNull(encodeTerminalKey(keyEvent(Key.AltLeft)))
+        assertNull(encodeTerminalKey(keyEvent(Key.MetaLeft, meta = true)))
+    }
+
+    @Test
+    fun awtUndefinedKeyCharIsNotEncoded() {
+        assertNull(
+            encodeTerminalKey(
+                KeyEvent(
+                    key = Key.Unknown,
+                    type = KeyEventType.KeyDown,
+                    codePoint = 0xFFFF,
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun formatTerminalPasteWrapsMultilineWhenBracketed() {
         val bytes = formatTerminalPaste("line1\nline2", bracketedPaste = true)
         assertEquals("\u001B[200~line1\nline2\u001B[201~", bytes.decodeToString())
@@ -44,11 +66,13 @@ class RustTerminalCanvasSupportTest {
         key: Key,
         ctrl: Boolean = false,
         meta: Boolean = false,
+        codePoint: Int = 0,
     ): KeyEvent = KeyEvent(
         key = key,
         type = KeyEventType.KeyDown,
         isCtrlPressed = ctrl,
         isMetaPressed = meta,
+        codePoint = codePoint,
     )
 
     @Test

--- a/data/workspace/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
+++ b/data/workspace/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
@@ -147,6 +147,7 @@ class DesktopWorkspaceStore(
             selectedPackage = props.getProperty("selectedPackage")?.takeIf { it.isNotBlank() },
             lastActionProjectId = props.getProperty("lastActionProjectId")?.takeIf { it.isNotBlank() },
             lastActionId = props.getProperty("lastActionId")?.takeIf { it.isNotBlank() },
+            lastActionIdsByProject = loadLastActionIdsByProject(props),
             agentOsNotificationsEnabled = props.getProperty("agentOsNotificationsEnabled")?.toBooleanStrictOrNull() ?: true,
             agentNotificationSoundEnabled = props.getProperty("agentNotificationSoundEnabled")?.toBooleanStrictOrNull() ?: true,
             agentIconBadgeEnabled = props.getProperty("agentIconBadgeEnabled")?.toBooleanStrictOrNull() ?: true,
@@ -282,6 +283,7 @@ class DesktopWorkspaceStore(
             setProperty("selectedPackage", state.selectedPackage.orEmpty())
             setProperty("lastActionProjectId", state.lastActionProjectId.orEmpty())
             setProperty("lastActionId", state.lastActionId.orEmpty())
+            saveIndexedStringMap(this, "lastActionIdByProject", state.lastActionIdsByProject)
             setProperty("agentOsNotificationsEnabled", state.agentOsNotificationsEnabled.toString())
             setProperty("agentNotificationSoundEnabled", state.agentNotificationSoundEnabled.toString())
             setProperty("agentIconBadgeEnabled", state.agentIconBadgeEnabled.toString())
@@ -351,6 +353,14 @@ class DesktopWorkspaceStore(
                 pairedAtMillis = props.getProperty(prefix + "pairedAtMillis")?.toLongOrNull() ?: 0L,
             )
         }
+    }
+
+    private fun loadLastActionIdsByProject(props: Properties): Map<String, String> {
+        val stored = loadIndexedStringMap(props, "lastActionIdByProject")
+        if (stored.isNotEmpty()) return stored
+        val projectId = props.getProperty("lastActionProjectId")?.takeIf { it.isNotBlank() } ?: return emptyMap()
+        val actionId = props.getProperty("lastActionId")?.takeIf { it.isNotBlank() } ?: return emptyMap()
+        return mapOf(projectId to actionId)
     }
 
     private fun loadIndexedStringMap(props: Properties, prefix: String): Map<String, String> {

--- a/data/workspace/src/desktopTest/kotlin/app/andy/desktop/service/DesktopWorkspaceStoreTest.kt
+++ b/data/workspace/src/desktopTest/kotlin/app/andy/desktop/service/DesktopWorkspaceStoreTest.kt
@@ -145,6 +145,25 @@ class DesktopWorkspaceStoreTest {
         assertEquals("Database", tracing.filesTab)
         assertEquals("garden", tracing.lastActionProjectId)
         assertEquals("test", tracing.lastActionId)
+        assertEquals(mapOf("garden" to "test"), tracing.lastActionIdsByProject)
+
+        DesktopWorkspaceStore(file).save(
+            tracing.copy(
+                lastActionProjectId = "mobile",
+                lastActionId = "install",
+                lastActionIdsByProject = mapOf(
+                    "garden" to "test",
+                    "mobile" to "install",
+                ),
+            ),
+        )
+        val perProjectActions = DesktopWorkspaceStore(file).load()
+        assertEquals("mobile", perProjectActions.lastActionProjectId)
+        assertEquals("install", perProjectActions.lastActionId)
+        assertEquals(
+            mapOf("garden" to "test", "mobile" to "install"),
+            perProjectActions.lastActionIdsByProject,
+        )
 
         file.writeText(file.readText().replace("performanceTab=Tracing", "performanceTab=Nope"))
         assertEquals("Metrics", DesktopWorkspaceStore(file).load().performanceTab)

--- a/domain/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
@@ -124,6 +124,8 @@ data class WorkspaceState(
     val lastActionProjectId: String? = null,
     /** Last action shown in the header action runner. */
     val lastActionId: String? = null,
+    /** Last selected or run action id keyed by project id (header runner + Projects page). */
+    val lastActionIdsByProject: Map<String, String> = emptyMap(),
     val agentOsNotificationsEnabled: Boolean = true,
     val agentNotificationSoundEnabled: Boolean = true,
     val agentIconBadgeEnabled: Boolean = true,

--- a/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -768,6 +768,13 @@ private fun ProjectCockpit(
                                     onEditAction = { editingAction = EditingAction(current.id, it) },
                                     onNewAction = { editingAction = EditingAction(current.id, null) },
                                     onRunAction = { action ->
+                                        onUpdateWorkspace {
+                                            it.copy(
+                                                lastActionProjectId = current.id,
+                                                lastActionId = action.id,
+                                                lastActionIdsByProject = it.lastActionIdsByProject + (current.id to action.id),
+                                            )
+                                        }
                                         val runId = services.actionRuns.run(current, action)
                                         onNotifyTerminalRun(runId)
                                     },

--- a/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
+++ b/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
@@ -928,6 +928,7 @@ internal class ShellState(
             it.copy(
                 lastActionProjectId = project.id,
                 lastActionId = action.id,
+                lastActionIdsByProject = it.lastActionIdsByProject + (project.id to action.id),
             )
         }
         val runId = services.actionRuns.run(project, action)
@@ -937,34 +938,51 @@ internal class ShellState(
     }
 
     fun rememberActionSelection(projectId: String, actionId: String?) {
+        val resolvedActionId = resolveLastActionId(projectId, actionId)
         if (
             workspaceState.lastActionProjectId == projectId &&
-            workspaceState.lastActionId == actionId
+            workspaceState.lastActionId == resolvedActionId
+        ) {
+            return
+        }
+        updateWorkspace {
+            val rememberedMap = if (actionId != null && resolvedActionId != null) {
+                it.lastActionIdsByProject + (projectId to resolvedActionId)
+            } else {
+                it.lastActionIdsByProject
+            }
+            it.copy(
+                lastActionProjectId = projectId,
+                lastActionId = resolvedActionId,
+                lastActionIdsByProject = rememberedMap,
+            )
+        }
+    }
+
+    fun rememberLastProject(projectId: String) {
+        val resolvedActionId = resolveLastActionId(projectId, actionId = null)
+        if (
+            workspaceState.lastActionProjectId == projectId &&
+            workspaceState.lastActionId == resolvedActionId
         ) {
             return
         }
         updateWorkspace {
             it.copy(
                 lastActionProjectId = projectId,
-                lastActionId = actionId,
+                lastActionId = resolvedActionId,
             )
         }
     }
 
-    fun rememberLastProject(projectId: String) {
-        if (workspaceState.lastActionProjectId == projectId) return
-        val actionId = workspaceState.lastActionId?.takeIf { actionId ->
-            actionsConfig.projects
-                .firstOrNull { it.id == projectId }
-                ?.actions
-                ?.any { it.id == actionId } == true
-        } ?: actionsConfig.projects.firstOrNull { it.id == projectId }?.actions?.firstOrNull()?.id
-        updateWorkspace {
-            it.copy(
-                lastActionProjectId = projectId,
-                lastActionId = actionId,
-            )
-        }
+    private fun resolveLastActionId(projectId: String, actionId: String?): String? {
+        val projectActions = actionsConfig.projects.firstOrNull { it.id == projectId }?.actions.orEmpty()
+        if (projectActions.isEmpty()) return null
+        actionId?.takeIf { id -> projectActions.any { it.id == id } }?.let { return it }
+        workspaceState.lastActionIdsByProject[projectId]
+            ?.takeIf { id -> projectActions.any { it.id == id } }
+            ?.let { return it }
+        return projectActions.firstOrNull()?.id
     }
 
     fun stopAction(run: RunningAction) {

--- a/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/TopChrome.kt
+++ b/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/TopChrome.kt
@@ -328,7 +328,7 @@ private fun ActionRunnerSelector(
                         AndyDropdownMenuItem(
                             label = item.name,
                             onClick = {
-                                onSelectionChange(item.id, item.actions.firstOrNull()?.id)
+                                onSelectionChange(item.id, null)
                                 projectMenuOpen = false
                             },
                         )


### PR DESCRIPTION
## Summary
- Show animated loading screens in `andy tui` while connecting to andyd and fetching chats (including remote sockets).
- Remember the last selected action per project in workspace state so switching projects restores the right runner action.
- Append commands to an already-running action terminal instead of restarting, queue writes until the PTY is alive, and skip encoding modifier-only/undefined terminal keys.
- Defer stale ACP file-change cards on first paint until enrichment runs; batch tmux session liveness in `chat.list`.

## Test plan
- [x] `cargo test` in `cli/andy`
- [x] `./gradlew :data:agents:desktopTest --tests FileChangesEnrichmentTest --tests DesktopActionRunServiceTest --tests RustTerminalCanvasSupportTest`
- [x] `./gradlew :data:workspace:desktopTest --tests DesktopWorkspaceStoreTest`
- [ ] CI green on macOS/Linux/Windows desktop tests and assemble jobs


Made with [Cursor](https://cursor.com)