### PR TITLE
Polish agent transcript tool fences and chat metadata

### DIFF
--- a/core/platform/src/androidMain/kotlin/app/andy/AndroidPlatformActuals.kt
+++ b/core/platform/src/androidMain/kotlin/app/andy/AndroidPlatformActuals.kt
@@ -81,11 +81,21 @@ actual suspend fun readClipboardImagePaths(): List<String> = emptyList()
 private val displayDateTimeFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a", Locale.getDefault())
 
+private val displayTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("h:mm a", Locale.getDefault())
+
 actual fun hostTimeZoneId(): String = ZoneId.systemDefault().id
 
 actual fun formatDisplayDateTime(epochMillis: Long): String {
     if (epochMillis <= 0L) return "-"
     return displayDateTimeFormatter.format(
+        Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()),
+    )
+}
+
+actual fun formatDisplayTime(epochMillis: Long): String {
+    if (epochMillis <= 0L) return "-"
+    return displayTimeFormatter.format(
         Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()),
     )
 }

--- a/core/platform/src/commonMain/kotlin/app/andy/PlatformText.kt
+++ b/core/platform/src/commonMain/kotlin/app/andy/PlatformText.kt
@@ -9,6 +9,9 @@ fun currentTimeMillis(): Long = Clock.System.now().toEpochMilliseconds()
 
 expect fun formatDisplayDateTime(epochMillis: Long): String
 
+/** Wall-clock time in the host locale/timezone, e.g. `2:08 PM`. */
+expect fun formatDisplayTime(epochMillis: Long): String
+
 expect fun hostTimeZoneId(): String
 
 fun formatDecimal(value: Number, fractionDigits: Int): String {

--- a/core/platform/src/desktopMain/kotlin/app/andy/PlatformText.desktop.kt
+++ b/core/platform/src/desktopMain/kotlin/app/andy/PlatformText.desktop.kt
@@ -8,11 +8,21 @@ import java.util.Locale
 private val displayDateTimeFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a", Locale.getDefault())
 
+private val displayTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("h:mm a", Locale.getDefault())
+
 actual fun hostTimeZoneId(): String = ZoneId.systemDefault().id
 
 actual fun formatDisplayDateTime(epochMillis: Long): String {
     if (epochMillis <= 0L) return "-"
     return displayDateTimeFormatter.format(
+        Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()),
+    )
+}
+
+actual fun formatDisplayTime(epochMillis: Long): String {
+    if (epochMillis <= 0L) return "-"
+    return displayTimeFormatter.format(
         Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()),
     )
 }

--- a/core/platform/src/wasmJsMain/kotlin/app/andy/WebPlatformActuals.kt
+++ b/core/platform/src/wasmJsMain/kotlin/app/andy/WebPlatformActuals.kt
@@ -93,7 +93,17 @@ actual fun formatDisplayDateTime(epochMillis: Long): String {
     return formatJsDisplayDateTime(epochMillis.toDouble()).toString()
 }
 
+actual fun formatDisplayTime(epochMillis: Long): String {
+    if (epochMillis <= 0L) return "-"
+    return formatJsDisplayTime(epochMillis.toDouble()).toString()
+}
+
 private fun formatJsDisplayDateTime(epochMillis: Double): JsString =
     js(
         "(new Date(epochMillis)).toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })",
+    )
+
+private fun formatJsDisplayTime(epochMillis: Double): JsString =
+    js(
+        "(new Date(epochMillis)).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })",
     )

