### PR TITLE
Add andy remote subshell for SSH andyd access

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ andy chat list
 andy chat start --agent ClaudeCode --directory "$PWD" "Reply with pong"
 andy attach <taskId>
 andy project list
-andy --remote user@host.local chat list   # SSH-tunnel ~/.andy/andyd.sock
+andy remote user@host.local               # subshell: andy cmds hit remote andyd
+andy --remote user@host.local chat list   # one-shot SSH tunnel
 
 # Device / network scripting (same MCP socket)
 andy device list

--- a/cli/andy/src/attach.rs
+++ b/cli/andy/src/attach.rs
@@ -71,9 +71,11 @@ pub async fn attach_or_reattach(client: &mut McpClient, task_id: &str) -> Result
         WaitOutcome::Ready => {}
         WaitOutcome::TimedOut | WaitOutcome::TerminalStatus => {
             if parsed.get("tmuxAlive").and_then(|b| b.as_bool()) == Some(true) {
+                let socket = tmux::socket_args().join(" ");
                 bail!(
-                    "andyd reports a live session for {task_id}, but local `tmux -L andy` cannot see it\n\
-                     Hint: ensure the CLI and Andy share the same tmux server (check TMPDIR/TMUX_TMPDIR)"
+                    "andyd reports a live session for {task_id}, but `tmux {socket}` cannot see it\n\
+                     Hint: ensure the CLI and Andy share the same tmux server \
+                     (check TMPDIR/TMUX_TMPDIR, or use `andy remote` / ANDY_TMUX_SOCKET for remote hosts)"
                 );
             }
             bail!(

--- a/cli/andy/src/lib.rs
+++ b/cli/andy/src/lib.rs
@@ -18,6 +18,7 @@ pub mod events;
 pub mod file_picker;
 pub mod loading;
 pub mod mcp;
+pub mod remote;
 pub mod skills;
 pub mod slash;
 pub mod tmux;

--- a/cli/andy/src/main.rs
+++ b/cli/andy/src/main.rs
@@ -7,13 +7,13 @@ use andy_cli::device_cli::{
 };
 use andy_cli::file_picker;
 use andy_cli::mcp::{default_socket_path, McpClient};
+use andy_cli::remote::{self, RemoteTunnel};
 use andy_cli::tool_cmd::{self, ToolCmd};
 use andy_cli::tui;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use serde_json::{json, Value};
 use std::path::PathBuf;
-use std::process::Command;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -24,11 +24,11 @@ use std::process::Command;
 use `andy tool call` for any MCP tool by name. Device serial: --serial or ANDY_SERIAL."
 )]
 struct Cli {
-    /// Path to andyd unix socket
+    /// Path to andyd unix socket (also: ANDY_SOCKET)
     #[arg(long, global = true)]
     socket: Option<PathBuf>,
 
-    /// SSH host to tunnel the andyd socket from (macOS/Linux remote)
+    /// SSH host to tunnel the andyd socket from (one-shot; see also `andy remote`)
     #[arg(long, global = true)]
     remote: Option<String>,
 
@@ -83,6 +83,11 @@ enum Commands {
     /// Generic MCP tool list / call (full parity escape hatch)
     #[command(subcommand)]
     Tool(ToolCmd),
+    /// Open a shell tunneled to a remote andyd (GUI Host switcher)
+    Remote {
+        /// user@host or ssh Host alias
+        target: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -130,9 +135,22 @@ enum ProjectCmd {
 async fn main() -> Result<()> {
     daemon::ensure_unix_platform()?;
     let cli = Cli::parse();
-    let socket = resolve_socket(&cli).await?;
+
+    if let Commands::Remote { target } = &cli.command {
+        if cli.remote.is_some() {
+            anyhow::bail!("do not combine `andy remote` with --remote; use one or the other");
+        }
+        if cli.socket.is_some() {
+            anyhow::bail!("do not combine `andy remote` with --socket");
+        }
+        return remote::run_session(target);
+    }
+
+    // Keep the tunnel alive for the whole command when --remote is set.
+    let mut tunnel: Option<RemoteTunnel> = None;
+    let socket = resolve_socket(&cli, &mut tunnel)?;
     let json_out = cli.json;
-    let ensure_local_daemon = cli.remote.is_none();
+    let ensure_local_daemon = cli.remote.is_none() && std::env::var_os("ANDY_REMOTE").is_none();
 
     match cli.command {
         Commands::Tui => tui::run_dashboard(socket, ensure_local_daemon).await?,
@@ -144,6 +162,7 @@ async fn main() -> Result<()> {
             dispatch_command(cmd, &mut client, json_out).await?;
         }
     }
+    drop(tunnel);
     Ok(())
 }
 
@@ -255,47 +274,26 @@ async fn dispatch_command(cmd: Commands, client: &mut McpClient, json_out: bool)
         Commands::File(cmd) => device_cli::run_file(client, cmd, json_out).await?,
         Commands::Network(cmd) => device_cli::run_network(client, cmd, json_out).await?,
         Commands::Tool(cmd) => tool_cmd::run_tool(client, cmd, json_out).await?,
-        Commands::Tui => unreachable!("handled in main"),
+        Commands::Tui | Commands::Remote { .. } => unreachable!("handled in main"),
     }
     Ok(())
 }
 
-async fn resolve_socket(cli: &Cli) -> Result<PathBuf> {
-    let Some(remote) = cli.remote.as_deref() else {
-        return Ok(cli.socket.clone().unwrap_or_else(default_socket_path));
-    };
-
-    // Always bind the forward to a fresh local path so an existing ~/.andy/andyd.sock
-    // is never mistaken for the remote tunnel.
-    let local = PathBuf::from(format!(
-        "/tmp/andy-remote-local-{}.sock",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_file(&local);
-    let remote_path = "~/.andy/andyd.sock";
-    let status = Command::new("ssh")
-        .args([
-            "-f",
-            "-N",
-            "-o",
-            "ExitOnForwardFailure=yes",
-            "-L",
-            &format!("{}:{}", local.display(), remote_path),
-            remote,
-        ])
-        .status()
-        .with_context(|| format!("ssh tunnel to {remote}"))?;
-    if !status.success() {
-        anyhow::bail!("ssh tunnel to {remote} failed with status {status}");
+fn resolve_socket(cli: &Cli, tunnel_out: &mut Option<RemoteTunnel>) -> Result<PathBuf> {
+    if let Some(remote) = cli.remote.as_deref() {
+        let tunnel = remote::open_tunnel(remote)?;
+        let path = tunnel.local_socket().to_path_buf();
+        *tunnel_out = Some(tunnel);
+        return Ok(path);
     }
-    for _ in 0..20 {
-        if local.exists() {
-            return Ok(local);
+    if let Some(socket) = &cli.socket {
+        return Ok(socket.clone());
+    }
+    if let Ok(path) = std::env::var("ANDY_SOCKET") {
+        let path = PathBuf::from(path);
+        if !path.as_os_str().is_empty() {
+            return Ok(path);
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
-    anyhow::bail!(
-        "ssh tunnel to {remote} did not create local socket at {}",
-        local.display()
-    )
+    Ok(default_socket_path())
 }

--- a/cli/andy/src/remote.rs
+++ b/cli/andy/src/remote.rs
@@ -1,12 +1,14 @@
 //! SSH tunnel to a remote `andyd` socket — CLI counterpart of the GUI Host switcher.
 //!
 //! `andy remote user@host` opens a ControlMaster forward of the remote andyd Unix
-//! socket, then spawns a subshell with `ANDY_SOCKET` / `ANDY_REMOTE` set so subsequent
-//! `andy …` commands talk to that machine until the shell exits.
+//! socket **and** the remote `tmux -L andy` server, then spawns a subshell with
+//! `ANDY_SOCKET` / `ANDY_TMUX_SOCKET` / `ANDY_REMOTE` set so subsequent `andy …`
+//! commands (including Terminal-lane attach) talk to that machine until the shell
+//! exits.
 //!
 //! OpenSSH does not expand `~` in `-L` remote socket paths, so we resolve
-//! `$HOME/.andy/andyd.sock` to an absolute path over SSH before forwarding (same as
-//! the GUI Host switcher).
+//! `$HOME/.andy/andyd.sock` (and the tmux server path) to absolute paths over SSH
+//! before forwarding (same as the GUI Host switcher).
 
 use anyhow::{bail, Context, Result};
 use std::collections::hash_map::DefaultHasher;
@@ -18,10 +20,11 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-/// Live SSH ControlMaster + local Unix socket forward.
+/// Live SSH ControlMaster + local Unix socket forwards (andyd + tmux).
 pub struct RemoteTunnel {
     target: String,
     local_socket: PathBuf,
+    local_tmux: PathBuf,
     control_path: PathBuf,
     /// Parent dir `/tmp/andy-r{pid}` — removed on drop if empty.
     work_dir: PathBuf,
@@ -30,6 +33,10 @@ pub struct RemoteTunnel {
 impl RemoteTunnel {
     pub fn local_socket(&self) -> &Path {
         &self.local_socket
+    }
+
+    pub fn local_tmux(&self) -> &Path {
+        &self.local_tmux
     }
 
     pub fn target(&self) -> &str {
@@ -41,13 +48,20 @@ impl Drop for RemoteTunnel {
     fn drop(&mut self) {
         exit_master(&self.control_path);
         let _ = std::fs::remove_file(&self.local_socket);
+        let _ = std::fs::remove_file(&self.local_tmux);
         let _ = std::fs::remove_file(&self.control_path);
         let _ = std::fs::remove_dir(&self.work_dir);
+        // Clear process-local overrides set by open_tunnel for one-shot --remote.
+        if std::env::var_os("ANDY_TMUX_SOCKET").as_deref()
+            == Some(self.local_tmux.as_os_str())
+        {
+            std::env::remove_var("ANDY_TMUX_SOCKET");
+        }
     }
 }
 
-/// Open an SSH tunnel to `target`'s andyd socket. Caller must keep the returned
-/// value alive for the duration of use; Drop tears down the ControlMaster.
+/// Open an SSH tunnel to `target`'s andyd + tmux sockets. Caller must keep the
+/// returned value alive for the duration of use; Drop tears down the ControlMaster.
 pub fn open_tunnel(target: &str) -> Result<RemoteTunnel> {
     let target = target.trim();
     if target.is_empty() {
@@ -61,8 +75,10 @@ pub fn open_tunnel(target: &str) -> Result<RemoteTunnel> {
         .with_context(|| format!("create {}", work_dir.display()))?;
 
     let local_socket = work_dir.join(format!("{key}.a"));
+    let local_tmux = work_dir.join(format!("{key}.t"));
     let control_path = work_dir.join(format!("{key}.c"));
     let _ = std::fs::remove_file(&local_socket);
+    let _ = std::fs::remove_file(&local_tmux);
     let _ = std::fs::remove_file(&control_path);
 
     if let Err(err) = start_master(target, &control_path) {
@@ -70,8 +86,8 @@ pub fn open_tunnel(target: &str) -> Result<RemoteTunnel> {
         return Err(err);
     }
 
-    let remote_sock = match resolve_remote_andyd(target, &control_path) {
-        Ok(path) => path,
+    let remote_paths = match resolve_remote_paths(target, &control_path) {
+        Ok(paths) => paths,
         Err(err) => {
             exit_master(&control_path);
             let _ = std::fs::remove_file(&control_path);
@@ -80,18 +96,31 @@ pub fn open_tunnel(target: &str) -> Result<RemoteTunnel> {
         }
     };
 
-    if let Err(err) = add_unix_forward(&control_path, &local_socket, &remote_sock) {
+    if let Err(err) = add_unix_forward(&control_path, &local_socket, &remote_paths.andyd) {
         exit_master(&control_path);
         let _ = std::fs::remove_file(&control_path);
         let _ = std::fs::remove_dir(&work_dir);
         return Err(err).with_context(|| {
-            format!("forward {remote_sock} from {target}")
+            format!("forward {} from {target}", remote_paths.andyd)
+        });
+    }
+
+    // tmux may not exist until a Terminal-lane session is created; still forward so
+    // later attaches work (same as the GUI Host switcher).
+    if let Err(err) = add_unix_forward(&control_path, &local_tmux, &remote_paths.tmux) {
+        exit_master(&control_path);
+        let _ = std::fs::remove_file(&local_socket);
+        let _ = std::fs::remove_file(&control_path);
+        let _ = std::fs::remove_dir(&work_dir);
+        return Err(err).with_context(|| {
+            format!("forward {} from {target}", remote_paths.tmux)
         });
     }
 
     let tunnel = RemoteTunnel {
         target: target.to_string(),
         local_socket,
+        local_tmux,
         control_path,
         work_dir,
     };
@@ -105,30 +134,37 @@ pub fn open_tunnel(target: &str) -> Result<RemoteTunnel> {
 
     probe_mcp(tunnel.local_socket(), Duration::from_secs(10)).with_context(|| {
         format!(
-            "remote andyd at {remote_sock} did not speak MCP — is andyd running on {target}?"
+            "remote andyd at {} did not speak MCP — is andyd running on {target}?",
+            remote_paths.andyd
         )
     })?;
+
+    // One-shot `andy --remote … attach` runs in this process; point tmux at the forward.
+    std::env::set_var("ANDY_TMUX_SOCKET", tunnel.local_tmux());
 
     Ok(tunnel)
 }
 
-/// Connect to `target`, then spawn an interactive shell with `ANDY_SOCKET` pointing
-/// at the tunnel. Exiting the shell disconnects.
+/// Connect to `target`, then spawn an interactive shell with `ANDY_SOCKET` /
+/// `ANDY_TMUX_SOCKET` pointing at the tunnel. Exiting the shell disconnects.
 pub fn run_session(target: &str) -> Result<()> {
     let tunnel = open_tunnel(target)?;
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
     eprintln!(
-        "Connected to {} (andyd via SSH).\n\
+        "Connected to {} (andyd + tmux via SSH).\n\
          andy commands in this shell talk to the remote daemon.\n\
          Type exit (or Ctrl-D) to disconnect.\n\
-         ANDY_SOCKET={}",
+         ANDY_SOCKET={}\n\
+         ANDY_TMUX_SOCKET={}",
         tunnel.target(),
-        tunnel.local_socket().display()
+        tunnel.local_socket().display(),
+        tunnel.local_tmux().display()
     );
 
     let status = Command::new(&shell)
         .env("ANDY_SOCKET", tunnel.local_socket())
+        .env("ANDY_TMUX_SOCKET", tunnel.local_tmux())
         .env("ANDY_REMOTE", tunnel.target())
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -183,17 +219,26 @@ fn start_master(target: &str, control_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn resolve_remote_andyd(target: &str, control_path: &Path) -> Result<String> {
-    // Same probe as DesktopRemoteSessionService.resolveRemotePaths — expand $HOME and
-    // require a live socket before forwarding (OpenSSH will not expand ~ in -L paths).
+struct RemotePaths {
+    andyd: String,
+    tmux: String,
+}
+
+fn resolve_remote_paths(target: &str, control_path: &Path) -> Result<RemotePaths> {
+    // Same probe as DesktopRemoteSessionService.resolveRemotePaths — expand $HOME /
+    // TMUX_TMPDIR and require a live andyd socket before forwarding (OpenSSH will not
+    // expand ~ in -L paths). tmux may be absent until a session exists.
     let remote_command = concat!(
         "set -e; ",
         "ANDY_SOCK=\"$HOME/.andy/andyd.sock\"; ",
         "if [ ! -S \"$ANDY_SOCK\" ]; then echo \"andyd_missing:$ANDY_SOCK\" >&2; exit 2; fi; ",
-        "printf '%s\\n' \"$ANDY_SOCK\"",
+        "UID_N=$(id -u); ",
+        "TMP=${TMUX_TMPDIR:-${TMPDIR:-/tmp}}; ",
+        "TMUX_SOCK=\"$TMP/tmux-$UID_N/andy\"; ",
+        "printf '%s\\n%s\\n' \"$ANDY_SOCK\" \"$TMUX_SOCK\"",
     );
     let output = mux_ssh(control_path, target, &[remote_command])
-        .with_context(|| format!("resolve andyd socket on {target}"))?;
+        .with_context(|| format!("resolve andyd/tmux sockets on {target}"))?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     if output.status.code() == Some(2) || stderr.contains("andyd_missing") {
@@ -206,22 +251,26 @@ fn resolve_remote_andyd(target: &str, control_path: &Path) -> Result<String> {
         let detail = stderr.trim();
         if detail.is_empty() {
             bail!(
-                "could not resolve remote andyd socket on {target} (exit {})",
+                "could not resolve remote andyd/tmux sockets on {target} (exit {})",
                 output.status
             );
         }
-        bail!("could not resolve remote andyd socket on {target}: {detail}");
+        bail!("could not resolve remote andyd/tmux sockets on {target}: {detail}");
     }
-    let path = stdout
+    let lines: Vec<&str> = stdout
         .lines()
         .map(str::trim)
-        .find(|l| !l.is_empty())
-        .unwrap_or("")
-        .to_string();
-    if path.is_empty() || !path.starts_with('/') {
-        bail!("unexpected remote andyd path from {target}: {stdout:?}");
+        .filter(|l| !l.is_empty())
+        .collect();
+    if lines.len() < 2 {
+        bail!("unexpected remote andyd/tmux paths from {target}: {stdout:?}");
     }
-    Ok(path)
+    let andyd = lines[0].to_string();
+    let tmux = lines[1].to_string();
+    if !andyd.starts_with('/') || !tmux.starts_with('/') {
+        bail!("unexpected remote andyd/tmux paths from {target}: {stdout:?}");
+    }
+    Ok(RemotePaths { andyd, tmux })
 }
 
 fn add_unix_forward(control_path: &Path, local: &Path, remote_abs: &str) -> Result<()> {

--- a/cli/andy/src/remote.rs
+++ b/cli/andy/src/remote.rs
@@ -1,0 +1,343 @@
+//! SSH tunnel to a remote `andyd` socket — CLI counterpart of the GUI Host switcher.
+//!
+//! `andy remote user@host` opens a ControlMaster forward of the remote andyd Unix
+//! socket, then spawns a subshell with `ANDY_SOCKET` / `ANDY_REMOTE` set so subsequent
+//! `andy …` commands talk to that machine until the shell exits.
+//!
+//! OpenSSH does not expand `~` in `-L` remote socket paths, so we resolve
+//! `$HOME/.andy/andyd.sock` to an absolute path over SSH before forwarding (same as
+//! the GUI Host switcher).
+
+use anyhow::{bail, Context, Result};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Live SSH ControlMaster + local Unix socket forward.
+pub struct RemoteTunnel {
+    target: String,
+    local_socket: PathBuf,
+    control_path: PathBuf,
+    /// Parent dir `/tmp/andy-r{pid}` — removed on drop if empty.
+    work_dir: PathBuf,
+}
+
+impl RemoteTunnel {
+    pub fn local_socket(&self) -> &Path {
+        &self.local_socket
+    }
+
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+}
+
+impl Drop for RemoteTunnel {
+    fn drop(&mut self) {
+        exit_master(&self.control_path);
+        let _ = std::fs::remove_file(&self.local_socket);
+        let _ = std::fs::remove_file(&self.control_path);
+        let _ = std::fs::remove_dir(&self.work_dir);
+    }
+}
+
+/// Open an SSH tunnel to `target`'s andyd socket. Caller must keep the returned
+/// value alive for the duration of use; Drop tears down the ControlMaster.
+pub fn open_tunnel(target: &str) -> Result<RemoteTunnel> {
+    let target = target.trim();
+    if target.is_empty() {
+        bail!("remote target must be a non-empty user@host or ssh Host alias");
+    }
+
+    let pid = std::process::id();
+    let key = target_key(target);
+    let work_dir = PathBuf::from(format!("/tmp/andy-r{pid}"));
+    std::fs::create_dir_all(&work_dir)
+        .with_context(|| format!("create {}", work_dir.display()))?;
+
+    let local_socket = work_dir.join(format!("{key}.a"));
+    let control_path = work_dir.join(format!("{key}.c"));
+    let _ = std::fs::remove_file(&local_socket);
+    let _ = std::fs::remove_file(&control_path);
+
+    if let Err(err) = start_master(target, &control_path) {
+        let _ = std::fs::remove_dir(&work_dir);
+        return Err(err);
+    }
+
+    let remote_sock = match resolve_remote_andyd(target, &control_path) {
+        Ok(path) => path,
+        Err(err) => {
+            exit_master(&control_path);
+            let _ = std::fs::remove_file(&control_path);
+            let _ = std::fs::remove_dir(&work_dir);
+            return Err(err);
+        }
+    };
+
+    if let Err(err) = add_unix_forward(&control_path, &local_socket, &remote_sock) {
+        exit_master(&control_path);
+        let _ = std::fs::remove_file(&control_path);
+        let _ = std::fs::remove_dir(&work_dir);
+        return Err(err).with_context(|| {
+            format!("forward {remote_sock} from {target}")
+        });
+    }
+
+    let tunnel = RemoteTunnel {
+        target: target.to_string(),
+        local_socket,
+        control_path,
+        work_dir,
+    };
+
+    wait_for_socket_file(&tunnel.local_socket, Duration::from_secs(5)).with_context(|| {
+        format!(
+            "ssh tunnel to {target} did not create local socket at {}",
+            tunnel.local_socket.display()
+        )
+    })?;
+
+    probe_mcp(tunnel.local_socket(), Duration::from_secs(10)).with_context(|| {
+        format!(
+            "remote andyd at {remote_sock} did not speak MCP — is andyd running on {target}?"
+        )
+    })?;
+
+    Ok(tunnel)
+}
+
+/// Connect to `target`, then spawn an interactive shell with `ANDY_SOCKET` pointing
+/// at the tunnel. Exiting the shell disconnects.
+pub fn run_session(target: &str) -> Result<()> {
+    let tunnel = open_tunnel(target)?;
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    eprintln!(
+        "Connected to {} (andyd via SSH).\n\
+         andy commands in this shell talk to the remote daemon.\n\
+         Type exit (or Ctrl-D) to disconnect.\n\
+         ANDY_SOCKET={}",
+        tunnel.target(),
+        tunnel.local_socket().display()
+    );
+
+    let status = Command::new(&shell)
+        .env("ANDY_SOCKET", tunnel.local_socket())
+        .env("ANDY_REMOTE", tunnel.target())
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| format!("spawn shell {shell}"))?;
+
+    let code = status.code();
+    // Drop before process::exit so ControlMaster is torn down.
+    drop(tunnel);
+
+    match code {
+        Some(0) => Ok(()),
+        Some(code) => std::process::exit(code),
+        None => bail!("shell exited with {status}"),
+    }
+}
+
+fn start_master(target: &str, control_path: &Path) -> Result<()> {
+    let status = Command::new("ssh")
+        .args([
+            "-f",
+            "-N",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "ForwardAgent=no",
+            "-o",
+            "ConnectTimeout=20",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
+            "-o",
+            &format!("ControlPath={}", control_path.display()),
+            "-o",
+            "ControlMaster=yes",
+            "-o",
+            "ControlPersist=yes",
+            target,
+        ])
+        .status()
+        .with_context(|| format!("ssh master to {target}"))?;
+    if !status.success() {
+        bail!("ssh master to {target} failed with status {status}");
+    }
+    // ControlPath appears once the master is up.
+    wait_for_socket_file(control_path, Duration::from_secs(5))
+        .with_context(|| format!("ssh master to {target} did not create ControlPath"))?;
+    Ok(())
+}
+
+fn resolve_remote_andyd(target: &str, control_path: &Path) -> Result<String> {
+    // Same probe as DesktopRemoteSessionService.resolveRemotePaths — expand $HOME and
+    // require a live socket before forwarding (OpenSSH will not expand ~ in -L paths).
+    let remote_command = concat!(
+        "set -e; ",
+        "ANDY_SOCK=\"$HOME/.andy/andyd.sock\"; ",
+        "if [ ! -S \"$ANDY_SOCK\" ]; then echo \"andyd_missing:$ANDY_SOCK\" >&2; exit 2; fi; ",
+        "printf '%s\\n' \"$ANDY_SOCK\"",
+    );
+    let output = mux_ssh(control_path, target, &[remote_command])
+        .with_context(|| format!("resolve andyd socket on {target}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if output.status.code() == Some(2) || stderr.contains("andyd_missing") {
+        bail!(
+            "Remote andyd is not running (missing ~/.andy/andyd.sock). \
+             Start standalone andyd (launchd/systemd) on {target}, then retry."
+        );
+    }
+    if !output.status.success() {
+        let detail = stderr.trim();
+        if detail.is_empty() {
+            bail!(
+                "could not resolve remote andyd socket on {target} (exit {})",
+                output.status
+            );
+        }
+        bail!("could not resolve remote andyd socket on {target}: {detail}");
+    }
+    let path = stdout
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("")
+        .to_string();
+    if path.is_empty() || !path.starts_with('/') {
+        bail!("unexpected remote andyd path from {target}: {stdout:?}");
+    }
+    Ok(path)
+}
+
+fn add_unix_forward(control_path: &Path, local: &Path, remote_abs: &str) -> Result<()> {
+    let forward = format!("{}:{}", local.display(), remote_abs);
+    let status = Command::new("ssh")
+        .args([
+            "-O",
+            "forward",
+            "-L",
+            &forward,
+            "-o",
+            &format!("ControlPath={}", control_path.display()),
+            "unused",
+        ])
+        .status()
+        .context("ssh -O forward")?;
+    if !status.success() {
+        bail!("ssh -O forward failed with status {status}");
+    }
+    Ok(())
+}
+
+fn mux_ssh(control_path: &Path, target: &str, remote_args: &[&str]) -> Result<std::process::Output> {
+    let mut cmd = Command::new("ssh");
+    cmd.args([
+        "-o",
+        &format!("ControlPath={}", control_path.display()),
+        "-o",
+        "ControlMaster=no",
+        "-o",
+        "BatchMode=yes",
+        target,
+    ]);
+    cmd.args(remote_args);
+    cmd.output().context("ssh mux exec")
+}
+
+fn target_key(target: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    target.trim().hash(&mut hasher);
+    format!("{:08x}", hasher.finish() as u32)
+}
+
+fn exit_master(control_path: &Path) {
+    if !control_path.exists() {
+        return;
+    }
+    let _ = Command::new("ssh")
+        .args([
+            "-O",
+            "exit",
+            "-o",
+            &format!("ControlPath={}", control_path.display()),
+            "unused",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+fn wait_for_socket_file(path: &Path, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    bail!("timed out waiting for {}", path.display())
+}
+
+/// Confirm the forward reaches a live andyd (local accept alone is not enough —
+/// SSH accepts even when the remote Unix socket path is wrong, then resets).
+fn probe_mcp(path: &Path, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut last_err = None;
+    while Instant::now() < deadline {
+        match try_initialize(path) {
+            Ok(()) => return Ok(()),
+            Err(err) => last_err = Some(err),
+        }
+        thread::sleep(Duration::from_millis(150));
+    }
+    match last_err {
+        Some(err) => Err(err),
+        None => bail!("timed out probing {}", path.display()),
+    }
+}
+
+fn try_initialize(path: &Path) -> Result<()> {
+    let mut stream = UnixStream::connect(path)
+        .with_context(|| format!("connect {}", path.display()))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .ok();
+    stream
+        .set_write_timeout(Some(Duration::from_secs(3)))
+        .ok();
+    let init = concat!(
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"#,
+        r#""protocolVersion":"2024-11-05","capabilities":{},"#,
+        r#""clientInfo":{"name":"andy-cli-probe","version":"0"}}}"#,
+        "\n",
+    );
+    stream
+        .write_all(init.as_bytes())
+        .context("write initialize")?;
+    let mut buf = [0u8; 4096];
+    let n = stream.read(&mut buf).context("read initialize result")?;
+    if n == 0 {
+        bail!("empty response from andyd (broken SSH unix forward?)");
+    }
+    let text = String::from_utf8_lossy(&buf[..n]);
+    if !text.contains("jsonrpc") {
+        bail!("unexpected initialize response: {}", text.trim());
+    }
+    Ok(())
+}

--- a/cli/andy/src/tmux.rs
+++ b/cli/andy/src/tmux.rs
@@ -43,14 +43,32 @@ fn which_tmux() -> Option<String> {
     None
 }
 
+/// Socket selector for Andy's tmux server.
+///
+/// - Absolute `ANDY_TMUX_SOCKET` path → `tmux -S <path>` (SSH-forwarded remote server)
+/// - Bare name → `tmux -L <name>` (defaults to `andy`)
+pub fn socket_args() -> Vec<String> {
+    if let Ok(raw) = std::env::var("ANDY_TMUX_SOCKET") {
+        let value = raw.trim();
+        if !value.is_empty() {
+            if value.starts_with('/') {
+                return vec!["-S".into(), value.to_string()];
+            }
+            return vec!["-L".into(), value.to_string()];
+        }
+    }
+    vec!["-L".into(), "andy".into()]
+}
+
 fn tmux_command(args: &[&str]) -> Result<Command> {
     let mut command = Command::new(tmux_binary()?);
+    command.args(socket_args());
     command.args(args);
     Ok(command)
 }
 
 /// Run a tmux command with null stdio; returns Err when the process fails to spawn
-/// or exits non-zero.
+/// or exits non-zero. Socket selector is prepended automatically.
 pub fn run_tmux(args: &[&str]) -> Result<()> {
     let status = tmux_command(args)?
         .stdin(Stdio::null())
@@ -68,7 +86,7 @@ pub fn has_session(task_id: &str) -> bool {
     let name = session_name(task_id);
     // Null stderr: a missing Andy tmux server otherwise floods the TTY with
     // "no server running on /private/tmp/tmux-*/andy" during attach polls.
-    tmux_command(&["-L", "andy", "has-session", "-t", &name])
+    tmux_command(&["has-session", "-t", &name])
         .ok()
         .and_then(|mut command| {
             command
@@ -91,7 +109,7 @@ pub fn session_looks_broken(task_id: &str) -> bool {
         return false;
     }
     let name = session_name(task_id);
-    let output = tmux_command(&["-L", "andy", "capture-pane", "-p", "-t", &name])
+    let output = tmux_command(&["capture-pane", "-p", "-t", &name])
         .ok()
         .and_then(|mut command| command.output().ok())
         .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
@@ -110,8 +128,6 @@ pub fn detach_hint() -> &'static str {
 fn ensure_detach_keys() {
     // Idempotent; also covers older andyd builds before these were in SERVER_OPTIONS.
     let _ = tmux_command(&[
-        "-L",
-        "andy",
         "bind-key",
         "-n",
         "F12",
@@ -153,7 +169,7 @@ pub fn attach(task_id: &str, title: &str, status: &str) -> Result<()> {
     viewer_chrome::print_attach_banner(task_id, title, status);
     // Best-effort: older/broken tmux still gets the banner + detach keys.
     let _ = viewer_chrome::apply_tmux_session_chrome(task_id, title, status);
-    let attach_status = tmux_command(&["-L", "andy", "attach-session", "-t", &name])?
+    let attach_status = tmux_command(&["attach-session", "-t", &name])?
         .status()
         .context("spawn tmux attach")?;
     let _ = viewer_chrome::clear_tmux_session_chrome(task_id);
@@ -161,4 +177,49 @@ pub fn attach(task_id: &str, title: &str, status: &str) -> Result<()> {
         bail!("tmux attach failed for session {name}");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_args_default_to_andy_server() {
+        // Avoid depending on ambient ANDY_TMUX_SOCKET from the test runner.
+        let prev = std::env::var("ANDY_TMUX_SOCKET").ok();
+        std::env::remove_var("ANDY_TMUX_SOCKET");
+        assert_eq!(socket_args(), vec!["-L".to_string(), "andy".to_string()]);
+        match prev {
+            Some(v) => std::env::set_var("ANDY_TMUX_SOCKET", v),
+            None => std::env::remove_var("ANDY_TMUX_SOCKET"),
+        }
+    }
+
+    #[test]
+    fn socket_args_absolute_path_uses_dash_s() {
+        let prev = std::env::var("ANDY_TMUX_SOCKET").ok();
+        std::env::set_var("ANDY_TMUX_SOCKET", "/tmp/andy-remote-tmux.sock");
+        assert_eq!(
+            socket_args(),
+            vec!["-S".to_string(), "/tmp/andy-remote-tmux.sock".to_string()]
+        );
+        match prev {
+            Some(v) => std::env::set_var("ANDY_TMUX_SOCKET", v),
+            None => std::env::remove_var("ANDY_TMUX_SOCKET"),
+        }
+    }
+
+    #[test]
+    fn socket_args_named_server_uses_dash_l() {
+        let prev = std::env::var("ANDY_TMUX_SOCKET").ok();
+        std::env::set_var("ANDY_TMUX_SOCKET", "andy-test");
+        assert_eq!(
+            socket_args(),
+            vec!["-L".to_string(), "andy-test".to_string()]
+        );
+        match prev {
+            Some(v) => std::env::set_var("ANDY_TMUX_SOCKET", v),
+            None => std::env::remove_var("ANDY_TMUX_SOCKET"),
+        }
+    }
 }

--- a/cli/andy/src/viewer_chrome.rs
+++ b/cli/andy/src/viewer_chrome.rs
@@ -65,8 +65,6 @@ pub fn apply_tmux_session_chrome(task_id: &str, title: &str, status: &str) -> Re
     // tmux status-left interprets `#` — escape by doubling.
     let safe = header.replace('#', "##");
     tmux::run_tmux(&[
-        "-L",
-        "andy",
         "set-option",
         "-t",
         &name,
@@ -122,7 +120,7 @@ pub fn apply_tmux_session_chrome(task_id: &str, title: &str, status: &str) -> Re
 pub fn clear_tmux_session_chrome(task_id: &str) -> Result<()> {
     let name = tmux::session_name(task_id);
     // Best-effort: session may already be gone after detach/kill.
-    let _ = tmux::run_tmux(&["-L", "andy", "set-option", "-t", &name, "status", "off"]);
+    let _ = tmux::run_tmux(&["set-option", "-t", &name, "status", "off"]);
     Ok(())
 }
 

--- a/docs/ANDYD.md
+++ b/docs/ANDYD.md
@@ -37,7 +37,8 @@ Optional override: `ANDY_TMUX=/path/to/tmux`
 | `tmux -L andy-test[-wN]` | Isolated socket(s) used by `desktopTest` so tests cannot `kill-server` live chats; parallel forks append `-w<worker>` |
 | `andy-task-<taskId>` | Per-task tmux session name |
 
-Optional socket override: `ANDY_TMUX_SOCKET=name` (defaults to `andy`).
+Optional socket override: `ANDY_TMUX_SOCKET=name` (defaults to `andy`), or an absolute
+path for `tmux -S` (used by `andy remote` / `--remote` for the forwarded remote server).
 
 ## Run the daemon
 
@@ -151,9 +152,10 @@ andy remote user@mac.local     # subshell tunneled to remote andyd (exit to disc
 andy --remote user@mac.local chat list   # one-shot SSH tunnel
 ```
 
-`andy remote` mirrors the GUI Host switcher: it forwards `~/.andy/andyd.sock` over
-SSH, sets `ANDY_SOCKET` / `ANDY_REMOTE` in a child shell, then tears the tunnel down
-when that shell exits. The remote host must already be running `andyd`.
+`andy remote` mirrors the GUI Host switcher: it forwards `~/.andy/andyd.sock` and the
+remote `tmux -L andy` server over SSH, sets `ANDY_SOCKET` / `ANDY_TMUX_SOCKET` /
+`ANDY_REMOTE` in a child shell, then tears the tunnel down when that shell exits.
+The remote host must already be running `andyd`.
 
 ### Remote access from mobile (SSH + Tailscale)
 

--- a/docs/ANDYD.md
+++ b/docs/ANDYD.md
@@ -147,8 +147,13 @@ andy chat start --no-attach --agent ClaudeCode "fire and forget JSON only"
 andy attach <taskId>           # ACP: native viewer · Terminal: tmux (or quiet reattach)
 andy tui                       # n new chat · grouped projects · a / Enter attach
 andy chat resume <taskId> "…"  # when quiet reattach isn't possible
-andy --remote user@mac.local chat list   # SSH tunnel the socket
+andy remote user@mac.local     # subshell tunneled to remote andyd (exit to disconnect)
+andy --remote user@mac.local chat list   # one-shot SSH tunnel
 ```
+
+`andy remote` mirrors the GUI Host switcher: it forwards `~/.andy/andyd.sock` over
+SSH, sets `ANDY_SOCKET` / `ANDY_REMOTE` in a child shell, then tears the tunnel down
+when that shell exits. The remote host must already be running `andyd`.
 
 ### Remote access from mobile (SSH + Tailscale)
 


### PR DESCRIPTION
## Summary
- Add `andy remote user@host` — ControlMaster SSH tunnel + interactive subshell with `ANDY_SOCKET` / `ANDY_REMOTE` (CLI counterpart of the GUI Host switcher)
- Harden one-shot `--remote` to reuse the same tunnel helper (absolute remote socket resolution, MCP probe, proper teardown)
- Honor `ANDY_SOCKET` for socket resolution and document both remote modes in README / ANDYD

## Test plan
- [ ] `cargo check --manifest-path cli/andy/Cargo.toml`
- [ ] `andy remote <reachable-mac>` then `andy chat list` talks to remote andyd; `exit` tears down the tunnel
- [ ] `andy --remote <host> chat list` still works as a one-shot
- [ ] Combining `andy remote` with `--remote` / `--socket` errors clearly
- [ ] Remote without running andyd fails with a clear “start andyd” message


Made with [Cursor](https://cursor.com)