### PR TITLE
Fix Ctrl+C SIGINT when AWT delivers ETX keyChar

### DIFF
--- a/data/agents/src/desktopMain/kotlin/app/andy/terminal/rust/RustTerminalKeys.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/terminal/rust/RustTerminalKeys.kt
@@ -82,29 +82,45 @@ internal fun encodeTerminalKey(event: KeyEvent): ByteArray? {
 }
 
 private fun encodeCtrl(event: KeyEvent): ByteArray? {
-    // Prefer the physical key. AWT KEY_PRESSED for Ctrl+letter sets keyChar to the C0
-    // control (Ctrl+C → ETX 0x03), not the letter — deriving from utf16CodePoint alone
-    // would lowercase 0x03 and miss the 'c' → 0x03 mapping, so SIGINT never reached the PTY.
-    ctrlLetterFromKey(event.key)?.let { letter ->
-        return byteArrayOf((letter.code - 'a'.code + 1).toByte())
-    }
     val cp = event.utf16CodePoint
-    if (cp in 0x01..0x1F) {
-        return byteArrayOf(cp.toByte())
+    // AWT KEY_PRESSED for Ctrl+letter sets keyChar to the C0 control (Ctrl+C → ETX
+    // 0x03), not the letter. Prefer the physical key only in that case (or when no
+    // useful char arrived). Printable code points with Ctrl held — e.g. AltGr exposed
+    // as Ctrl+Alt producing '@' — must fall through to the UTF-8 path.
+    val codePointIsC0OrMissing =
+        cp == 0 || cp == KEY_CHAR_UNDEFINED || cp in 0x01..0x1F
+
+    if (codePointIsC0OrMissing) {
+        ctrlLetterFromKey(event.key)?.let { letter ->
+            return byteArrayOf((letter.code - 'a'.code + 1).toByte())
+        }
+        // Named keys have explicit encodings in encodeTerminalKey; don't override
+        // them with AWT's raw C0 (Ctrl+Enter → LF, Ctrl+Backspace → BS).
+        if (event.key.hasNamedTerminalEncoding()) return null
+        if (cp in 0x01..0x1F) {
+            return byteArrayOf(cp.toByte())
+        }
+        return null
     }
-    val ch = when {
-        cp != 0 &&
-            cp != KEY_CHAR_UNDEFINED &&
-            Character.isValidCodePoint(cp) -> cp.toChar().lowercaseChar()
-        else -> return null
-    }
+
+    if (!Character.isValidCodePoint(cp)) return null
+    val ch = cp.toChar().lowercaseChar()
     val ctrl = when (ch) {
+        in 'a'..'z' -> ch.code - 'a'.code + 1
         '[' -> 0x1B
         '\\' -> 0x1C
         ']' -> 0x1D
         else -> return null
     }
     return byteArrayOf(ctrl.toByte())
+}
+
+private fun Key.hasNamedTerminalEncoding(): Boolean = when (this) {
+    Key.Enter, Key.NumPadEnter, Key.Tab, Key.Backspace, Key.Escape,
+    Key.DirectionUp, Key.DirectionDown, Key.DirectionLeft, Key.DirectionRight,
+    Key.MoveHome, Key.MoveEnd, Key.PageUp, Key.PageDown, Key.Delete,
+    -> true
+    else -> false
 }
 
 private fun ctrlLetterFromKey(key: Key): Char? = when (key) {

--- a/data/agents/src/desktopMain/kotlin/app/andy/terminal/rust/RustTerminalKeys.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/terminal/rust/RustTerminalKeys.kt
@@ -82,38 +82,23 @@ internal fun encodeTerminalKey(event: KeyEvent): ByteArray? {
 }
 
 private fun encodeCtrl(event: KeyEvent): ByteArray? {
+    // Prefer the physical key. AWT KEY_PRESSED for Ctrl+letter sets keyChar to the C0
+    // control (Ctrl+C → ETX 0x03), not the letter — deriving from utf16CodePoint alone
+    // would lowercase 0x03 and miss the 'c' → 0x03 mapping, so SIGINT never reached the PTY.
+    ctrlLetterFromKey(event.key)?.let { letter ->
+        return byteArrayOf((letter.code - 'a'.code + 1).toByte())
+    }
+    val cp = event.utf16CodePoint
+    if (cp in 0x01..0x1F) {
+        return byteArrayOf(cp.toByte())
+    }
     val ch = when {
-        event.utf16CodePoint != 0 && Character.isValidCodePoint(event.utf16CodePoint) ->
-            event.utf16CodePoint.toChar().lowercaseChar()
-        else -> ctrlLetterFromKey(event.key) ?: return null
+        cp != 0 &&
+            cp != KEY_CHAR_UNDEFINED &&
+            Character.isValidCodePoint(cp) -> cp.toChar().lowercaseChar()
+        else -> return null
     }
     val ctrl = when (ch) {
-        'a' -> 0x01
-        'b' -> 0x02
-        'c' -> 0x03
-        'd' -> 0x04
-        'e' -> 0x05
-        'f' -> 0x06
-        'g' -> 0x07
-        'h' -> 0x08
-        'i' -> 0x09
-        'j' -> 0x0A
-        'k' -> 0x0B
-        'l' -> 0x0C
-        'm' -> 0x0D
-        'n' -> 0x0E
-        'o' -> 0x0F
-        'p' -> 0x10
-        'q' -> 0x11
-        'r' -> 0x12
-        's' -> 0x13
-        't' -> 0x14
-        'u' -> 0x15
-        'v' -> 0x16
-        'w' -> 0x17
-        'x' -> 0x18
-        'y' -> 0x19
-        'z' -> 0x1A
         '[' -> 0x1B
         '\\' -> 0x1C
         ']' -> 0x1D

--- a/data/agents/src/desktopTest/kotlin/app/andy/terminal/rust/RustTerminalCanvasSupportTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/terminal/rust/RustTerminalCanvasSupportTest.kt
@@ -46,6 +46,31 @@ class RustTerminalCanvasSupportTest {
     }
 
     @Test
+    fun altGrPrintableSurvivesWhenAwtReportsCtrl() {
+        // German AltGr+Q → '@'; AWT often exposes AltGr as Ctrl+Alt with a printable code point.
+        assertEquals(
+            listOf('@'.code),
+            encodeTerminalKey(keyEvent(Key.Q, ctrl = true, codePoint = '@'.code))?.map { it.toInt() and 0xFF },
+        )
+    }
+
+    @Test
+    fun ctrlEnterKeepsCarriageReturnWhenAwtDeliversLf() {
+        assertEquals(
+            listOf('\r'.code),
+            encodeTerminalKey(keyEvent(Key.Enter, ctrl = true, codePoint = 0x0A))?.map { it.toInt() and 0xFF },
+        )
+    }
+
+    @Test
+    fun ctrlBackspaceKeepsDeleteWhenAwtDeliversBs() {
+        assertEquals(
+            listOf(0x7F),
+            encodeTerminalKey(keyEvent(Key.Backspace, ctrl = true, codePoint = 0x08))?.map { it.toInt() and 0xFF },
+        )
+    }
+
+    @Test
     fun modifierOnlyKeysAreNotEncoded() {
         assertNull(encodeTerminalKey(keyEvent(Key.ShiftLeft)))
         assertNull(encodeTerminalKey(keyEvent(Key.ShiftRight)))

--- a/data/agents/src/desktopTest/kotlin/app/andy/terminal/rust/RustTerminalCanvasSupportTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/terminal/rust/RustTerminalCanvasSupportTest.kt
@@ -29,6 +29,23 @@ class RustTerminalCanvasSupportTest {
     }
 
     @Test
+    fun ctrlCEncodesSigintWhenAwtDeliversEtxCodePoint() {
+        // Real Compose Desktop events: AWT keyChar for Ctrl+C is ETX (0x03), not 'c'.
+        assertEquals(
+            listOf(0x03),
+            encodeTerminalKey(keyEvent(Key.C, ctrl = true, codePoint = 0x03))?.map { it.toInt() and 0xFF },
+        )
+    }
+
+    @Test
+    fun ctrlDEncodesEofWhenAwtDeliversEotCodePoint() {
+        assertEquals(
+            listOf(0x04),
+            encodeTerminalKey(keyEvent(Key.D, ctrl = true, codePoint = 0x04))?.map { it.toInt() and 0xFF },
+        )
+    }
+
+    @Test
     fun modifierOnlyKeysAreNotEncoded() {
         assertNull(encodeTerminalKey(keyEvent(Key.ShiftLeft)))
         assertNull(encodeTerminalKey(keyEvent(Key.ShiftRight)))


### PR DESCRIPTION
## Summary
- Prefer the physical key when encoding Ctrl chords so Compose Desktop / AWT KEY_PRESSED events that set `utf16CodePoint` to the C0 control (Ctrl+C → ETX `0x03`) still map to the correct PTY byte.
- Fall back to raw C0 code points and remaining punctuation chords (`[`, `\`, `]`).
- Add regression tests for AWT ETX/EOT code points on Ctrl+C / Ctrl+D.

## Test plan
- [x] `./gradlew :data:agents:desktopTest --tests 'app.andy.terminal.rust.RustTerminalCanvasSupportTest'`
- [ ] In a Rust terminal canvas session, Ctrl+C interrupts a running foreground process (SIGINT reaches the PTY)
- [ ] Ctrl+D still sends EOF as expected


Made with [Cursor](https://cursor.com)