--- a/domain/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/AcpToolCallPresentation.kt
@@ -352,14 +352,25 @@ object AcpToolCallPresentation {
         isString && (content.contains('\n') || content.length > InlineValueLimit)
 
     private fun renderJsonMarkdown(element: JsonElement): String = when (element) {
-        is JsonObject -> element.entries.joinToString("\n") { (key, value) ->
-            val label = humanize(key)
-            when {
-                value is JsonPrimitive && value.isBlockText() -> "- **$label:**\n${fencedBlock(value.content)}"
-                value is JsonPrimitive -> "- **$label:** ${renderPrimitive(value)}"
-                else -> {
-                    val nested = renderJsonMarkdown(value)
-                    "- **$label:**\n${nested.prependIndent("  ")}"
+        is JsonObject -> {
+            // Prefer a sibling path so a Read/ Grep `content` fence can carry `kotlin` / `ts` / …
+            val pathHint = pathKeys.firstNotNullOfOrNull { key ->
+                (element[key] as? JsonPrimitive)?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
+            }
+            element.entries.joinToString("\n") { (key, value) ->
+                val label = humanize(key)
+                when {
+                    // Nest the fence under the list item (2-space indent). A column-0 fence ends the
+                    // list, so mid-file fragments with uneven absolute indent look like they "escaped"
+                    // the content: label — less-indented lines align with the bullet while deeper
+                    // lines still sit under it.
+                    value is JsonPrimitive && value.isBlockText() ->
+                        "- **$label:**\n${fencedBlock(value.content, pathHint).prependIndent("  ")}"
+                    value is JsonPrimitive -> "- **$label:** ${renderPrimitive(value)}"
+                    else -> {
+                        val nested = renderJsonMarkdown(value)
+                        "- **$label:**\n${nested.prependIndent("  ")}"
+                    }
                 }
             }
         }
@@ -374,15 +385,84 @@ object AcpToolCallPresentation {
     }
 
     /** Fence long enough to survive backticks in the body, so Markdown cannot break mid-payload. */
-    private fun fencedBlock(body: String): String {
-        val longestRun = Regex("`+").findAll(body).maxOfOrNull { it.value.length } ?: 0
+    private fun fencedBlock(body: String, pathHint: String? = null): String {
+        val dedented = dedentCommonIndent(body.trimEnd())
+        val longestRun = Regex("`+").findAll(dedented).maxOfOrNull { it.value.length } ?: 0
         val fence = "`".repeat(maxOf(3, longestRun + 1))
-        return "$fence${payloadLanguage(body)}\n${body.trimEnd()}\n$fence"
+        return "$fence${payloadLanguage(dedented, pathHint)}\n$dedented\n$fence"
     }
 
-    private fun payloadLanguage(body: String): String =
-        if (body.startsWith("diff --git") || diffHunkHeader.containsMatchIn(body)) "diff" else ""
+    /**
+     * Strip the shared leading indent from a file/command fragment. Read tools often return a slice
+     * that still carries the surrounding function's indent; without this, "main-level" lines in the
+     * fragment sit flush with the tool-row bullet while nested lines look correctly nested.
+     */
+    fun dedentCommonIndent(text: String): String {
+        val lines = text.replace("\r\n", "\n").split('\n')
+        val indents = lines.mapNotNull { line ->
+            if (line.isBlank()) null
+            else line.indexOfFirst { it != ' ' && it != '\t' }.takeIf { it >= 0 }
+        }
+        val indent = indents.minOrNull() ?: return text
+        if (indent == 0) return text
+        return lines.joinToString("\n") { line ->
+            if (line.isBlank()) ""
+            else line.drop(minOf(indent, line.length))
+        }
+    }
 
+    private val pathKeys = listOf(
+        "path", "file_path", "filePath", "file", "target_file", "uri", "notebook_path",
+    )
+
+    private fun payloadLanguage(body: String, pathHint: String? = null): String {
+        languageForPath(pathHint)?.let { return it }
+        if (body.startsWith("diff --git") || diffHunkHeader.containsMatchIn(body)) return "diff"
+        return languageFromContent(body).orEmpty()
+    }
+
+    private fun languageForPath(path: String?): String? {
+        val ext = path?.substringAfterLast('.', "")?.lowercase().orEmpty()
+        if (ext.isEmpty() || ext == path?.lowercase()) return null
+        return when (ext) {
+            "kt", "kts" -> "kotlin"
+            "java" -> "java"
+            "js", "mjs", "cjs" -> "javascript"
+            "ts", "tsx" -> "typescript"
+            "py" -> "python"
+            "rs" -> "rust"
+            "go" -> "go"
+            "rb" -> "ruby"
+            "sh", "bash", "zsh" -> "shell"
+            "json" -> "json"
+            "yaml", "yml" -> "yaml"
+            "md", "markdown" -> "markdown"
+            "html", "htm" -> "html"
+            "css" -> "css"
+            "sql" -> "sql"
+            "xml" -> "xml"
+            "c", "h" -> "c"
+            "cpp", "cc", "cxx", "hpp" -> "cpp"
+            "swift" -> "swift"
+            else -> null
+        }
+    }
+
+    /** Best-effort language when the payload has no path (Cursor Read often sends only `content`). */
+    private fun languageFromContent(body: String): String? {
+        val sample = body.lineSequence().take(40).joinToString("\n")
+        return when {
+            Regex("""\b(fun |val |var |suspend fun |data class |@Composable)\b""").containsMatchIn(sample) -> "kotlin"
+            Regex("""\b(def |async def |from \w+ import |elif )\b""").containsMatchIn(sample) -> "python"
+            Regex("""\b(fn |let mut |impl |pub struct )\b""").containsMatchIn(sample) -> "rust"
+            Regex("""\b(func |package main|:=)\b""").containsMatchIn(sample) -> "go"
+            Regex("""\b(const |let |function |=>|export )\b""").containsMatchIn(sample) &&
+                (sample.contains("interface ") || sample.contains(": string") || sample.contains(": number")) ->
+                "typescript"
+            Regex("""\b(function |const |let |=>|export )\b""").containsMatchIn(sample) -> "javascript"
+            else -> null
+        }
+    }
     private fun renderPrimitive(value: JsonPrimitive): String {
         val content = value.contentOrNull ?: value.toString()
         return when {

--- a/domain/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
+++ b/domain/src/commonTest/kotlin/app/andy/model/AcpToolCallPresentationTest.kt
@@ -251,16 +251,63 @@ class AcpToolCallPresentationTest {
             """
             - **exitCode:** 0
             - **stdout:**
-            ```
-            first line
-            second line
-            ```
+              ```
+              first line
+              second line
+              ```
             - **stderr:** —
             """.trimIndent(),
             body,
         )
         assertEquals(listOf("first line\nsecond line"), AcpToolCallPresentation.payloadTextValues(payload))
         assertTrue(AcpToolCallPresentation.payloadTextValues("plain text output").isEmpty())
+    }
+
+    @Test
+    fun readContentFenceDedentsAndNestsUnderTheLabel() {
+        val snippet = """
+            |            variant == ChatBubbleVariant.Ghost -> Color.Transparent
+            |        }
+            |        val shape = chatBubbleShape(group, alignEnd)
+        """.trimMargin()
+        val escaped = snippet.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+        val payload = """{"content":"$escaped"}"""
+
+        val body = AcpToolCallPresentation.displayDetail(payload)
+
+        assertEquals(
+            """
+            - **content:**
+              ```kotlin
+                  variant == ChatBubbleVariant.Ghost -> Color.Transparent
+              }
+              val shape = chatBubbleShape(group, alignEnd)
+              ```
+            """.trimIndent(),
+            body,
+        )
+    }
+
+    @Test
+    fun readContentFenceUsesPathExtensionForLanguage() {
+        val payload =
+            """{"path":"src/Main.kt","content":"    fun main() {\n        println(42)\n    }"}"""
+
+        val body = AcpToolCallPresentation.displayDetail(payload)
+
+        assertTrue(body.contains("```kotlin\n"))
+        assertTrue(body.contains("fun main() {"))
+        assertFalse(body.contains("    fun main() {"), "common indent should be stripped")
+    }
+
+    @Test
+    fun dedentCommonIndentPreservesRelativeStructure() {
+        val text = "        val a = 1\n            val b = 2\n        val c = 3"
+        assertEquals(
+            "val a = 1\n    val b = 2\nval c = 3",
+            AcpToolCallPresentation.dedentCommonIndent(text),
+        )
+        assertEquals("fun x() {}", AcpToolCallPresentation.dedentCommonIndent("fun x() {}"))
     }
 
     @Test

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -669,6 +669,7 @@ fun AgentTaskDetail(
                         originalPrompt = task.prompt.ifBlank { task.title },
                         originalImagePaths = task.imagePaths,
                         originalSkills = task.skills,
+                        originalPromptAtMillis = task.createdAtMillis,
                         restoreScrollKey = task.id,
                         scrollMemory = transcriptScrollMemory,
                         scrollToLatestRequest = scrollToLatestRequest,

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -84,6 +83,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import app.andy.formatDisplayTime
 import app.andy.loadImageBitmap
 import app.andy.domain.ToolCallFileContent
 import app.andy.domain.detectUnifiedDiff
@@ -210,6 +210,8 @@ fun AgentTranscript(
     originalPrompt: String? = null,
     originalImagePaths: List<String> = emptyList(),
     originalSkills: List<AgentSkill> = emptyList(),
+    /** Wall time for the launch prompt bubble when it is synthesized (not from [AgentEvent.UserMessage]). */
+    originalPromptAtMillis: Long? = null,
     completedContent: (@Composable () -> Unit)? = null,
     /** Scrolls with the transcript on the live edge, below pending input and above events. */
     trailingContent: (@Composable () -> Unit)? = null,
@@ -577,6 +579,9 @@ fun AgentTranscript(
                                 metadata = originalPrompt?.takeIf { it.isNotBlank() }?.let { prompt ->
                                     {
                                         ChatMessageMetadata(
+                                            timestamp = originalPromptAtMillis
+                                                ?.takeIf { it > 0L }
+                                                ?.let(::formatDisplayTime),
                                             reverse = true,
                                             footer = { ChatMessageCopyAction(prompt) },
                                         )
@@ -996,6 +1001,7 @@ private fun TranscriptEvent(
                 metadata = copyText?.let { text ->
                     {
                         ChatMessageMetadata(
+                            timestamp = event.atMillis.takeIf { it > 0L }?.let(::formatDisplayTime),
                             reverse = true,
                             footer = { ChatMessageCopyAction(text) },
                         )
@@ -2137,9 +2143,10 @@ private fun codeLanguageForPath(path: String?): String = when (path?.substringAf
 
 /** Wraps [body] in a Markdown fence long enough to survive any backtick runs already inside it. */
 private fun fencedCodeBlock(body: String, language: String = ""): String {
-    val longestRun = Regex("`+").findAll(body).maxOfOrNull { it.value.length } ?: 0
+    val dedented = AcpToolCallPresentation.dedentCommonIndent(body.trimEnd())
+    val longestRun = Regex("`+").findAll(dedented).maxOfOrNull { it.value.length } ?: 0
     val fence = "`".repeat(maxOf(3, longestRun + 1))
-    return "$fence$language\n$body\n$fence"
+    return "$fence$language\n$dedented\n$fence"
 }
 
 @Composable
@@ -2245,17 +2252,7 @@ private fun TranscriptExpandableRow(
                         },
                     ),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                if (expandable) {
-                    Text(
-                        if (expanded) "v" else ">",
-                        color = headlineColor.copy(alpha = 0.7f),
-                        fontFamily = MonoFont,
-                        fontSize = 11.sp,
-                        modifier = Modifier.width(10.dp),
-                    )
-                }
                 if (headlineContent != null) {
                     Box(Modifier.weight(1f, fill = false)) { headlineContent() }
                 } else {

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -573,19 +573,25 @@ fun AgentTranscript(
                 if (originalPromptVisible) {
                     item(key = "original-prompt", contentType = "message") {
                         SelectionContainer {
+                            val originalTimestamp = originalPromptAtMillis
+                                ?.takeIf { it > 0L }
+                                ?.let(::formatDisplayTime)
+                            val originalCopyText = originalPrompt?.takeIf { it.isNotBlank() }
                             ChatMessageBubble(
                                 sender = ChatBubbleSender.User,
                                 testTag = "user-message-bubble",
-                                metadata = originalPrompt?.takeIf { it.isNotBlank() }?.let { prompt ->
+                                metadata = if (originalTimestamp != null || originalCopyText != null) {
                                     {
                                         ChatMessageMetadata(
-                                            timestamp = originalPromptAtMillis
-                                                ?.takeIf { it > 0L }
-                                                ?.let(::formatDisplayTime),
+                                            timestamp = originalTimestamp,
                                             reverse = true,
-                                            footer = { ChatMessageCopyAction(prompt) },
+                                            footer = originalCopyText?.let { prompt ->
+                                                { ChatMessageCopyAction(prompt) }
+                                            },
                                         )
                                     }
+                                } else {
+                                    null
                                 },
                             ) {
                                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -979,7 +985,11 @@ private fun TranscriptEvent(
                 event.text.stripTrailingConnectionStallError(),
             )
             if (visibleText.isBlank() || visibleText.isRetriableConnectionStallMessage()) return
-            AgentResponse(group = bubbleGroup, copyText = visibleText) {
+            AgentResponse(
+                group = bubbleGroup,
+                copyText = visibleText,
+                atMillis = event.atMillis,
+            ) {
                 ChatMarkdown(visibleText, lineHeight = 21.sp)
             }
         }
@@ -994,18 +1004,21 @@ private fun TranscriptEvent(
             val displayText = userMessageDisplayText(event)
             val copyText = displayText.takeIf { it.isNotBlank() }
                 ?: event.skills.takeIf { it.isNotEmpty() }?.joinToString(" ") { "/${it.name}" }
+            val timestamp = event.atMillis.takeIf { it > 0L }?.let(::formatDisplayTime)
             ChatMessageBubble(
                 sender = ChatBubbleSender.User,
                 group = bubbleGroup,
                 testTag = "user-message-bubble",
-                metadata = copyText?.let { text ->
+                metadata = if (timestamp != null || copyText != null) {
                     {
                         ChatMessageMetadata(
-                            timestamp = event.atMillis.takeIf { it > 0L }?.let(::formatDisplayTime),
+                            timestamp = timestamp,
                             reverse = true,
-                            footer = { ChatMessageCopyAction(text) },
+                            footer = copyText?.let { text -> { ChatMessageCopyAction(text) } },
                         )
                     }
+                } else {
+                    null
                 },
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -1276,18 +1289,24 @@ private fun ChatUserText(text: String) {
 private fun AgentResponse(
     group: ChatBubbleGroup = ChatBubbleGroup.Single,
     copyText: String? = null,
+    atMillis: Long? = null,
     content: @Composable () -> Unit,
 ) {
+    val timestamp = atMillis?.takeIf { it > 0L }?.let(::formatDisplayTime)
+    val copyable = copyText?.takeIf { it.isNotBlank() }
     ChatMessageBubble(
         sender = ChatBubbleSender.Assistant,
         variant = ChatBubbleVariant.Ghost,
         group = group,
-        metadata = copyText?.takeIf { it.isNotBlank() }?.let { text ->
+        metadata = if (timestamp != null || copyable != null) {
             {
                 ChatMessageMetadata(
-                    footer = { ChatMessageCopyAction(text) },
+                    timestamp = timestamp,
+                    footer = copyable?.let { text -> { ChatMessageCopyAction(text) } },
                 )
             }
+        } else {
+            null
         },
     ) {
         content()
@@ -1325,7 +1344,10 @@ private fun AgentCompletion(
             }
         }
         event.finalText?.takeIf { it.isNotBlank() }?.let {
-            AgentResponse(copyText = stripDecisionCheckpointMarkup(it)) {
+            AgentResponse(
+                copyText = stripDecisionCheckpointMarkup(it),
+                atMillis = event.atMillis,
+            ) {
                 ChatMarkdown(stripDecisionCheckpointMarkup(it), lineHeight = 18.sp)
             }
         }

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatMessageBubble.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatMessageBubble.kt
@@ -1,7 +1,10 @@
 package app.andy.ui.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,17 +15,30 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.andy.andy.generated.resources.Res
@@ -32,11 +48,12 @@ import app.andy.ui.theme.AndyColors
 import app.andy.ui.theme.AndyRadius
 import app.andy.ui.theme.AndySpace
 import app.andy.ui.theme.DisplayFont
+import app.andy.ui.theme.Green
 import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
 import app.andy.ui.theme.andyTokens
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.painterResource
-import androidx.compose.foundation.Image
 
 enum class ChatBubbleSender {
     User,
@@ -85,28 +102,31 @@ fun ChatMessageBubble(
         ChatBubbleGroup.Middle, ChatBubbleGroup.Last -> -ChatBubbleGroupPullUp
         else -> 0.dp
     }
+    // Chat radius is 28dp — keep content clear of the curve. Metadata sits outside the
+    // bubble, so bottom padding stays full even when a copy/timestamp row follows.
+    val horizontalPad = AndySpace.Space4
     val verticalPadding = when (group) {
         ChatBubbleGroup.First -> PaddingValues(
-            start = AndySpace.Space3,
-            end = AndySpace.Space3,
-            top = AndySpace.Space2,
-            bottom = AndySpace.Space1,
-        )
-        ChatBubbleGroup.Middle -> PaddingValues(
-            start = AndySpace.Space3,
-            end = AndySpace.Space3,
-            top = AndySpace.Space1,
-            bottom = AndySpace.Space1,
-        )
-        ChatBubbleGroup.Last -> PaddingValues(
-            start = AndySpace.Space3,
-            end = AndySpace.Space3,
-            top = AndySpace.Space1,
+            start = horizontalPad,
+            end = horizontalPad,
+            top = AndySpace.Space3,
             bottom = AndySpace.Space2,
         )
+        ChatBubbleGroup.Middle -> PaddingValues(
+            start = horizontalPad,
+            end = horizontalPad,
+            top = AndySpace.Space2,
+            bottom = AndySpace.Space2,
+        )
+        ChatBubbleGroup.Last -> PaddingValues(
+            start = horizontalPad,
+            end = horizontalPad,
+            top = AndySpace.Space2,
+            bottom = AndySpace.Space3,
+        )
         ChatBubbleGroup.Single -> PaddingValues(
-            horizontal = AndySpace.Space3,
-            vertical = AndySpace.Space2,
+            horizontal = horizontalPad,
+            vertical = AndySpace.Space3,
         )
     }
     Column(
@@ -137,7 +157,18 @@ fun ChatMessageBubble(
                 content = content,
             )
             if (metadata != null) {
-                Column(Modifier.padding(horizontal = AndySpace.Space3, vertical = AndySpace.Space1)) {
+                // Keep copy under the bubble edge — fillMaxWidth here used to stretch user
+                // bubbles to the chat width and park the icon far from short skill pills.
+                Box(
+                    Modifier
+                        .align(if (alignEnd) Alignment.End else Alignment.Start)
+                        .padding(
+                            start = AndySpace.Space3,
+                            end = AndySpace.Space3,
+                            top = if (alignEnd) 2.dp else 0.dp,
+                            bottom = AndySpace.Space1,
+                        ),
+                ) {
                     metadata()
                 }
             }
@@ -172,7 +203,6 @@ fun ChatBubbleText(
 
 /**
  * Astryx ChatMessageMetadata — `timestamp · footer · status`.
- * Andy currently ships copy-only footer content.
  */
 @Composable
 fun ChatMessageMetadata(
@@ -185,9 +215,7 @@ fun ChatMessageMetadata(
     val hasContent = timestamp != null || footer != null || status != null
     if (!hasContent) return
     Row(
-        modifier
-            .padding(top = AndySpace.Space1)
-            .fillMaxWidth(),
+        modifier,
         horizontalArrangement = if (reverse) Arrangement.End else Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -206,6 +234,8 @@ fun ChatMessageMetadata(
     }
 }
 
+private const val CopiedFeedbackMillis = 1_400L
+
 /** Icon-only copy control for [ChatMessageMetadata] footer. */
 @Composable
 fun ChatMessageCopyAction(
@@ -214,17 +244,48 @@ fun ChatMessageCopyAction(
 ) {
     if (text.isBlank()) return
     val copyText = rememberCopyText()
-    IconButton(
-        onClick = { copyText(text) },
-        modifier = modifier.size(28.dp),
-        contentDescription = "Copy message",
-    ) {
-        Image(
-            painter = painterResource(Res.drawable.markdown_copy),
-            contentDescription = null,
-            modifier = Modifier.size(14.dp),
-            colorFilter = ColorFilter.tint(TextSecondary.copy(alpha = 0.72f)),
-        )
+    var justCopied by remember { mutableStateOf(false) }
+    LaunchedEffect(justCopied) {
+        if (!justCopied) return@LaunchedEffect
+        delay(CopiedFeedbackMillis)
+        justCopied = false
+    }
+    // Material's default 48dp touch target leaves a large empty gap under short bubbles.
+    CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+        Tooltip(text = "Copied", forceVisible = justCopied, delayMillis = 0) {
+            Box(
+                modifier
+                    .size(16.dp)
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = if (justCopied) "Copied" else "Copy message"
+                    }
+                    .clickable(onClickLabel = "Copy message", enabled = !justCopied) {
+                        copyText(text)
+                        justCopied = true
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                if (justCopied) {
+                    Text(
+                        "✓",
+                        color = Green,
+                        fontSize = 12.sp,
+                        lineHeight = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                        textAlign = TextAlign.Center,
+                    )
+                } else {
+                    Image(
+                        painter = painterResource(Res.drawable.markdown_copy),
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                        colorFilter = ColorFilter.tint(TextSecondary.copy(alpha = 0.72f)),
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/MarkdownPreview.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/MarkdownPreview.kt
@@ -246,7 +246,9 @@ private fun AndyMarkdown(
         markdownState = markdownState,
         colors = markdownColor(
             text = if (thinking) TextSecondary else TextPrimary,
-            codeBackground = AndyColors.Neutral850.copy(alpha = if (thinking) 0.35f else 0.55f),
+            // Thinking/tool rows sit on a near-black aside — keep code chrome strong enough that a
+            // Read fragment's less-indented lines still read as inside the fence, not as body text.
+            codeBackground = AndyColors.Neutral850.copy(alpha = if (thinking) 0.72f else 0.55f),
             inlineCodeBackground = AndyColors.Neutral700.copy(alpha = if (thinking) 0.45f else 0.72f),
             dividerColor = Border.copy(alpha = if (thinking) 0.35f else 0.45f),
             tableBackground = AndyColors.Neutral850.copy(alpha = if (thinking) 0.4f else 0.65f),

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/Tooltip.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/Tooltip.kt
@@ -43,12 +43,18 @@ fun Tooltip(
     text: String,
     modifier: Modifier = Modifier,
     delayMillis: Long = TooltipDelayMillis,
+    /** When non-null, drives visibility directly (e.g. ephemeral "Copied" feedback). */
+    forceVisible: Boolean? = null,
     content: @Composable () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val hovered by interactionSource.collectIsHoveredAsState()
     var visible by remember { mutableStateOf(false) }
-    LaunchedEffect(hovered, text) {
+    LaunchedEffect(hovered, text, forceVisible) {
+        if (forceVisible != null) {
+            visible = forceVisible
+            return@LaunchedEffect
+        }
         if (!hovered) {
             visible = false
             return@LaunchedEffect
@@ -91,7 +97,7 @@ fun Tooltip(
     }
 }
 
-private class TooltipAboveAnchorPositionProvider(private val gapPx: Int) : PopupPositionProvider {
+internal class TooltipAboveAnchorPositionProvider(private val gapPx: Int) : PopupPositionProvider {
     override fun calculatePosition(
         anchorBounds: IntRect,
         windowSize: IntSize,

--- a/ui/components/src/commonTest/kotlin/app/andy/ui/components/ToolContentFenceAstTest.kt
+++ b/ui/components/src/commonTest/kotlin/app/andy/ui/components/ToolContentFenceAstTest.kt
@@ -1,0 +1,31 @@
+package app.andy.ui.components
+
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ToolContentFenceAstTest {
+    @Test
+    fun nestedContentFenceStaysInsideListItem() {
+        val md = """
+            |- **content:**
+            |  ```kotlin
+            |      variant == Ghost
+            |  }
+            |  val shape = 1
+            |  ```
+        """.trimMargin()
+        val root = MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(md)
+        fun find(node: ASTNode, type: org.intellij.markdown.IElementType): ASTNode? {
+            if (node.type == type) return node
+            return node.children.firstNotNullOfOrNull { find(it, type) }
+        }
+        val listItem = find(root, MarkdownElementTypes.LIST_ITEM)
+        assertTrue(listItem != null, "expected list item")
+        val fenceInList = find(listItem, MarkdownElementTypes.CODE_FENCE)
+        assertTrue(fenceInList != null, "fence should nest under list item, not sit as a sibling")
+    }
+}


### PR DESCRIPTION
## Summary
- Nest and dedent Read/Grep tool-content Markdown fences under list labels, with language tags from path/content heuristics, so fragments no longer escape the bullet and look like body text.
- Show wall-clock timestamps on transcript bubbles and tighten copy/metadata layout under short user messages (compact copy control with ephemeral “Copied” feedback).
- Drop the mono expand chevron on tool rows and strengthen thinking-row code chrome so fences stay visually distinct.

## Test plan
- [x] `:domain:desktopTest` — `AcpToolCallPresentationTest`
- [x] `:ui:components:desktopTest` — `ToolContentFenceAstTest`
- [ ] Confirm a Read tool result with indented Kotlin nests under **content:** with a `kotlin` fence
- [ ] Confirm user/agent bubbles show a time stamp and compact copy that flashes “Copied”
- [ ] Spot-check expandable tool rows still expand without the old `>`/`v` chevron


Made with [Cursor](https://cursor.com)