### PR TITLE
Linux mirror/agent fixes and durable ACP connection recovery

### DIFF
--- a/composeApp/src/desktopMain/kotlin/app/andy/desktop/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/andy/desktop/Main.kt
@@ -30,6 +30,7 @@ import app.andy.desktop.service.DesktopWorkspaceStore
 import app.andy.desktop.service.PendingAgentTaskOpen
 import app.andy.di.openAndyDesktopGraph
 import app.andy.desktop.service.resolveRuntimeMode
+import app.andy.desktop.service.mirror.GpuMirrorHostRegistry
 import app.andy.desktop.service.mirror.GpuMirrorJni
 import app.andy.desktop.service.mirror.NativeMirrorHostRegistry
 import app.andy.model.IosTargetKind
@@ -317,6 +318,11 @@ fun main() {
                         appFocus.focused = true
                         services.agentRuns.setAppForeground(appFocus.isForeground())
                         consumePendingOpen()
+                        // Only restore overlays when a Live host is still showing. Blind
+                        // resume remounts warm-detached presenters over other tabs.
+                        if (GpuMirrorJni.isAvailable() && GpuMirrorHostRegistry.anyHostShowing()) {
+                            GpuMirrorJni.resumeAfterDesktopSwitch()
+                        }
                     }
 
                     override fun windowDeactivated(event: java.awt.event.WindowEvent) {

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -3302,21 +3302,11 @@ class DesktopAgentRunService(
     }
 
     private fun stopNow(taskId: String) {
-        val recovering = currentTask(taskId)?.takeIf { it.connectionRecovery != null }
-        if (recovering != null) {
+        if (currentTask(taskId)?.connectionRecovery != null) {
+            // Cancel the delayed resume, then fall through so a live ACP child is torn down
+            // the same way as a normal Stop (instead of leaving the provider session running).
             connectionRecoveryJobs.remove(taskId)?.cancel()
-            updateTask(taskId) {
-                it.copy(
-                    status = AgentStatus.Done,
-                    stoppedByUser = true,
-                    resumable = false,
-                    connectionRecovery = null,
-                    finishedAtMillis = System.currentTimeMillis(),
-                    unread = false,
-                )
-            }
-            scope.launch { persist() }
-            return
+            updateTask(taskId) { it.copy(connectionRecovery = null) }
         }
         val acpTask = currentTask(taskId)?.takeIf { it.lane == AgentLaneKind.Acp }
         if (acpTask != null) {
@@ -5719,10 +5709,11 @@ class DesktopAgentRunService(
             if (shouldFlushEditBatchBefore(event)) needsFlush = true
             if (event is AgentEvent.ToolCall && cwd != null) trackEditToolCall(taskId, event, cwd)
         }
-        appendEventsDirect(taskId, events)
-        if (task?.connectionRecovery != null && events.any(::isConnectionRecoveryProgress)) {
+        val accepted = appendEventsDirect(taskId, events)
+        if (task?.connectionRecovery != null && accepted.any(::isConnectionRecoveryProgress)) {
             // A provider produced durable new work after the last retry. Future transport drops
             // receive a fresh bounded budget instead of being counted as one endless outage.
+            // Only accepted events count — replay filtered during session reopen is not progress.
             clearAcpRecoveryState(taskId)
         }
         if (needsFlush) {
@@ -5740,8 +5731,8 @@ class DesktopAgentRunService(
         else -> false
     }
 
-    private fun appendEventsDirect(taskId: String, events: List<AgentEvent>) {
-        if (events.isEmpty()) return
+    private fun appendEventsDirect(taskId: String, events: List<AgentEvent>): List<AgentEvent> {
+        if (events.isEmpty()) return emptyList()
         val task = currentTask(taskId)
         val isAcp = task?.lane == AgentLaneKind.Acp
         val flow = eventFlows.computeIfAbsent(taskId) {
@@ -5771,7 +5762,7 @@ class DesktopAgentRunService(
                 }
             }.first
         }
-        if (accepted.isEmpty()) return
+        if (accepted.isEmpty()) return emptyList()
         accepted.filterIsInstance<AgentEvent.AvailableCommands>().forEach { event ->
             task?.let { recordSlashCommands(it.agent, it.worktreePath ?: it.cwd, event.commands) }
         }
@@ -5789,6 +5780,7 @@ class DesktopAgentRunService(
             }
             if (isAcp) next else next.takeLast(MAX_TERMINAL_EVENTS_IN_MEMORY)
         }
+        return accepted
     }
 
     private fun mergeAcpTranscriptEvent(

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -68,14 +68,16 @@ import app.andy.model.ProjectVerificationVerdict
 import app.andy.model.ProjectWorkflowStage
 import app.andy.model.ProjectWorkflowState
 import app.andy.model.toProjectProfile
-import app.andy.model.CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS
 import app.andy.model.CONNECTION_STALL_RETRY_PROMPT
-import app.andy.model.MAX_CONNECTION_STALL_AUTO_RETRIES
-import app.andy.model.RESOURCE_EXHAUSTED_AUTO_RETRY_BACKOFF_MS
+import app.andy.model.AgentConnectionRecovery
+import app.andy.model.AgentConnectionRecoveryReason
 import app.andy.model.coalesceAcpTranscriptEvents
 import app.andy.model.coalesceAgentStreamDeltas
+import app.andy.model.connectionStallRetryBackoffMillis
 import app.andy.model.hasRetriableConnectionStall
 import app.andy.model.hasRetriableResourceExhausted
+import app.andy.model.isRetriableConnectionStallMessage
+import app.andy.model.maxAutomaticAttempts
 import app.andy.model.planTextFromAcpTranscript
 import app.andy.model.followUpCliPayload
 import app.andy.model.followUpPromptForLiveTerminal
@@ -230,8 +232,10 @@ class DesktopAgentRunService(
     /** While reconnecting an ACP session, drop provider history replay into the transcript. */
     private val acpSuppressProviderReplay = ConcurrentHashMap.newKeySet<String>()
     private val acpProviderReplayScratch = ConcurrentHashMap<String, StringBuilder>()
-    /** Automatic resume attempts per task turn after a provider connection stall. */
-    private val connectionStallAutoRetries = ConcurrentHashMap<String, Int>()
+    /** One scheduled bounded continuation per stalled ACP task. State itself lives on [AgentTask]. */
+    private val connectionRecoveryJobs = ConcurrentHashMap<String, Job>()
+    /** Lets [resume] distinguish the scheduler's silent prompt from a user-initiated retry. */
+    private val scheduledConnectionRecoveryResumes = ConcurrentHashMap.newKeySet<String>()
     /** Outstanding ACP session-mode syncs; [resume] awaits these so Implement doesn't race plan→agent. */
     private val acpPlanModeSyncJobs = ConcurrentHashMap<String, Job>()
 
@@ -325,6 +329,7 @@ class DesktopAgentRunService(
             repairCompletedSpecWorkflowStates()
             reconcileStuckWorkflowArtifacts()
             ready.complete(Unit)
+            restoreConnectionRecoveryJobs()
             // A crash skips the shutdown hook, so a previous session's disposable directory can
             // survive. Only stale roots are swept, so a second running instance is untouched.
             withContext(Dispatchers.IO) { runCatching { TemporaryChatArtifacts.sweepOrphans() } }
@@ -1499,8 +1504,16 @@ class DesktopAgentRunService(
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
     ) {
-        val existing = currentTask(taskId) ?: return
+        var existing = currentTask(taskId) ?: return
         if (existing.userInputRequest != null) return
+        val scheduledRecovery = taskId in scheduledConnectionRecoveryResumes
+        if (!scheduledRecovery && existing.connectionRecovery != null) {
+            // Any explicit user continuation takes precedence over a delayed automatic one.
+            connectionRecoveryJobs.remove(taskId)?.cancel()
+            updateTask(taskId) { current -> current.copy(connectionRecovery = null) }
+            existing = currentTask(taskId) ?: return
+            scope.launch { persist() }
+        }
         // Keep the chat's original provenance; a contextual follow-up only fills an empty one.
         val task = if (provenance != null && existing.provenance == null) {
             existing.copy(provenance = provenance)
@@ -2045,9 +2058,10 @@ class DesktopAgentRunService(
             contextTokens = null,
             contextWindowTokens = null,
             unread = false,
+            connectionRecovery = null,
         )
         store.deleteTaskArtifacts(taskId)
-        connectionStallAutoRetries.remove(taskId)
+        connectionRecoveryJobs.remove(taskId)?.cancel()
         eventFlows[taskId]?.value = emptyList()
         upsertTask(retried)
         persist()
@@ -2776,39 +2790,12 @@ class DesktopAgentRunService(
         if (deferAcpFinishIfAwaitingInput(taskId)) return promptSuccess
 
         val stalled = transcriptHasConnectionStall(taskId)
-        val attempt = connectionStallAutoRetries.getOrDefault(taskId, 0)
-        if (
-            stalled &&
-            attempt < MAX_CONNECTION_STALL_AUTO_RETRIES &&
-            acpManager.isAlive(taskId)
-        ) {
-            val nextAttempt = attempt + 1
-            val resourceExhausted = transcriptHasResourceExhausted(taskId)
-            connectionStallAutoRetries[taskId] = nextAttempt
-            appendLaunchDiagnostics(taskId, "connectionStallAutoRetry=$nextAttempt\n")
-            updateTask(taskId) {
-                it.copy(
-                    status = AgentStatus.Working,
-                    errorMessage = null,
-                    finishedAtMillis = null,
-                    exitCode = null,
-                )
-            }
-            appendEvents(
-                taskId,
-                listOf(AgentEvent.UserMessage(System.currentTimeMillis(), CONNECTION_STALL_RETRY_PROMPT)),
-            )
-            val backoffMs = if (resourceExhausted) {
-                RESOURCE_EXHAUSTED_AUTO_RETRY_BACKOFF_MS * nextAttempt
-            } else {
-                CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS * nextAttempt
-            }
-            delay(backoffMs)
-            val retrySuccess = acpManager.prompt(taskId, CONNECTION_STALL_RETRY_PROMPT, emptyList())
-            return completeAcpPromptTurn(taskId, retrySuccess)
+        if (!stalled) {
+            clearAcpRecoveryState(taskId)
+        } else if (scheduleStalledAcpRecovery(taskId)) {
+            return true
         }
 
-        connectionStallAutoRetries.remove(taskId)
         val outcome = acpManager.awaitRunOutcome(taskId)
         val stillStalled = transcriptHasConnectionStall(taskId)
         val recovered = promptSuccess && !stillStalled
@@ -2836,6 +2823,96 @@ class DesktopAgentRunService(
             stopReason = outcome.stopReason,
         )
         return recovered || resumableAfterStall
+    }
+
+    /** Records a bounded, durable continuation rather than recursively blocking this run job. */
+    private fun scheduleStalledAcpRecovery(taskId: String): Boolean {
+        val task = currentTask(taskId) ?: return false
+        if (!acpManager.isAlive(taskId)) return false
+        val reason = if (transcriptHasResourceExhausted(taskId)) {
+            AgentConnectionRecoveryReason.ResourceExhausted
+        } else {
+            AgentConnectionRecoveryReason.Transport
+        }
+        val prior = task.connectionRecovery?.takeIf { it.reason == reason && !it.paused }
+        val nextAttempt = (prior?.attemptsWithoutProgress ?: 0) + 1
+        val now = System.currentTimeMillis()
+        val recovery = if (nextAttempt > reason.maxAutomaticAttempts()) {
+            AgentConnectionRecovery(
+                attemptsWithoutProgress = prior?.attemptsWithoutProgress ?: reason.maxAutomaticAttempts(),
+                reason = reason,
+                paused = true,
+            )
+        } else {
+            AgentConnectionRecovery(
+                attemptsWithoutProgress = nextAttempt,
+                reason = reason,
+                nextRetryAtMillis = now + connectionStallRetryBackoffMillis(nextAttempt, reason),
+            )
+        }
+        updateTask(taskId) { current ->
+            current.copy(
+                status = AgentStatus.Done,
+                exitCode = null,
+                errorMessage = null,
+                finishedAtMillis = now,
+                resumable = true,
+                interrupted = false,
+                statusConfident = false,
+                connectionRecovery = recovery,
+            )
+        }
+        appendLaunchDiagnostics(
+            taskId,
+            "connectionStallRecovery=${recovery.reason}:${recovery.attemptsWithoutProgress}:" +
+                "${if (recovery.paused) "paused" else "scheduled"}\n",
+        )
+        scope.launch {
+            persist()
+            if (!recovery.paused) scheduleConnectionRecovery(taskId)
+        }
+        return true
+    }
+
+    /** Rebuilds persisted scheduled continuations after `andyd` or the desktop client starts. */
+    private fun restoreConnectionRecoveryJobs() {
+        _tasks.value.forEach { task ->
+            task.connectionRecovery?.takeIf { !it.paused && it.nextRetryAtMillis != null }?.let {
+                scheduleConnectionRecovery(task.id)
+            }
+        }
+    }
+
+    private fun scheduleConnectionRecovery(taskId: String) {
+        if (connectionRecoveryJobs[taskId]?.isActive == true) return
+        val job = scope.launch(Dispatchers.IO) {
+            val task = currentTask(taskId) ?: return@launch
+            val recovery = task.connectionRecovery ?: return@launch
+            if (recovery.paused || task.stoppedByUser) return@launch
+            val delayMillis = ((recovery.nextRetryAtMillis ?: System.currentTimeMillis()) - System.currentTimeMillis())
+                .coerceAtLeast(0L)
+            delay(delayMillis)
+            val readyTask = currentTask(taskId) ?: return@launch
+            val readyRecovery = readyTask.connectionRecovery ?: return@launch
+            if (readyRecovery.paused || readyTask.stoppedByUser) return@launch
+            scheduledConnectionRecoveryResumes.add(taskId)
+            try {
+                resume(taskId, CONNECTION_STALL_RETRY_PROMPT)
+            } finally {
+                scheduledConnectionRecoveryResumes.remove(taskId)
+            }
+        }
+        val prior = connectionRecoveryJobs.putIfAbsent(taskId, job)
+        if (prior != null) job.cancel()
+        job.invokeOnCompletion { connectionRecoveryJobs.remove(taskId, job) }
+    }
+
+    private fun clearAcpRecoveryState(taskId: String) {
+        val task = currentTask(taskId) ?: return
+        if (task.connectionRecovery == null) return
+        connectionRecoveryJobs.remove(taskId)?.cancel()
+        updateTask(taskId) { current -> current.copy(connectionRecovery = null) }
+        scope.launch { persist() }
     }
 
     private fun transcriptHasConnectionStall(taskId: String): Boolean =
@@ -3225,6 +3302,22 @@ class DesktopAgentRunService(
     }
 
     private fun stopNow(taskId: String) {
+        val recovering = currentTask(taskId)?.takeIf { it.connectionRecovery != null }
+        if (recovering != null) {
+            connectionRecoveryJobs.remove(taskId)?.cancel()
+            updateTask(taskId) {
+                it.copy(
+                    status = AgentStatus.Done,
+                    stoppedByUser = true,
+                    resumable = false,
+                    connectionRecovery = null,
+                    finishedAtMillis = System.currentTimeMillis(),
+                    unread = false,
+                )
+            }
+            scope.launch { persist() }
+            return
+        }
         val acpTask = currentTask(taskId)?.takeIf { it.lane == AgentLaneKind.Acp }
         if (acpTask != null) {
             handles[taskId]?.stopRequested = true
@@ -3304,7 +3397,8 @@ class DesktopAgentRunService(
         acpManager.clear(taskId)
         queuedAcpPermissions.remove(taskId)
         eventFlows.remove(taskId)
-        connectionStallAutoRetries.remove(taskId)
+        connectionRecoveryJobs.remove(taskId)?.cancel()
+        scheduledConnectionRecoveryResumes.remove(taskId)
         _tasks.update { list ->
             list.mapNotNull { existing ->
                 when {
@@ -4179,6 +4273,9 @@ class DesktopAgentRunService(
 
     /** Persist state and tear down owned tmux sessions on JVM exit or explicit close. */
     fun shutdownForProcessExit() {
+        connectionRecoveryJobs.values.forEach { it.cancel() }
+        connectionRecoveryJobs.clear()
+        scheduledConnectionRecoveryResumes.clear()
         runCatching { snapshotActiveTasksBeforeShutdown() }
         runCatching { discardTemporaryChatsForProcessExit() }
         _tasks.value.filter { it.lane == AgentLaneKind.Acp && acpManager.isAlive(it.id) }.forEach { task ->
@@ -5623,12 +5720,24 @@ class DesktopAgentRunService(
             if (event is AgentEvent.ToolCall && cwd != null) trackEditToolCall(taskId, event, cwd)
         }
         appendEventsDirect(taskId, events)
+        if (task?.connectionRecovery != null && events.any(::isConnectionRecoveryProgress)) {
+            // A provider produced durable new work after the last retry. Future transport drops
+            // receive a fresh bounded budget instead of being counted as one endless outage.
+            clearAcpRecoveryState(taskId)
+        }
         if (needsFlush) {
             val atMillis = events.lastOrNull()?.atMillis ?: System.currentTimeMillis()
             scheduleFileChangesEnrichment(taskId, flushBatch = true, atMillis = atMillis)
         } else if (task?.lane == AgentLaneKind.Acp) {
             scheduleFileChangesEnrichment(taskId)
         }
+    }
+
+    private fun isConnectionRecoveryProgress(event: AgentEvent): Boolean = when (event) {
+        is AgentEvent.AssistantText -> event.text.isNotBlank() && !event.text.isRetriableConnectionStallMessage()
+        is AgentEvent.ToolCall -> event.state != AgentToolState.Failed
+        is AgentEvent.ToolResult -> !event.isError
+        else -> false
     }
 
     private fun appendEventsDirect(taskId: String, events: List<AgentEvent>) {

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStore.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStore.kt
@@ -2,6 +2,8 @@ package app.andy.desktop.service.agents
 
 import app.andy.model.AgentAutonomy
 import app.andy.model.AgentContextualProvenance
+import app.andy.model.AgentConnectionRecovery
+import app.andy.model.AgentConnectionRecoveryReason
 import app.andy.model.AgentKind
 import app.andy.model.AgentLaneKind
 import app.andy.model.AgentQuotaAccess
@@ -296,6 +298,10 @@ internal data class AgentTaskDto(
     val vendorSessionId: String = "",
     val acpSessionId: String = "",
     val stopReason: String = "",
+    val connectionRecoveryAttempts: Int = 0,
+    val connectionRecoveryReason: String = "",
+    val connectionRecoveryNextRetryAtMillis: Long = 0,
+    val connectionRecoveryPaused: Boolean = false,
     val lane: String = AgentLaneKind.Terminal.name,
     /** Newer stores make the persisted lane authoritative; old stores still use artifact migration. */
     val laneExplicit: Boolean = false,
@@ -685,6 +691,19 @@ internal fun AgentTaskDto.toModel(scrollbackFile: (String) -> File): AgentTask? 
         vendorSessionId = vendorSessionId.takeIf { it.isNotBlank() },
         acpSessionId = acpSessionId.takeIf { it.isNotBlank() },
         stopReason = stopReason.takeIf { it.isNotBlank() },
+        connectionRecovery = connectionRecoveryReason
+            .takeIf { connectionRecoveryAttempts > 0 }
+            ?.let { rawReason ->
+                AgentConnectionRecoveryReason.entries.firstOrNull { it.name == rawReason }
+                    ?.let { reason ->
+                        AgentConnectionRecovery(
+                            attemptsWithoutProgress = connectionRecoveryAttempts,
+                            reason = reason,
+                            nextRetryAtMillis = connectionRecoveryNextRetryAtMillis.takeIf { it > 0 },
+                            paused = connectionRecoveryPaused,
+                        )
+                    }
+            },
         lane = AgentLaneKind.entries.firstOrNull { it.name == lane }
             ?.takeIf { laneExplicit }
             ?: inferAgentLaneFromArtifacts(
@@ -802,6 +821,10 @@ internal fun AgentStoreState.toFileDto(): AgentsFileDto = AgentsFileDto(
             vendorSessionId = task.vendorSessionId.orEmpty(),
             acpSessionId = task.acpSessionId.orEmpty(),
             stopReason = task.stopReason.orEmpty(),
+            connectionRecoveryAttempts = task.connectionRecovery?.attemptsWithoutProgress ?: 0,
+            connectionRecoveryReason = task.connectionRecovery?.reason?.name.orEmpty(),
+            connectionRecoveryNextRetryAtMillis = task.connectionRecovery?.nextRetryAtMillis ?: 0,
+            connectionRecoveryPaused = task.connectionRecovery?.paused ?: false,
             lane = task.lane.name,
             laneExplicit = true,
             createdAtMillis = task.createdAtMillis,

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/WorktreeManager.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/WorktreeManager.kt
@@ -1,5 +1,6 @@
 package app.andy.desktop.service.agents
 
+import app.andy.desktop.service.GitLocator
 import app.andy.domain.parseUnifiedDiff
 import app.andy.model.AgentKind
 import app.andy.model.AgentChangeSummary
@@ -497,7 +498,8 @@ class WorktreeManager(
     private fun git(dir: String, vararg args: String): GitResult = git(dir, args.toList(), emptyMap())
 
     private fun git(dir: String, args: List<String>, env: Map<String, String>): GitResult = runCatching {
-        val process = ProcessBuilder(listOf("git", "-C", dir) + args).redirectErrorStream(true)
+        val binary = GitLocator.resolve() ?: return GitResult(-1, "git not found")
+        val process = ProcessBuilder(listOf(binary, "-C", dir) + args).redirectErrorStream(true)
             .apply { environment().putAll(env) }
             .start()
         val output = readOutputWithin(process, timeoutSeconds = 30)

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpProcessLauncher.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpProcessLauncher.kt
@@ -1,5 +1,6 @@
 package app.andy.desktop.service.agents.acp
 
+import app.andy.terminal.IDE_XDG_KEYS
 import app.andy.terminal.replaceProcessEnvironment
 import app.andy.terminal.scrubInheritedTerminalEnvironment
 import kotlinx.coroutines.Dispatchers
@@ -143,8 +144,11 @@ internal fun ProcessBuilder.applyLaunchEnv(
         replaceProcessEnvironment(environment(), env)
     }
     // Defense in depth: a caller that forgot to scrub still must not leak
-    // CURSOR_AGENT / NODE_OPTIONS from the parent JVM into the ACP child.
+    // CURSOR_AGENT / NODE_OPTIONS / sandbox XDG_* from the parent JVM.
+    // Restore only XDG keys the caller (login shell / overrides) actually set.
+    val keepXdg = env.filterKeys { it in IDE_XDG_KEYS }
     scrubInheritedTerminalEnvironment(environment())
+    environment().putAll(keepXdg)
     ensureNodeDirOnPath(environment(), command, nodeBinary)
     return this
 }

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpSession.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpSession.kt
@@ -14,6 +14,7 @@ import app.andy.model.AgentSessionMode
 import app.andy.model.AgentTask
 import app.andy.model.modelForCli
 import app.andy.model.runtimeKind
+import com.agentclientprotocol.agent.AgentInfo
 import com.agentclientprotocol.client.Client
 import com.agentclientprotocol.client.ClientInfo
 import com.agentclientprotocol.client.ClientOperationsFactory
@@ -157,7 +158,7 @@ class AcpSession(
 
         val acpClient = Client(rpc)
         client = acpClient
-        acpClient.initialize(
+        val agentInfo = acpClient.initialize(
             ClientInfo(
                 capabilities = ClientCapabilities(
                     fs = FileSystemCapability(readTextFile = true, writeTextFile = true),
@@ -166,6 +167,7 @@ class AcpSession(
                 implementation = Implementation("Andy", "desktop", "Andy ACP client"),
             ),
         )
+        acpClient.authenticateAdvertisedLogin(task.runtimeKind(), agentInfo)
 
         val parameters = SessionCreationParameters(
             cwd = cwd.path,
@@ -344,4 +346,16 @@ class AcpSession(
 internal fun acpSessionModelId(task: AgentTask): String? {
     if (task.runtimeKind() == AgentKind.Goose) return gooseProviderAndModel(task).second
     return task.modelForCli()?.trim()?.takeIf { it.isNotBlank() }
+}
+
+/**
+ * cursor-agent always advertises `cursor_login`. `session/new` can succeed when
+ * `~/.config/cursor/auth.json` is visible, but fails with "Authentication required"
+ * when Cursor's sandbox `XDG_CONFIG_HOME` hides it. `authenticate` is the ACP
+ * handshake that binds that login (and yields a clearer error if it is missing).
+ */
+internal suspend fun Client.authenticateAdvertisedLogin(agent: AgentKind, agentInfo: AgentInfo) {
+    if (agent != AgentKind.Cursor) return
+    val methodId = agentInfo.authMethods.firstOrNull()?.id ?: return
+    authenticate(methodId)
 }

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpSlashCommandProbe.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpSlashCommandProbe.kt
@@ -97,7 +97,7 @@ internal class AcpSlashCommandProbe(
             )
             rpc.start()
             val client = Client(rpc)
-            client.initialize(
+            val agentInfo = client.initialize(
                 ClientInfo(
                     capabilities = ClientCapabilities(
                         fs = FileSystemCapability(readTextFile = true, writeTextFile = false),
@@ -106,6 +106,7 @@ internal class AcpSlashCommandProbe(
                     implementation = Implementation("Andy", "desktop", "Andy ACP slash probe"),
                 ),
             )
+            client.authenticateAdvertisedLogin(agent, agentInfo)
             val operationsFactory = ClientOperationsFactory { _, _ ->
                 probeOperations(cwd, commands)
             }

--- a/data/agents/src/desktopMain/kotlin/app/andy/terminal/TerminalEnvironment.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/terminal/TerminalEnvironment.kt
@@ -20,6 +20,12 @@ private val DROP_ENV_KEYS = setOf(
     "FORCE_COLOR",
     "NO_COLOR",
     "CI",
+    // Cursor/VS Code sandbox XDG so cursor-agent finds ~/.local/state/cursor auth, not an empty
+    // IDE store. Restored from the user's login shell / launch overrides after scrub.
+    "XDG_STATE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
 )
 
 private val DROP_ENV_PREFIXES = listOf(
@@ -32,6 +38,13 @@ private val DROP_ENV_PREFIXES = listOf(
 private val KEEP_ENV_KEYS = setOf(
     "CURSOR_API_KEY",
     "CURSOR_AUTH_TOKEN",
+)
+
+internal val IDE_XDG_KEYS = setOf(
+    "XDG_STATE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
 )
 
 /**
@@ -81,7 +94,12 @@ fun buildTerminalLaunchEnvironment(
     val env = HashMap(System.getenv())
     env.putAll(loginShellEnv)
     env.putAll(overrides)
+    val xdgFromShell = loginShellEnv.filterKeys { it in IDE_XDG_KEYS }
+    val xdgFromOverrides = overrides.filterKeys { it in IDE_XDG_KEYS }
     scrubInheritedTerminalEnvironment(env)
+    // Scrub drops IDE-sandbox XDG_*; put back only what the user's shell or caller set.
+    env.putAll(xdgFromShell)
+    env.putAll(xdgFromOverrides)
     return env
 }
 

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentLaunchEnvironmentTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/AgentLaunchEnvironmentTest.kt
@@ -60,6 +60,26 @@ class AgentLaunchEnvironmentTest {
     }
 
     @Test
+    fun scrubsIdeSandboxXdgSoCursorAgentFindsUserAuth() {
+        val env = mutableMapOf(
+            "HOME" to "/home/test",
+            "PATH" to "/usr/bin",
+            "XDG_STATE_HOME" to "/tmp/cursor-sandbox/state",
+            "XDG_CONFIG_HOME" to "/tmp/cursor-sandbox/config",
+            "XDG_CACHE_HOME" to "/tmp/cursor-sandbox/cache",
+            "XDG_DATA_HOME" to "/tmp/cursor-sandbox/data",
+        )
+
+        scrubInheritedAgentEnvironment(env)
+
+        assertEquals("/home/test", env["HOME"])
+        assertNull(env["XDG_STATE_HOME"])
+        assertNull(env["XDG_CONFIG_HOME"])
+        assertNull(env["XDG_CACHE_HOME"])
+        assertNull(env["XDG_DATA_HOME"])
+    }
+
+    @Test
     fun scrubAfterMergeRemovesIdeVarsThatPutAllCannotDrop() {
         // Reproduces the historical bug: System.getenv() + putAll(scrubbed) left
         // NODE_OPTIONS in place because scrubbed maps omit keys instead of nulling them.
@@ -134,6 +154,37 @@ class AgentLaunchEnvironmentTest {
         )
         assertNull(env["NODE_OPTIONS"])
         assertEquals("/from/shell", env["PATH"])
+    }
+
+    @Test
+    fun buildTerminalLaunchEnvironmentDropsJvmXdgUnlessLoginShellSetsIt() {
+        val env = buildTerminalLaunchEnvironment(
+            loginShellEnv = mapOf("PATH" to "/from/shell"),
+        )
+        assertNull(env["XDG_STATE_HOME"])
+        assertNull(env["XDG_CONFIG_HOME"])
+        assertEquals("/from/shell", env["PATH"])
+    }
+
+    @Test
+    fun buildTerminalLaunchEnvironmentRestoresLoginShellXdgAfterScrub() {
+        val env = buildTerminalLaunchEnvironment(
+            loginShellEnv = mapOf(
+                "PATH" to "/from/shell",
+                "XDG_STATE_HOME" to "/home/test/.local/state",
+            ),
+        )
+        assertEquals("/home/test/.local/state", env["XDG_STATE_HOME"])
+        assertEquals("/from/shell", env["PATH"])
+    }
+
+    @Test
+    fun buildTerminalLaunchEnvironmentPrefersOverrideXdgOverLoginShell() {
+        val env = buildTerminalLaunchEnvironment(
+            overrides = mapOf("XDG_STATE_HOME" to "/custom/state"),
+            loginShellEnv = mapOf("XDG_STATE_HOME" to "/home/test/.local/state"),
+        )
+        assertEquals("/custom/state", env["XDG_STATE_HOME"])
     }
 
     @Test

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStoreTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStoreTest.kt
@@ -1,6 +1,8 @@
 package app.andy.desktop.service.agents
 
 import app.andy.model.AgentAutonomy
+import app.andy.model.AgentConnectionRecovery
+import app.andy.model.AgentConnectionRecoveryReason
 import app.andy.model.AgentContextualProvenance
 import app.andy.model.AgentKind
 import app.andy.model.AgentLaneKind
@@ -181,6 +183,30 @@ class DesktopAgentTaskStoreTest {
         store.save(AgentStoreState(tasks = listOf(task)))
         val loaded = store.load()
         assertEquals(listOf(task), loaded.tasks)
+    }
+
+    @Test
+    fun roundTripsDurableConnectionRecovery() = withStore { store ->
+        val task = AgentTask(
+            id = "task-recovery",
+            title = "wait for CI",
+            prompt = "ship it",
+            agent = AgentKind.Cursor,
+            cwd = "/tmp",
+            originDir = "/tmp",
+            lane = AgentLaneKind.Acp,
+            status = AgentStatus.Done,
+            resumable = true,
+            connectionRecovery = AgentConnectionRecovery(
+                attemptsWithoutProgress = 2,
+                reason = AgentConnectionRecoveryReason.Transport,
+                nextRetryAtMillis = 3_000,
+            ),
+            createdAtMillis = 1,
+            finishedAtMillis = 2,
+        )
+        store.save(AgentStoreState(tasks = listOf(task)))
+        assertEquals(listOf(task), store.load().tasks)
     }
 
     @Test

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/ProjectWorkflowServiceTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/ProjectWorkflowServiceTest.kt
@@ -52,9 +52,9 @@ class ProjectWorkflowServiceTest {
     fun manualCompleteBuildAttemptAdvancesWorkflow() = runBlocking {
         withHarness(
             WorkflowAdapter(
-                // Long enough for the test to observe the active build and call
-                // completeWorkflowRun; keep short so desktopTest doesn't look hung.
-                buildKeepAliveSeconds = 20,
+                // Hold until completeWorkflowRun force-kills the shell. A short sleep races
+                // under loaded macOS CI where start/observe can take longer than 20s.
+                buildKeepAliveSeconds = (harnessTimeoutMillis(60_000, 180_000, 300_000) / 1_000L).toInt(),
                 reviewOutcomes = ArrayDeque(listOf("approved")),
             ),
         ) { harness ->
@@ -1130,8 +1130,8 @@ class ProjectWorkflowServiceTest {
     fun pauseAfterBuildCompletesDoesNotLeaveVerificationWaiting() = runBlocking {
         withHarness(
             WorkflowAdapter(
-                // Keep the build alive long enough to arm pause-after-current.
-                buildKeepAliveSeconds = 20,
+                // Hold until completeWorkflowRun force-kills; same CI race as manualComplete.
+                buildKeepAliveSeconds = (harnessTimeoutMillis(60_000, 180_000, 300_000) / 1_000L).toInt(),
                 reviewOutcomes = ArrayDeque(listOf("approved")),
             ),
         ) { harness ->

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpProcessLauncherTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/acp/AcpProcessLauncherTest.kt
@@ -174,6 +174,38 @@ class AcpProcessLauncherTest {
         assertEquals("/usr/bin", builder.environment()["PATH"])
     }
 
+    @Test
+    fun applyLaunchEnvDropsParentXdgSandboxUnlessCallerSetsIt() {
+        val builder = ProcessBuilder("true")
+        builder.environment()["XDG_STATE_HOME"] = "/tmp/cursor-sandbox/state"
+        builder.environment()["XDG_CONFIG_HOME"] = "/tmp/cursor-sandbox/config"
+        builder.applyLaunchEnv(
+            env = mapOf(
+                "PATH" to "/usr/bin",
+                "HOME" to "/tmp",
+            ),
+            command = listOf("cursor-agent", "acp"),
+        )
+        assertNull(builder.environment()["XDG_STATE_HOME"])
+        assertNull(builder.environment()["XDG_CONFIG_HOME"])
+        assertEquals("/usr/bin", builder.environment()["PATH"])
+    }
+
+    @Test
+    fun applyLaunchEnvKeepsCallerXdgAfterScrub() {
+        val builder = ProcessBuilder("true")
+        builder.environment()["XDG_STATE_HOME"] = "/tmp/cursor-sandbox/state"
+        builder.applyLaunchEnv(
+            env = mapOf(
+                "PATH" to "/usr/bin",
+                "HOME" to "/tmp",
+                "XDG_STATE_HOME" to "/home/test/.local/state",
+            ),
+            command = listOf("cursor-agent", "acp"),
+        )
+        assertEquals("/home/test/.local/state", builder.environment()["XDG_STATE_HOME"])
+    }
+
     private fun pathValue(env: Map<String, String>): String? =
         env.entries.firstOrNull { it.key.equals("PATH", ignoreCase = true) }?.value
 }

--- a/data/mirror/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
+++ b/data/mirror/src/desktopMain/kotlin/app/andy/desktop/MirrorVideoSurface.desktop.kt
@@ -24,6 +24,7 @@ import app.andy.desktop.service.mirror.GpuMirrorHostRegistry
 import app.andy.desktop.service.mirror.GpuMirrorJni
 import app.andy.desktop.service.mirror.GpuMirrorPresenter
 import app.andy.desktop.service.mirror.GpuMirrorSessions
+import app.andy.desktop.service.mirror.LinuxMirrorDesktopVisibilityEffect
 import app.andy.desktop.service.mirror.NativeMirrorHostRegistry
 import app.andy.desktop.service.mirror.NativeMirrorJni
 import java.awt.AlphaComposite
@@ -36,6 +37,7 @@ import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.HierarchyBoundsAdapter
 import java.awt.event.HierarchyEvent
+import java.awt.event.HierarchyListener
 import java.awt.event.FocusAdapter
 import java.awt.event.FocusEvent
 import java.awt.event.KeyAdapter
@@ -47,6 +49,9 @@ import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.RenderingHints
+import java.awt.Window
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferInt
 import java.awt.geom.Ellipse2D
@@ -91,6 +96,9 @@ actual fun MirrorVideoSurface(
                 gpuMirrorStreamKey = gpuMirrorStreamKey,
             )
         }
+        LinuxMirrorDesktopVisibilityEffect(
+            enabled = nativePresentation && gpuMirrorStreamKey != null && GpuMirrorJni.isAvailable(),
+        )
         Box(modifier.background(Color.Black)) {
             if (!suppressHeavyweight) {
                 SwingPanel(
@@ -148,6 +156,9 @@ actual fun MirrorVideoSurface(
                 gpuMirrorStreamKey = gpuMirrorStreamKey,
             )
         }
+        LinuxMirrorDesktopVisibilityEffect(
+            enabled = nativePresentation && gpuMirrorStreamKey != null && GpuMirrorJni.isAvailable(),
+        )
         Box(modifier.background(Color.Black)) {
             if (!suppressHeavyweight) {
                 SwingPanel(
@@ -243,6 +254,17 @@ private class MirrorPanel(
     private var pendingFrame: MirrorFrame? = null
     private var frameDispatchPending = false
     private var gpuPresenter: GpuMirrorPresenter? = null
+    private var resumeGpuPresentationAttempts = 0
+    private var ancestorWindow: Window? = null
+    private val ancestorWindowListener = object : WindowAdapter() {
+        override fun windowActivated(e: WindowEvent) {
+            if (!occluded && hostsNativePresentation) resumeGpuPresentationAfterShow()
+        }
+
+        override fun windowStateChanged(e: WindowEvent) {
+            if (!occluded && hostsNativePresentation) updatePresentationGeometry()
+        }
+    }
 
     private fun prefersGpuHub(): Boolean =
         hostsNativePresentation && gpuMirrorStreamKey != null && GpuMirrorJni.isAvailable()
@@ -268,8 +290,6 @@ private class MirrorPanel(
         ) {
             return cached
         }
-        cached?.close()
-        invalidateGpuPresenter()
         GpuMirrorHostRegistry.presenterFor(this)?.let { existing ->
             if (existing.decoderId == pipeline.decoderId) {
                 gpuPresenter = existing
@@ -277,17 +297,50 @@ private class MirrorPanel(
             }
             existing.close()
         }
+        GpuMirrorHostRegistry.unattachedPresenterForDecoder(pipeline.decoderId)?.let { orphan ->
+            gpuPresenter = orphan
+            return orphan
+        }
+        cached?.takeIf { it.decoderId == pipeline.decoderId }?.let { orphan ->
+            gpuPresenter = orphan
+            return orphan
+        }
+        cached?.close()
+        invalidateGpuPresenter()
         return pipeline.createPresenter(this)?.also { gpuPresenter = it }
     }
 
     private fun attachGpuPresentationIfReady() {
         if (MirrorPresentationGuard.suppressingGeometry || !prefersGpuHub()) return
+        // Boot attach before the Canvas has a real size leaves a stuck/invisible overlay;
+        // tab remount works because size is already valid by then.
+        if (!isShowing || width <= 0 || height <= 0) return
         val presenter = ensureGpuPresenter() ?: return
         if (presenter.isAttachedTo(this)) {
             presenter.updateGeometry(this)
+            presenter.repaint()
             return
         }
         presenter.attach(this, fillNativePresentationHost)
+    }
+
+    private fun resumeGpuPresentationAfterShow() {
+        if (!prefersGpuHub() || occluded || !hostsNativePresentation || !isDisplayable) return
+        val resume = Runnable {
+            // Retry until the hub session exists and the host has real bounds — on first
+            // Live open the session often arrives after addNotify.
+            if (!isDisplayable || !isShowing || width <= 0 || height <= 0 || !usesGpuHub()) {
+                if (resumeGpuPresentationAttempts++ < 40) {
+                    SwingUtilities.invokeLater(this::resumeGpuPresentationAfterShow)
+                }
+                return@Runnable
+            }
+            resumeGpuPresentationAttempts = 0
+            attachGpuPresentationIfReady()
+            ensureGpuPresenter()?.warmResume(this)
+            GpuMirrorJni.resumeAfterDesktopSwitch()
+        }
+        if (SwingUtilities.isEventDispatchThread()) resume.run() else SwingUtilities.invokeLater(resume)
     }
 
     private var presentationGeometryPending = false
@@ -483,13 +536,12 @@ private class MirrorPanel(
         addMouseWheelListener(listener)
         addFocusListener(object : FocusAdapter() {
             override fun focusGained(event: FocusEvent) {
-                // Focus can bury a non-child Metal overlay under the black Canvas. Refresh
-                // geometry so hub re-parents via addChildWindow without orderFront flashing.
                 if (occluded || !hostsNativePresentation) return
                 if (usesGpuHub()) {
-                    ensureGpuPresenter()?.invalidateGeometry()
+                    ensureGpuPresenter()?.repaint()
+                } else {
+                    updatePresentationGeometry()
                 }
-                updatePresentationGeometry()
             }
         })
         addComponentListener(object : ComponentAdapter() {
@@ -503,7 +555,9 @@ private class MirrorPanel(
             }
 
             override fun componentShown(event: ComponentEvent) {
-                if (!occluded && hostsNativePresentation) updatePresentationGeometry()
+                if (!occluded && hostsNativePresentation) {
+                    SwingUtilities.invokeLater { resumeGpuPresentationAfterShow() }
+                }
                 if (!nativeMetadataFrame) presentCpuFrame()
             }
         })
@@ -516,13 +570,25 @@ private class MirrorPanel(
                 if (!occluded && hostsNativePresentation) updatePresentationGeometry()
             }
         })
+        addHierarchyListener(HierarchyListener { e ->
+            if (e.changeFlags and HierarchyEvent.SHOWING_CHANGED.toLong() != 0L &&
+                isShowing && !occluded && hostsNativePresentation
+            ) {
+                resumeGpuPresentationAfterShow()
+            }
+        })
     }
 
     override fun addNotify() {
         super.addNotify()
+        SwingUtilities.getWindowAncestor(this)?.let { window ->
+            ancestorWindow?.takeIf { it !== window }?.removeWindowListener(ancestorWindowListener)
+            ancestorWindow = window
+            window.addWindowListener(ancestorWindowListener)
+        }
         if (hostsNativePresentation) {
             if (prefersGpuHub()) {
-                attachGpuPresentationIfReady()
+                SwingUtilities.invokeLater { resumeGpuPresentationAfterShow() }
             } else {
                 NativeMirrorHostRegistry.markHostsMetalPresentation(
                     this,
@@ -538,9 +604,11 @@ private class MirrorPanel(
         // Teardown runs before Canvas loses its heavyweight peer. Unregister first so a sibling
         // Live/pop-out host can reclaim the Metal presenter instead of destroying the session.
         presentationGeometryPending = false
+        ancestorWindow?.removeWindowListener(ancestorWindowListener)
+        ancestorWindow = null
         if (hostsNativePresentation) {
             if (prefersGpuHub()) {
-                gpuPresenter?.close()
+                gpuPresenter?.detach()
                 gpuPresenter = null
             } else {
                 NativeMirrorHostRegistry.unregister(this)
@@ -636,6 +704,9 @@ private class MirrorPanel(
                 gpuMirrorStreamKey?.let { key ->
                     GpuMirrorSessions.get(key)?.setContentSize(frame.width, frame.height)
                     ensureGpuPresenter()?.setContentSize(frame.width, frame.height)
+                }
+                if (gpuPresenter?.isAttachedTo(this) != true) {
+                    SwingUtilities.invokeLater { resumeGpuPresentationAfterShow() }
                 }
             } else {
                 NativeMirrorJni.setPresentationContentSize(frame.width, frame.height)

--- a/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/GpuMirrorHostRegistry.kt
+++ b/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/GpuMirrorHostRegistry.kt
@@ -19,11 +19,9 @@ object GpuMirrorHostRegistry {
         presentersByDecoder.add(presenter)
     }
 
+    /** Drops the host mapping only; keeps the presenter warm for tab-switch reattach. */
     fun unregisterPresenter(host: Canvas) {
-        val removed = presentersByHost.remove(host)
-        if (removed != null) {
-            presentersByDecoder.remove(removed)
-        }
+        presentersByHost.remove(host)
     }
 
     /** Drops a presenter from the decoder index without touching another host's registration. */
@@ -44,6 +42,12 @@ object GpuMirrorHostRegistry {
     fun presentersForDecoder(decoderId: Long): List<GpuMirrorPresenter> =
         presentersByDecoder.filter { it.decoderId == decoderId }
 
+    /** Presenter detached from its canvas but still decoding; safe to reattach after tab switches. */
+    fun unattachedPresenterForDecoder(decoderId: Long): GpuMirrorPresenter? =
+        presentersForDecoder(decoderId).firstOrNull { it !in presentersByHost.values }
+
+    fun anyHostShowing(): Boolean = presentersByHost.keys.any { it.isShowing }
+
     fun pruneOrphanedPresenters(decoderId: Long) {
         val registered = presentersByHost.values.toSet()
         presentersForDecoder(decoderId)
@@ -63,7 +67,9 @@ object GpuMirrorHostRegistry {
         }
     }
 
-    fun allPresenters(): List<GpuMirrorPresenter> = presentersByHost.values.distinct()
+    fun attachedPresenters(): List<GpuMirrorPresenter> = presentersByHost.values.distinct()
+
+    fun allPresenters(): List<GpuMirrorPresenter> = presentersByDecoder.toList()
 
     /** Test-only snapshot of registered hosts. */
     fun registeredHostsForTests(): List<Canvas> = presentersByHost.keys.toList()

--- a/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/GpuMirrorJni.kt
+++ b/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/GpuMirrorJni.kt
@@ -214,6 +214,28 @@ object GpuMirrorJni {
         return "#%02X%02X%02X".format((color ushr 16) and 0xff, (color ushr 8) and 0xff, color and 0xff)
     }
 
+    fun readWindowDesktop(windowNumber: Int): Int =
+        if (!loadResult.isSuccess || windowNumber == 0) -1
+        else runCatching { nativeReadWindowDesktop(windowNumber) }.getOrDefault(-1)
+
+    fun refreshAllPresenters() {
+        if (!loadResult.isSuccess) return
+        runCatching { nativeRefreshAllPresenters() }
+    }
+
+    fun suppressForDesktopSwitch() {
+        if (!loadResult.isSuccess) return
+        runCatching { nativeSuppressForDesktopSwitch() }
+    }
+
+    fun resumeAfterDesktopSwitch() {
+        if (!loadResult.isSuccess) return
+        runCatching { nativeResumeAfterDesktopSwitch() }
+    }
+
+    fun shouldResumePresentersAfterDesktopSwitch(): Boolean =
+        loadResult.isSuccess && runCatching { nativeShouldResumePresentersAfterDesktopSwitch() }.getOrDefault(false)
+
     private fun loadLibrary() = runCatching {
         val resourcePath = NativeMirrorJni.resourcePath()
             ?: error("No packaged native GPU mirror bridge is available for this desktop platform")
@@ -298,4 +320,9 @@ object GpuMirrorJni {
         visible: Boolean,
     )
     private external fun nativeInspectPixel(decoderId: Long, normalizedX: Float, normalizedY: Float): Int
+    private external fun nativeReadWindowDesktop(windowNumber: Int): Int
+    private external fun nativeRefreshAllPresenters()
+    private external fun nativeSuppressForDesktopSwitch()
+    private external fun nativeShouldResumePresentersAfterDesktopSwitch(): Boolean
+    private external fun nativeResumeAfterDesktopSwitch()
 }

--- a/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/GpuMirrorPipeline.kt
+++ b/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/GpuMirrorPipeline.kt
@@ -22,7 +22,7 @@ class GpuMirrorPipeline private constructor(
                 existing.close()
             }
         }
-        GpuMirrorHostRegistry.pruneOrphanedPresenters(decoderId)
+        GpuMirrorHostRegistry.unattachedPresenterForDecoder(decoderId)?.let { return it }
         val presenterId = GpuMirrorJni.createPresenter(decoderId)
         if (presenterId == 0L) return null
         return GpuMirrorPresenter(this, presenterId)
@@ -129,18 +129,23 @@ class GpuMirrorPresenter internal constructor(
             updateGeometry(host)
             return true
         }
-        detach()
+        warmDetach()
         this.fillHost = fillHost
         if (!GpuMirrorJni.openPresenterOverlay(presenterId)) return false
         GpuMirrorJni.setPresenterFillHost(presenterId, fillHost)
-        // Fresh native window: push the hidden state even if that is what we last applied.
-        visibleApplied = null
-        applyVisible(false)
         attachedHost = host
         GpuMirrorHostRegistry.registerPresenter(host, this)
         lastGeometryKey = null
+        visibleApplied = null
         val finalizeAttach = {
+            lastGeometryKey = null
+            // Clear desktop suppress before showing — setVisible alone must not, or
+            // geometry updates during VD switches remount the floating overlay.
+            GpuMirrorJni.resumeAfterDesktopSwitch()
             commitGeometry(host)
+            visibleApplied = null
+            visibleRequested = true
+            applyVisible(true)
             GpuMirrorJni.repaintPresenter(presenterId)
         }
         if (SwingUtilities.isEventDispatchThread()) {
@@ -154,16 +159,18 @@ class GpuMirrorPresenter internal constructor(
     fun isAttachedTo(host: Canvas): Boolean = attachedHost === host
 
     fun detach() {
+        warmDetach()
+    }
+
+    /** Hides the overlay and unregisters the host without destroying the native presenter. */
+    private fun warmDetach() {
         val host = attachedHost
         attachedHost = null
-        // Only clear the registry slot when we still own it. Replacing a presenter on the same
-        // Canvas closes the previous one after the new registration; that close must not wipe
-        // the replacement out of GpuMirrorHostRegistry.
         if (host != null && GpuMirrorHostRegistry.presenterFor(host) === this) {
             GpuMirrorHostRegistry.unregisterPresenter(host)
-        } else {
-            GpuMirrorHostRegistry.forgetPresenter(this)
         }
+        visibleRequested = false
+        visibleApplied = null
         applyVisible(false)
     }
 
@@ -267,8 +274,25 @@ class GpuMirrorPresenter internal constructor(
 
     val decoderId: Long get() = pipeline.decoderId
 
+    /** Re-shows a warm presenter after virtual-desktop switches or Live tab remounts. */
+    fun warmResume(host: Canvas) {
+        if (attachedHost !== host) {
+            attach(host, fillHost)
+            return
+        }
+        visibleRequested = true
+        visibleApplied = null
+        lastGeometryKey = null
+        GpuMirrorJni.resumeAfterDesktopSwitch()
+        applyVisible(true)
+        invalidateGeometry()
+        updateGeometry(host)
+        repaint()
+    }
+
     override fun close() {
-        detach()
+        warmDetach()
+        GpuMirrorHostRegistry.forgetPresenter(this)
         GpuMirrorJni.destroyPresenter(presenterId)
     }
 

--- a/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/LinuxMirrorDesktopGuard.kt
+++ b/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/LinuxMirrorDesktopGuard.kt
@@ -2,8 +2,11 @@ package app.andy.desktop.service.mirror
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
 
 /** KWin on Wayland exposes a single X11 root desktop; track Plasma desktops over D-Bus instead. */
 internal object LinuxKdeDesktop {
@@ -26,9 +29,22 @@ internal object LinuxKdeDesktop {
                 "org.kde.KWin",
                 "currentDesktop",
             ).redirectErrorStream(true).start()
-            val out = proc.inputStream.bufferedReader().readText()
-            check(proc.waitFor() == 0) { out }
-            out.substringAfter("i ").trim().toInt()
+            val out = StringBuilder()
+            val reader = Thread({
+                runCatching {
+                    proc.inputStream.bufferedReader().use { stream -> out.append(stream.readText()) }
+                }
+            }, "andy-kde-desktop-reader").apply { isDaemon = true }
+            reader.start()
+            if (!proc.waitFor(2, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                proc.waitFor(1, TimeUnit.SECONDS)
+                reader.join(1_000)
+                return@runCatching null
+            }
+            reader.join(1_000)
+            check(proc.exitValue() == 0) { out }
+            out.toString().substringAfter("i ").trim().toInt()
         }.getOrNull()
     }
 }
@@ -45,11 +61,11 @@ internal object LinuxKdeDesktop {
 internal fun LinuxMirrorDesktopVisibilityEffect(enabled: Boolean) {
     if (!enabled || !LinuxKdeDesktop.isActive() || !GpuMirrorJni.isAvailable()) return
     LaunchedEffect(Unit) {
-        var lastDesktop: Int? = LinuxKdeDesktop.currentIndex()
+        var lastDesktop: Int? = withContext(Dispatchers.IO) { LinuxKdeDesktop.currentIndex() }
         var liveDesktop: Int? = lastDesktop
         var suppressed = false
         while (isActive) {
-            val desktop = LinuxKdeDesktop.currentIndex()
+            val desktop = withContext(Dispatchers.IO) { LinuxKdeDesktop.currentIndex() }
             val hostShowing = GpuMirrorHostRegistry.anyHostShowing()
             val desktopChanged = desktop != null && lastDesktop != null && desktop != lastDesktop
             if (desktopChanged) {

--- a/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/LinuxMirrorDesktopGuard.kt
+++ b/data/mirror/src/desktopMain/kotlin/app/andy/desktop/service/mirror/LinuxMirrorDesktopGuard.kt
@@ -1,0 +1,76 @@
+package app.andy.desktop.service.mirror
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+/** KWin on Wayland exposes a single X11 root desktop; track Plasma desktops over D-Bus instead. */
+internal object LinuxKdeDesktop {
+    private val enabled: Boolean by lazy {
+        System.getProperty("os.name").orEmpty().contains("linux", ignoreCase = true) &&
+            System.getenv("XDG_CURRENT_DESKTOP").orEmpty().contains("KDE", ignoreCase = true)
+    }
+
+    fun isActive(): Boolean = enabled
+
+    fun currentIndex(): Int? {
+        if (!enabled) return null
+        return runCatching {
+            val proc = ProcessBuilder(
+                "busctl",
+                "--user",
+                "call",
+                "org.kde.KWin",
+                "/KWin",
+                "org.kde.KWin",
+                "currentDesktop",
+            ).redirectErrorStream(true).start()
+            val out = proc.inputStream.bufferedReader().readText()
+            check(proc.waitFor() == 0) { out }
+            out.substringAfter("i ").trim().toInt()
+        }.getOrNull()
+    }
+}
+
+/**
+ * Hide override-redirect GPU overlays when leaving the Plasma desktop where Live was
+ * showing; restore only when that desktop is current again and a Live host is attached.
+ *
+ * liveDesktop is only updated while stable on a desktop — never during the change
+ * detection tick (that previously set liveDesktop to the destination and immediately
+ * resumed, remounting the floating overlay on the wrong desktop).
+ */
+@Composable
+internal fun LinuxMirrorDesktopVisibilityEffect(enabled: Boolean) {
+    if (!enabled || !LinuxKdeDesktop.isActive() || !GpuMirrorJni.isAvailable()) return
+    LaunchedEffect(Unit) {
+        var lastDesktop: Int? = LinuxKdeDesktop.currentIndex()
+        var liveDesktop: Int? = lastDesktop
+        var suppressed = false
+        while (isActive) {
+            val desktop = LinuxKdeDesktop.currentIndex()
+            val hostShowing = GpuMirrorHostRegistry.anyHostShowing()
+            val desktopChanged = desktop != null && lastDesktop != null && desktop != lastDesktop
+            if (desktopChanged) {
+                GpuMirrorJni.suppressForDesktopSwitch()
+                suppressed = true
+            } else if (hostShowing && !suppressed && desktop != null) {
+                liveDesktop = desktop
+            }
+            if (suppressed && hostShowing && desktop != null && desktop == liveDesktop) {
+                GpuMirrorJni.resumeAfterDesktopSwitch()
+                GpuMirrorHostRegistry.attachedPresenters().forEach { presenter ->
+                    presenter.refreshGeometry()
+                    presenter.repaint()
+                }
+                suppressed = false
+            }
+            if (!hostShowing) {
+                suppressed = false
+            }
+            if (desktop != null) lastDesktop = desktop
+            delay(250)
+        }
+    }
+}

--- a/data/mirror/src/desktopTest/kotlin/app/andy/desktop/service/mirror/GpuMirrorHostRegistryTest.kt
+++ b/data/mirror/src/desktopTest/kotlin/app/andy/desktop/service/mirror/GpuMirrorHostRegistryTest.kt
@@ -88,6 +88,39 @@ class GpuMirrorHostRegistryTest {
         }
     }
 
+    @Test
+    fun detachKeepsPresenterWarmForDecoderReuse() {
+        if (!GpuMirrorJni.isAvailable()) return
+
+        lateinit var host: Canvas
+        lateinit var pipeline: GpuMirrorPipeline
+        var attached = false
+        var presenter: GpuMirrorPresenter? = null
+        SwingUtilities.invokeAndWait {
+            host = realizedCanvas("registry-warm-detach")
+            pipeline = GpuMirrorSessions.createAndBind("registry-warm-detach")!!
+            presenter = pipeline.createPresenter()!!
+            attached = presenter!!.attach(host, fillHost = false)
+        }
+        assumeTrue(
+            "GPU presenter attach needs a working display/Vulkan stack",
+            attached,
+        )
+        try {
+            SwingUtilities.invokeAndWait {
+                presenter!!.detach()
+            }
+            assertNull(GpuMirrorHostRegistry.presenterFor(host))
+            assertEquals(1, GpuMirrorHostRegistry.presentersForDecoder(pipeline.decoderId).size)
+            assertSame(presenter, GpuMirrorHostRegistry.unattachedPresenterForDecoder(pipeline.decoderId))
+        } finally {
+            SwingUtilities.invokeAndWait {
+                GpuMirrorSessions.release("registry-warm-detach")
+                disposeCanvas(host)
+            }
+        }
+    }
+
     private fun realizedCanvas(title: String): Canvas {
         val canvas = Canvas()
         val frame = JFrame(title)

--- a/data/mirror/src/desktopTest/kotlin/app/andy/desktop/service/mirror/GpuMirrorLinuxTest.kt
+++ b/data/mirror/src/desktopTest/kotlin/app/andy/desktop/service/mirror/GpuMirrorLinuxTest.kt
@@ -2,11 +2,13 @@ package app.andy.desktop.service.mirror
 
 import java.awt.BorderLayout
 import java.awt.Canvas
+import java.io.File
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.junit.Assume.assumeTrue
@@ -21,6 +23,24 @@ class GpuMirrorLinuxTest {
     fun linuxAmd64BridgeLoadsFromPackagedDesktopResources() {
         if (!isLinuxAmd64()) return
         assertTrue(GpuMirrorJni.isAvailable())
+    }
+
+    @Test
+    fun linuxJniDoesNotLinkDistroSpecificFfmpeg() {
+        if (!isLinuxAmd64() || !GpuMirrorJni.isAvailable()) return
+        val so = File(
+            System.getProperty("user.home"),
+            ".andy/mirror/andy-mirror/linux-x86_64/libandy-mirror-jni.so",
+        )
+        assumeTrue("expected extracted JNI after isAvailable()", so.isFile)
+        val proc = ProcessBuilder("readelf", "-d", so.absolutePath)
+            .redirectErrorStream(true)
+            .start()
+        val out = proc.inputStream.bufferedReader().readText()
+        assertEquals(0, proc.waitFor(), out)
+        assertFalse(out.contains("libavcodec"), out)
+        assertFalse(out.contains("libavutil"), out)
+        assertTrue(out.contains("libvulkan"), out)
     }
 
     @Test

--- a/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/GitLocator.kt
+++ b/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/GitLocator.kt
@@ -1,0 +1,94 @@
+package app.andy.desktop.service
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Resolves the host `git` binary. GUI apps and Flatpak sandboxes often inherit a
+ * minimal PATH that omits `/usr/bin`, so bare `ProcessBuilder("git", …)` fails even
+ * when the host binary is reachable at a well-known absolute path.
+ */
+object GitLocator {
+    private val cached = AtomicReference<String?>()
+
+    /** Resolves once per process; memoized after the first successful lookup. */
+    fun resolve(): String? {
+        cached.get()?.let { return it }
+        val resolved = locate()
+        cached.set(resolved)
+        return resolved
+    }
+
+    internal fun clearCacheForTests() {
+        cached.set(null)
+    }
+
+    internal fun locate(
+        processPath: String? = System.getenv("PATH"),
+        loginShellEnv: Map<String, String> = LoginShellEnvironment.current(),
+        knownPaths: List<String> = defaultKnownPaths(),
+        runShell: (List<String>) -> String? = ::runShellLookup,
+        osName: String = System.getProperty("os.name").orEmpty(),
+    ): String? {
+        fromPath(processPath)?.let { return it }
+        fromPath(loginShellEnv["PATH"])?.let { return it }
+        firstExecutable(knownPaths)?.let { return it }
+        if (osName.contains("win", ignoreCase = true)) return null
+        return lookupViaLoginShell(runShell)
+    }
+
+    internal fun fromPath(pathEnv: String?): String? {
+        if (pathEnv.isNullOrBlank()) return null
+        return pathEnv.split(File.pathSeparatorChar)
+            .asSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { File(it, "git") }
+            .firstOrNull { it.isFile && it.canExecute() }
+            ?.path
+    }
+
+    internal fun defaultKnownPaths(): List<String> {
+        val home = System.getProperty("user.home").orEmpty()
+        return listOf(
+            "/usr/bin/git",
+            "/usr/local/bin/git",
+            "/opt/homebrew/bin/git",
+            "$home/.local/bin/git",
+        )
+    }
+
+    private fun firstExecutable(paths: List<String>): String? =
+        paths.firstOrNull { File(it).canExecute() }
+
+    private fun lookupViaLoginShell(runShell: (List<String>) -> String?): String? {
+        val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: "/bin/sh"
+        val output = runShell(listOf(shell, "-lc", "command -v git || true")) ?: return null
+        val path = output.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() } ?: return null
+        return path.takeIf { File(it).canExecute() }
+    }
+
+    private fun runShellLookup(command: List<String>): String? = runCatching {
+        val process = ProcessBuilder(command).redirectErrorStream(true).start()
+        readOutputWithin(process, timeoutSeconds = 10)
+    }.getOrNull()
+
+    private fun readOutputWithin(process: Process, timeoutSeconds: Long): String? {
+        val output = StringBuffer()
+        val reader = Thread({
+            runCatching {
+                process.inputStream.bufferedReader().use { stream -> output.append(stream.readText()) }
+            }
+        }, "andy-git-locator-reader").apply { isDaemon = true }
+        reader.start()
+        if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            process.waitFor(1, TimeUnit.SECONDS)
+            reader.join(1_000)
+            return null
+        }
+        reader.join(1_000)
+        return output.toString()
+    }
+}

--- a/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/GitLocator.kt
+++ b/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/GitLocator.kt
@@ -31,26 +31,47 @@ object GitLocator {
         runShell: (List<String>) -> String? = ::runShellLookup,
         osName: String = System.getProperty("os.name").orEmpty(),
     ): String? {
-        fromPath(processPath)?.let { return it }
-        fromPath(loginShellEnv["PATH"])?.let { return it }
+        val windows = osName.contains("win", ignoreCase = true)
+        fromPath(processPath, windows)?.let { return it }
+        fromPath(loginShellEnv["PATH"], windows)?.let { return it }
         firstExecutable(knownPaths)?.let { return it }
-        if (osName.contains("win", ignoreCase = true)) return null
+        if (windows) return null
         return lookupViaLoginShell(runShell)
     }
 
-    internal fun fromPath(pathEnv: String?): String? {
+    internal fun fromPath(pathEnv: String?, windows: Boolean = false): String? {
         if (pathEnv.isNullOrBlank()) return null
+        val names = if (windows) {
+            // PATHEXT normally resolves bare "git", but File(...).isFile does not.
+            listOf("git.exe", "git.cmd", "git.bat", "git")
+        } else {
+            listOf("git")
+        }
         return pathEnv.split(File.pathSeparatorChar)
             .asSequence()
             .map { it.trim() }
             .filter { it.isNotEmpty() }
-            .map { File(it, "git") }
+            .flatMap { dir -> names.asSequence().map { name -> File(dir, name) } }
             .firstOrNull { it.isFile && it.canExecute() }
             ?.path
     }
 
-    internal fun defaultKnownPaths(): List<String> {
+    internal fun defaultKnownPaths(
+        osName: String = System.getProperty("os.name").orEmpty(),
+    ): List<String> {
         val home = System.getProperty("user.home").orEmpty()
+        if (osName.contains("win", ignoreCase = true)) {
+            val programFiles = System.getenv("ProgramFiles") ?: "C:\\Program Files"
+            val programFilesX86 = System.getenv("ProgramFiles(x86)") ?: "C:\\Program Files (x86)"
+            val localAppData = System.getenv("LOCALAPPDATA").orEmpty()
+            return listOf(
+                "$programFiles\\Git\\cmd\\git.exe",
+                "$programFiles\\Git\\bin\\git.exe",
+                "$programFilesX86\\Git\\cmd\\git.exe",
+                "$programFilesX86\\Git\\bin\\git.exe",
+                "$localAppData\\Programs\\Git\\cmd\\git.exe",
+            ).filter { it.isNotBlank() && !it.startsWith("\\") }
+        }
         return listOf(
             "/usr/bin/git",
             "/usr/local/bin/git",

--- a/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/LoginShellEnvironment.kt
+++ b/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/LoginShellEnvironment.kt
@@ -3,6 +3,17 @@ package app.andy.desktop.service
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
+private val IDE_SANDBOX_XDG_KEYS = setOf(
+    "XDG_STATE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
+)
+
+private val IDE_SANDBOX_PREFIXES = listOf("CURSOR_", "VSCODE_", "__CURSOR_")
+
+private val KEEP_ENV_KEYS = setOf("CURSOR_API_KEY", "CURSOR_AUTH_TOKEN")
+
 /**
  * Captures the user's real login-shell environment (PATH, JAVA_HOME, NVM_DIR, custom exports
  * from `.zshrc`/`.bashrc`, etc.) so processes Andy launches see what a normal terminal would —
@@ -16,6 +27,21 @@ object LoginShellEnvironment {
     private const val ENV_ENTRY_SEPARATOR = '\u0000'
 
     private val cached = AtomicReference<Map<String, String>?>(null)
+
+    /**
+     * Cursor/VS Code inject sandbox XDG_* and CURSOR_* into the JVM. A login-shell
+     * capture that inherits them makes `env -0` report the IDE store, so cursor-agent
+     * looks in an empty sandbox instead of `~/.local/state/cursor`.
+     */
+    fun dropIdeSandboxEnvironment(env: MutableMap<String, String>) {
+        IDE_SANDBOX_XDG_KEYS.forEach { env.remove(it) }
+        env.keys
+            .filter { key ->
+                key !in KEEP_ENV_KEYS && IDE_SANDBOX_PREFIXES.any { prefix -> key.startsWith(prefix) }
+            }
+            .toList()
+            .forEach { env.remove(it) }
+    }
 
     /** Captures once per process (forks a real shell); memoized after the first call. */
     fun current(): Map<String, String> {
@@ -65,7 +91,9 @@ object LoginShellEnvironment {
      * mode `AgentCliLocator.lookupViaLoginShell` guards against).
      */
     private fun runShellCapture(command: List<String>): String? = runCatching {
-        val process = ProcessBuilder(command).redirectErrorStream(true).start()
+        val builder = ProcessBuilder(command).redirectErrorStream(true)
+        dropIdeSandboxEnvironment(builder.environment())
+        val process = builder.start()
         process.outputStream.close()
         val output = StringBuffer()
         val reader = Thread({

--- a/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/GitLocatorTest.kt
+++ b/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/GitLocatorTest.kt
@@ -1,0 +1,63 @@
+package app.andy.desktop.service
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GitLocatorTest {
+    @Test
+    fun fromPathFindsGitInPathEntries() {
+        assertEquals(
+            "/usr/bin/git",
+            GitLocator.fromPath("/opt/bin:/usr/bin:/home/me/.local/bin"),
+        )
+        assertNull(GitLocator.fromPath("/opt/bin:/home/me/.local/bin"))
+        assertNull(GitLocator.fromPath(null))
+    }
+
+    @Test
+    fun locatePrefersProcessPathBeforeKnownLocations() {
+        val resolved = GitLocator.locate(
+            processPath = "/usr/bin",
+            loginShellEnv = mapOf("PATH" to "/opt/homebrew/bin"),
+            knownPaths = listOf("/opt/homebrew/bin/git"),
+            runShell = { error("shell lookup must not run when PATH already resolves git") },
+        )
+        assertEquals("/usr/bin/git", resolved)
+    }
+
+    @Test
+    fun locateFallsBackToKnownLocationsWhenPathIsEmpty() {
+        val resolved = GitLocator.locate(
+            processPath = null,
+            loginShellEnv = emptyMap(),
+            knownPaths = listOf("/usr/bin/git"),
+            runShell = { error("shell lookup must not run when known path matches") },
+        )
+        assertEquals("/usr/bin/git", resolved)
+    }
+
+    @Test
+    fun locateUsesLoginShellLookupAsLastResort() {
+        val resolved = GitLocator.locate(
+            processPath = null,
+            loginShellEnv = emptyMap(),
+            knownPaths = emptyList(),
+            runShell = { _ -> "/bin/sh\n" },
+            osName = "Linux",
+        )
+        assertEquals("/bin/sh", resolved)
+    }
+
+    @Test
+    fun locateSkipsShellLookupOnWindows() {
+        val resolved = GitLocator.locate(
+            processPath = null,
+            loginShellEnv = emptyMap(),
+            knownPaths = emptyList(),
+            runShell = { error("shell lookup must not run on Windows") },
+            osName = "Windows 11",
+        )
+        assertNull(resolved)
+    }
+}

--- a/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/GitLocatorTest.kt
+++ b/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/GitLocatorTest.kt
@@ -1,8 +1,12 @@
 package app.andy.desktop.service
 
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.pathString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import java.io.File
 
 class GitLocatorTest {
     @Test
@@ -13,6 +17,24 @@ class GitLocatorTest {
         )
         assertNull(GitLocator.fromPath("/opt/bin:/home/me/.local/bin"))
         assertNull(GitLocator.fromPath(null))
+    }
+
+    @Test
+    fun fromPathResolvesWindowsGitExeSuffix() {
+        val dir = createTempDirectory(prefix = "andy-git-locator-").toFile()
+        try {
+            val exe = File(dir, "git.exe").apply {
+                writeText("")
+                setExecutable(true)
+            }
+            assertEquals(
+                exe.path,
+                GitLocator.fromPath(dir.path, windows = true),
+            )
+            assertNull(GitLocator.fromPath(dir.path, windows = false))
+        } finally {
+            dir.deleteRecursively()
+        }
     }
 
     @Test
@@ -59,5 +81,11 @@ class GitLocatorTest {
             osName = "Windows 11",
         )
         assertNull(resolved)
+    }
+
+    @Test
+    fun defaultKnownPathsIncludesWindowsGitInstalls() {
+        val paths = GitLocator.defaultKnownPaths(osName = "Windows 11")
+        assertTrue(paths.any { it.endsWith("Git\\cmd\\git.exe") || it.endsWith("Git/cmd/git.exe") })
     }
 }

--- a/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/GitLocatorTest.kt
+++ b/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/GitLocatorTest.kt
@@ -1,22 +1,33 @@
 package app.andy.desktop.service
 
+import java.io.File
 import kotlin.io.path.createTempDirectory
-import kotlin.io.path.pathString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import java.io.File
 
 class GitLocatorTest {
     @Test
     fun fromPathFindsGitInPathEntries() {
-        assertEquals(
-            "/usr/bin/git",
-            GitLocator.fromPath("/opt/bin:/usr/bin:/home/me/.local/bin"),
-        )
-        assertNull(GitLocator.fromPath("/opt/bin:/home/me/.local/bin"))
-        assertNull(GitLocator.fromPath(null))
+        val root = createTempDirectory(prefix = "andy-git-path-").toFile()
+        try {
+            val opt = File(root, "opt").also { it.mkdirs() }
+            val usr = File(root, "usr-bin").also { it.mkdirs() }
+            File(usr, "git").apply {
+                writeText("")
+                setExecutable(true)
+            }
+            val path = listOf(opt.path, usr.path).joinToString(File.pathSeparator)
+            assertEquals(
+                File(usr, "git").path,
+                GitLocator.fromPath(path),
+            )
+            assertNull(GitLocator.fromPath(opt.path))
+            assertNull(GitLocator.fromPath(null))
+        } finally {
+            root.deleteRecursively()
+        }
     }
 
     @Test
@@ -39,36 +50,71 @@ class GitLocatorTest {
 
     @Test
     fun locatePrefersProcessPathBeforeKnownLocations() {
-        val resolved = GitLocator.locate(
-            processPath = "/usr/bin",
-            loginShellEnv = mapOf("PATH" to "/opt/homebrew/bin"),
-            knownPaths = listOf("/opt/homebrew/bin/git"),
-            runShell = { error("shell lookup must not run when PATH already resolves git") },
-        )
-        assertEquals("/usr/bin/git", resolved)
+        val root = createTempDirectory(prefix = "andy-git-prefer-").toFile()
+        try {
+            val processDir = File(root, "process").also { it.mkdirs() }
+            val known = File(root, "known").also { it.mkdirs() }
+            val processGit = File(processDir, "git").apply {
+                writeText("")
+                setExecutable(true)
+            }
+            File(known, "git").apply {
+                writeText("")
+                setExecutable(true)
+            }
+            val resolved = GitLocator.locate(
+                processPath = processDir.path,
+                loginShellEnv = mapOf("PATH" to known.path),
+                knownPaths = listOf(File(known, "git").path),
+                runShell = { error("shell lookup must not run when PATH already resolves git") },
+                osName = "Linux",
+            )
+            assertEquals(processGit.path, resolved)
+        } finally {
+            root.deleteRecursively()
+        }
     }
 
     @Test
     fun locateFallsBackToKnownLocationsWhenPathIsEmpty() {
-        val resolved = GitLocator.locate(
-            processPath = null,
-            loginShellEnv = emptyMap(),
-            knownPaths = listOf("/usr/bin/git"),
-            runShell = { error("shell lookup must not run when known path matches") },
-        )
-        assertEquals("/usr/bin/git", resolved)
+        val root = createTempDirectory(prefix = "andy-git-known-").toFile()
+        try {
+            val knownGit = File(root, "git").apply {
+                writeText("")
+                setExecutable(true)
+            }
+            val resolved = GitLocator.locate(
+                processPath = null,
+                loginShellEnv = emptyMap(),
+                knownPaths = listOf(knownGit.path),
+                runShell = { error("shell lookup must not run when known path matches") },
+                osName = "Linux",
+            )
+            assertEquals(knownGit.path, resolved)
+        } finally {
+            root.deleteRecursively()
+        }
     }
 
     @Test
     fun locateUsesLoginShellLookupAsLastResort() {
-        val resolved = GitLocator.locate(
-            processPath = null,
-            loginShellEnv = emptyMap(),
-            knownPaths = emptyList(),
-            runShell = { _ -> "/bin/sh\n" },
-            osName = "Linux",
-        )
-        assertEquals("/bin/sh", resolved)
+        val root = createTempDirectory(prefix = "andy-git-shell-").toFile()
+        try {
+            val shellGit = File(root, "git-from-shell").apply {
+                writeText("")
+                setExecutable(true)
+            }
+            val resolved = GitLocator.locate(
+                processPath = null,
+                loginShellEnv = emptyMap(),
+                knownPaths = emptyList(),
+                runShell = { _ -> "${shellGit.path}\n" },
+                osName = "Linux",
+            )
+            assertEquals(shellGit.path, resolved)
+        } finally {
+            root.deleteRecursively()
+        }
     }
 
     @Test
@@ -86,6 +132,6 @@ class GitLocatorTest {
     @Test
     fun defaultKnownPathsIncludesWindowsGitInstalls() {
         val paths = GitLocator.defaultKnownPaths(osName = "Windows 11")
-        assertTrue(paths.any { it.endsWith("Git\\cmd\\git.exe") || it.endsWith("Git/cmd/git.exe") })
+        assertTrue(paths.any { it.contains("Git") && it.endsWith("git.exe") })
     }
 }

--- a/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/LoginShellEnvironmentTest.kt
+++ b/data/platform-tools/src/desktopTest/kotlin/app/andy/desktop/service/LoginShellEnvironmentTest.kt
@@ -2,6 +2,7 @@ package app.andy.desktop.service
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LoginShellEnvironmentTest {
@@ -78,5 +79,28 @@ class LoginShellEnvironmentTest {
         assertEquals(listOf("/bin/zsh", "-ilc"), invokedCommand?.take(2))
         assertEquals("/opt/homebrew/bin:/usr/bin", result["PATH"])
         assertEquals("/opt/jdk", result["JAVA_HOME"])
+    }
+
+    @Test
+    fun dropIdeSandboxEnvironmentRemovesCursorXdgAndAgentMarkers() {
+        val env = mutableMapOf(
+            "PATH" to "/usr/bin",
+            "HOME" to "/home/test",
+            "XDG_STATE_HOME" to "/tmp/cursor-sandbox/state",
+            "XDG_CONFIG_HOME" to "/tmp/cursor-sandbox/config",
+            "CURSOR_AGENT" to "1",
+            "CURSOR_API_KEY" to "user-key",
+            "VSCODE_IPC_HOOK" to "/tmp/vscode.sock",
+        )
+
+        LoginShellEnvironment.dropIdeSandboxEnvironment(env)
+
+        assertEquals("/usr/bin", env["PATH"])
+        assertEquals("/home/test", env["HOME"])
+        assertEquals("user-key", env["CURSOR_API_KEY"])
+        assertNull(env["XDG_STATE_HOME"])
+        assertNull(env["XDG_CONFIG_HOME"])
+        assertNull(env["CURSOR_AGENT"])
+        assertNull(env["VSCODE_IPC_HOOK"])
     }
 }

--- a/domain/src/commonMain/kotlin/app/andy/model/AgentConnectionRecovery.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/AgentConnectionRecovery.kt
@@ -3,8 +3,17 @@ package app.andy.model
 /** Follow-up Andy sends after a provider stream stalls mid-turn. */
 const val CONNECTION_STALL_RETRY_PROMPT = "Continue where you left off."
 
-/** Automatic "continue" prompts Andy will send before surfacing the stall banner. */
-const val MAX_CONNECTION_STALL_AUTO_RETRIES = 2
+/**
+ * Maximum automatic continuations without any durable agent progress between them.
+ *
+ * This deliberately bounds a broken provider connection. A later meaningful tool/message
+ * update resets the count, so a real long-running task can recover more than once without
+ * turning a persistent outage into a hot loop.
+ */
+const val MAX_CONNECTION_STALL_AUTO_RETRIES = 5
+
+/** Capacity errors are not transport drops; retry fewer times and back off more slowly. */
+const val MAX_RESOURCE_EXHAUSTED_AUTO_RETRIES = 2
 
 /** Backoff before each automatic stall retry (multiplied by attempt number). */
 const val CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS = 1_000L
@@ -12,8 +21,28 @@ const val CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS = 1_000L
 /** Longer backoff when Cursor reports provider capacity exhaustion. */
 const val RESOURCE_EXHAUSTED_AUTO_RETRY_BACKOFF_MS = 3_000L
 
+/** Never leave a healthy provider idle in a rapid reconnect loop. */
+const val MAX_CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS = 30_000L
+
 /** Follow-up Andy sends when the user accepts a plan-mode turn and asks to implement. */
 const val IMPLEMENT_PLAN_PROMPT = "Implement the plan."
+
+enum class AgentConnectionRecoveryReason {
+    Transport,
+    ResourceExhausted,
+}
+
+/**
+ * Durable automatic-recovery checkpoint. It is stored on [AgentTask], allowing `andyd` to
+ * continue a pending recovery after the desktop client reconnects or the daemon restarts.
+ */
+data class AgentConnectionRecovery(
+    val attemptsWithoutProgress: Int,
+    val reason: AgentConnectionRecoveryReason,
+    val nextRetryAtMillis: Long? = null,
+    /** True only after the bounded automatic budget is spent. */
+    val paused: Boolean = false,
+)
 
 /**
  * Cursor (and some other ACP adapters) surface a transport drop as a standalone
@@ -68,6 +97,24 @@ fun List<AgentEvent>.hasRetriableResourceExhausted(): Boolean =
 /** Automatic continue prompts are kept in the log for turn boundaries, not shown in the transcript. */
 fun CharSequence.isSilentConnectionRecoveryPrompt(): Boolean =
     trim() == CONNECTION_STALL_RETRY_PROMPT
+
+/** Exponential, capped backoff for the next continuation attempt. */
+fun connectionStallRetryBackoffMillis(
+    attempt: Int,
+    reason: AgentConnectionRecoveryReason,
+): Long {
+    val base = when (reason) {
+        AgentConnectionRecoveryReason.Transport -> CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS
+        AgentConnectionRecoveryReason.ResourceExhausted -> RESOURCE_EXHAUSTED_AUTO_RETRY_BACKOFF_MS
+    }
+    val multiplier = 1L shl (attempt - 1).coerceIn(0, 5)
+    return (base * multiplier).coerceAtMost(MAX_CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS)
+}
+
+fun AgentConnectionRecoveryReason.maxAutomaticAttempts(): Int = when (this) {
+    AgentConnectionRecoveryReason.Transport -> MAX_CONNECTION_STALL_AUTO_RETRIES
+    AgentConnectionRecoveryReason.ResourceExhausted -> MAX_RESOURCE_EXHAUSTED_AUTO_RETRIES
+}
 
 private fun List<AgentEvent>.latestTurnStallTexts(): Sequence<CharSequence> = sequence {
     for (event in coalesceAcpTranscriptEvents(latestTurnEvents())) {

--- a/domain/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -532,6 +532,8 @@ data class AgentTask(
     val acpSessionId: String? = null,
     /** Last ACP prompt stop reason, retained for diagnostics and recovery. */
     val stopReason: String? = null,
+    /** Bounded, persisted recovery state for a lost ACP provider stream. */
+    val connectionRecovery: AgentConnectionRecovery? = null,
     /** Transport lane is fixed at creation (provider default / settings); not switched live. */
     val lane: AgentLaneKind = AgentLaneKind.Terminal,
     val createdAtMillis: Long,

--- a/domain/src/commonTest/kotlin/app/andy/model/AgentConnectionRecoveryTest.kt
+++ b/domain/src/commonTest/kotlin/app/andy/model/AgentConnectionRecoveryTest.kt
@@ -7,10 +7,16 @@ import kotlin.test.assertTrue
 
 class AgentConnectionRecoveryTest {
     @Test
-    fun autoRetryPolicyAllowsTwoBackoffAttempts() {
-        assertEquals(2, MAX_CONNECTION_STALL_AUTO_RETRIES)
+    fun autoRetryPolicyIsBoundedAndReasonAware() {
+        assertEquals(5, MAX_CONNECTION_STALL_AUTO_RETRIES)
+        assertEquals(2, MAX_RESOURCE_EXHAUSTED_AUTO_RETRIES)
         assertEquals(1_000L, CONNECTION_STALL_AUTO_RETRY_BACKOFF_MS)
         assertEquals(3_000L, RESOURCE_EXHAUSTED_AUTO_RETRY_BACKOFF_MS)
+        assertEquals(1_000L, connectionStallRetryBackoffMillis(1, AgentConnectionRecoveryReason.Transport))
+        assertEquals(16_000L, connectionStallRetryBackoffMillis(5, AgentConnectionRecoveryReason.Transport))
+        assertEquals(30_000L, connectionStallRetryBackoffMillis(6, AgentConnectionRecoveryReason.ResourceExhausted))
+        assertEquals(5, AgentConnectionRecoveryReason.Transport.maxAutomaticAttempts())
+        assertEquals(2, AgentConnectionRecoveryReason.ResourceExhausted.maxAutomaticAttempts())
         assertEquals("Continue where you left off.", CONNECTION_STALL_RETRY_PROMPT)
         assertTrue(CONNECTION_STALL_RETRY_PROMPT.isSilentConnectionRecoveryPrompt())
         assertFalse("keep going".isSilentConnectionRecoveryPrompt())
@@ -169,4 +175,5 @@ class AgentConnectionRecoveryTest {
         assertTrue(events.hasRetriableConnectionStall())
         assertFalse(events.hasRetriableResourceExhausted())
     }
+
 }

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -368,8 +368,9 @@ fun AgentTaskDetail(
     val selectedSkills = remember(followUp, availableSkills) {
         availableSkills.filter { skill -> followUp.referencesSkill(skill) }
     }
-    val showConnectionStallBanner = remember(transcriptEvents, task.isActive) {
-        shouldShowConnectionStallBanner(transcriptEvents, task.isActive)
+    val recovery = task.connectionRecovery
+    val showConnectionStallBanner = remember(transcriptEvents, task.isActive, recovery) {
+        recovery == null && shouldShowConnectionStallBanner(transcriptEvents, task.isActive)
     }
     val slashHighlight = rememberComposerSlashHighlight(
         agent = runtimeKind,
@@ -817,7 +818,23 @@ fun AgentTaskDetail(
             }
         }
 
-        if (showConnectionStallBanner) {
+        if (recovery != null) {
+            ConnectionRecoveryStatus(
+                recovery = recovery,
+                onResumeNow = if (recovery.paused) {
+                    {
+                        scope.launch {
+                            services.agentRuns.resume(
+                                taskId = task.id,
+                                followUp = CONNECTION_STALL_RETRY_PROMPT,
+                            )
+                        }
+                    }
+                } else {
+                    null
+                },
+            )
+        } else if (showConnectionStallBanner) {
             ConnectionStallBanner(
                 onRetry = {
                     scope.launch {

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -101,6 +101,9 @@ import app.andy.model.AgentThreadChangeSnapshot
 import app.andy.model.AgentPlanEntry
 import app.andy.model.AgentSpawnPresentation
 import app.andy.model.AgentTask
+import app.andy.model.AgentConnectionRecovery
+import app.andy.model.AgentConnectionRecoveryReason
+import app.andy.model.maxAutomaticAttempts
 import app.andy.model.AgentToolImage
 import app.andy.model.AgentToolKind
 import app.andy.model.AgentToolState
@@ -2602,6 +2605,50 @@ fun ConnectionStallBanner(
                 modifier = Modifier
                     .pointerHoverIcon(PointerIcon.Hand)
                     .clickable(onClick = onRetry)
+                    .padding(horizontal = 4.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Quiet status for the normal, bounded recovery path. The red retry card remains reserved for
+ * an unexpected stall that Andy could not safely schedule.
+ */
+@Composable
+fun ConnectionRecoveryStatus(
+    recovery: AgentConnectionRecovery,
+    onResumeNow: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    val limit = recovery.reason.maxAutomaticAttempts()
+    val label = when {
+        recovery.paused -> "Connection needs attention"
+        recovery.reason == AgentConnectionRecoveryReason.ResourceExhausted -> "Waiting for provider capacity"
+        else -> "Reconnecting automatically"
+    }
+    val detail = when {
+        recovery.paused -> "Andy paused after $limit attempts without new progress."
+        else -> "Retry ${recovery.attemptsWithoutProgress} of $limit"
+    }
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text("•", color = Cyan, fontSize = 13.sp)
+        Text(label, color = TextSecondary, fontSize = 12.sp)
+        Text(detail, color = TextSecondary.copy(alpha = 0.72f), fontSize = 12.sp)
+        if (onResumeNow != null) {
+            Text(
+                "Resume",
+                color = Cyan,
+                fontSize = 12.sp,
+                modifier = Modifier
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .clickable(onClick = onResumeNow)
                     .padding(horizontal = 4.dp, vertical = 2.dp),
             )
         }

--- a/native/andy-mirror/README.md
+++ b/native/andy-mirror/README.md
@@ -29,11 +29,12 @@ uploaded as NV12 into Vulkan textures. Presentation is an input-transparent
 override-redirect X11 window (XWayland on typical Wayland desktops) stacked
 over the Live Canvas.
 
-Requires system `libvulkan`, `libX11`, `libXfixes`, plus a recent `libavcodec` /
-`libavutil` at runtime (any common SONAME — Ubuntu's `.so.60`, Fedora/CachyOS
-`.so.61`/`.so.63`, etc.). The JNI library `dlopen`s FFmpeg so a GitHub release
-built on Ubuntu does not `DT_NEEDED` that distro's SONAME. Build still needs
-matching `-dev` headers (`pkg-config --cflags`). Overlay GLSL is compiled to
+Requires system `libvulkan`, `libX11`, `libXfixes`, plus runtime `libavcodec` /
+`libavutil` whose SONAME majors match the `-dev` headers used at build time
+(e.g. Ubuntu build headers → `.so.60`). The JNI library `dlopen`s only those
+majors so a GitHub release built on Ubuntu does not `DT_NEEDED` that distro's
+SONAME, and does not load a mismatched ABI that would corrupt `AVFrame` field
+offsets. Overlay GLSL is compiled to
 SPIR-V when `glslangValidator` or `glslc` is available; otherwise the committed
 `jni/linux/shaders/overlay_shaders.h` is used so CI/local builds do not need a
 shader toolchain. Regenerate that header after editing the GLSL. Native Wayland

--- a/native/andy-mirror/README.md
+++ b/native/andy-mirror/README.md
@@ -29,9 +29,12 @@ uploaded as NV12 into Vulkan textures. Presentation is an input-transparent
 override-redirect X11 window (XWayland on typical Wayland desktops) stacked
 over the Live Canvas.
 
-Requires system `libvulkan`, `libX11`, `libXfixes`, `libavcodec`, and
-`libavutil` (plus matching `-dev` packages to build). Overlay GLSL is compiled
-to SPIR-V when `glslangValidator` or `glslc` is available; otherwise the
-committed `jni/linux/shaders/overlay_shaders.h` is used so CI/local builds do
-not need a shader toolchain. Regenerate that header after editing the GLSL.
-Native Wayland (no X11) is out of scope.
+Requires system `libvulkan`, `libX11`, `libXfixes`, plus a recent `libavcodec` /
+`libavutil` at runtime (any common SONAME — Ubuntu's `.so.60`, Fedora/CachyOS
+`.so.61`/`.so.63`, etc.). The JNI library `dlopen`s FFmpeg so a GitHub release
+built on Ubuntu does not `DT_NEEDED` that distro's SONAME. Build still needs
+matching `-dev` headers (`pkg-config --cflags`). Overlay GLSL is compiled to
+SPIR-V when `glslangValidator` or `glslc` is available; otherwise the committed
+`jni/linux/shaders/overlay_shaders.h` is used so CI/local builds do not need a
+shader toolchain. Regenerate that header after editing the GLSL. Native Wayland
+(no X11) is out of scope.

--- a/native/andy-mirror/jni/linux/andy_mirror_av.c
+++ b/native/andy-mirror/jni/linux/andy_mirror_av.c
@@ -105,7 +105,7 @@ bool andy_av_ensure(void) {
             "andy-mirror: failed to dlopen %s / %s (%s)\n",
             codec_soname,
             util_soname,
-            dlerror(),
+            dlerror()
         );
         if (libavcodec_handle) dlclose(libavcodec_handle);
         if (libavutil_handle) dlclose(libavutil_handle);

--- a/native/andy-mirror/jni/linux/andy_mirror_av.c
+++ b/native/andy-mirror/jni/linux/andy_mirror_av.c
@@ -64,14 +64,15 @@ bool andy_av_ensure(void) {
         return ok;
     }
     loaded = true;
-    static const char *util_names[] = {
-        "libavutil.so.62", "libavutil.so.61", "libavutil.so.60", "libavutil.so.59", "libavutil.so.58",
-        "libavutil.so.57", "libavutil.so.56", "libavutil.so", NULL,
-    };
-    static const char *codec_names[] = {
-        "libavcodec.so.63", "libavcodec.so.62", "libavcodec.so.61", "libavcodec.so.60", "libavcodec.so.59",
-        "libavcodec.so.58", "libavcodec.so", NULL,
-    };
+    /* Struct layouts (AVCodecContext/AVFrame/AVPacket) are ABI-tied to the header
+     * majors used at compile time. Loading a different SONAME can resolve symbols
+     * while misreading fields — only accept the build-matched majors. */
+    char util_soname[32];
+    char codec_soname[32];
+    snprintf(util_soname, sizeof(util_soname), "libavutil.so.%d", LIBAVUTIL_VERSION_MAJOR);
+    snprintf(codec_soname, sizeof(codec_soname), "libavcodec.so.%d", LIBAVCODEC_VERSION_MAJOR);
+    const char *util_names[] = { util_soname, NULL };
+    const char *codec_names[] = { codec_soname, NULL };
     libavutil_handle = open_sonames(util_names);
     libavcodec_handle = open_sonames(codec_names);
     load_ok = libavutil_handle && libavcodec_handle &&
@@ -99,7 +100,13 @@ bool andy_av_ensure(void) {
         lookup_either("avcodec_parameters_free", (void **) &p_avcodec_parameters_free) &&
         lookup_either("avcodec_parameters_to_context", (void **) &p_avcodec_parameters_to_context);
     if (!load_ok) {
-        fprintf(stderr, "andy-mirror: failed to dlopen libavcodec/libavutil (%s)\n", dlerror());
+        fprintf(
+            stderr,
+            "andy-mirror: failed to dlopen %s / %s (%s)\n",
+            codec_soname,
+            util_soname,
+            dlerror(),
+        );
         if (libavcodec_handle) dlclose(libavcodec_handle);
         if (libavutil_handle) dlclose(libavutil_handle);
         libavcodec_handle = NULL;

--- a/native/andy-mirror/jni/linux/andy_mirror_av.c
+++ b/native/andy-mirror/jni/linux/andy_mirror_av.c
@@ -1,0 +1,211 @@
+#include "andy_mirror_av.h"
+
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+static pthread_mutex_t load_lock = PTHREAD_MUTEX_INITIALIZER;
+static bool loaded = false;
+static bool load_ok = false;
+static void *libavutil_handle = NULL;
+static void *libavcodec_handle = NULL;
+
+static void *(*p_av_malloc)(size_t) = NULL;
+static void (*p_avcodec_free_context)(AVCodecContext **) = NULL;
+static void (*p_av_buffer_unref)(AVBufferRef **) = NULL;
+static const AVCodec *(*p_avcodec_find_decoder_by_name)(const char *) = NULL;
+static AVCodecContext *(*p_avcodec_alloc_context3)(const AVCodec *) = NULL;
+static int (*p_av_hwdevice_ctx_create)(AVBufferRef **, enum AVHWDeviceType, const char *, AVDictionary *, int) = NULL;
+static AVBufferRef *(*p_av_buffer_ref)(const AVBufferRef *) = NULL;
+static int (*p_av_opt_set)(void *, const char *, const char *, int) = NULL;
+static int (*p_avcodec_open2)(AVCodecContext *, const AVCodec *, AVDictionary **) = NULL;
+static AVPacket *(*p_av_packet_alloc)(void) = NULL;
+static AVFrame *(*p_av_frame_alloc)(void) = NULL;
+static void (*p_av_packet_free)(AVPacket **) = NULL;
+static void (*p_av_frame_free)(AVFrame **) = NULL;
+static void (*p_avcodec_flush_buffers)(AVCodecContext *) = NULL;
+static void (*p_av_packet_unref)(AVPacket *) = NULL;
+static int (*p_av_new_packet)(AVPacket *, int) = NULL;
+static int (*p_avcodec_send_packet)(AVCodecContext *, const AVPacket *) = NULL;
+static int (*p_avcodec_receive_frame)(AVCodecContext *, AVFrame *) = NULL;
+static void (*p_av_frame_unref)(AVFrame *) = NULL;
+static int (*p_av_hwframe_transfer_data)(AVFrame *, const AVFrame *, int) = NULL;
+static AVCodecParameters *(*p_avcodec_parameters_alloc)(void) = NULL;
+static void (*p_avcodec_parameters_free)(AVCodecParameters **) = NULL;
+static int (*p_avcodec_parameters_to_context)(AVCodecContext *, const AVCodecParameters *) = NULL;
+
+static void *open_sonames(const char *const *names) {
+    for (int i = 0; names[i]; ++i) {
+        void *handle = dlopen(names[i], RTLD_NOW | RTLD_GLOBAL);
+        if (handle) return handle;
+    }
+    return NULL;
+}
+
+static bool lookup(void *handle, const char *name, void **out) {
+    if (!handle) return false;
+    dlerror();
+    void *sym = dlsym(handle, name);
+    if (!sym) return false;
+    *out = sym;
+    return true;
+}
+
+static bool lookup_either(const char *name, void **out) {
+    return lookup(libavcodec_handle, name, out) || lookup(libavutil_handle, name, out);
+}
+
+bool andy_av_ensure(void) {
+    pthread_mutex_lock(&load_lock);
+    if (loaded) {
+        const bool ok = load_ok;
+        pthread_mutex_unlock(&load_lock);
+        return ok;
+    }
+    loaded = true;
+    static const char *util_names[] = {
+        "libavutil.so.62", "libavutil.so.61", "libavutil.so.60", "libavutil.so.59", "libavutil.so.58",
+        "libavutil.so.57", "libavutil.so.56", "libavutil.so", NULL,
+    };
+    static const char *codec_names[] = {
+        "libavcodec.so.63", "libavcodec.so.62", "libavcodec.so.61", "libavcodec.so.60", "libavcodec.so.59",
+        "libavcodec.so.58", "libavcodec.so", NULL,
+    };
+    libavutil_handle = open_sonames(util_names);
+    libavcodec_handle = open_sonames(codec_names);
+    load_ok = libavutil_handle && libavcodec_handle &&
+        lookup_either("av_malloc", (void **) &p_av_malloc) &&
+        lookup_either("avcodec_free_context", (void **) &p_avcodec_free_context) &&
+        lookup_either("av_buffer_unref", (void **) &p_av_buffer_unref) &&
+        lookup_either("avcodec_find_decoder_by_name", (void **) &p_avcodec_find_decoder_by_name) &&
+        lookup_either("avcodec_alloc_context3", (void **) &p_avcodec_alloc_context3) &&
+        lookup_either("av_hwdevice_ctx_create", (void **) &p_av_hwdevice_ctx_create) &&
+        lookup_either("av_buffer_ref", (void **) &p_av_buffer_ref) &&
+        lookup_either("av_opt_set", (void **) &p_av_opt_set) &&
+        lookup_either("avcodec_open2", (void **) &p_avcodec_open2) &&
+        lookup_either("av_packet_alloc", (void **) &p_av_packet_alloc) &&
+        lookup_either("av_frame_alloc", (void **) &p_av_frame_alloc) &&
+        lookup_either("av_packet_free", (void **) &p_av_packet_free) &&
+        lookup_either("av_frame_free", (void **) &p_av_frame_free) &&
+        lookup_either("avcodec_flush_buffers", (void **) &p_avcodec_flush_buffers) &&
+        lookup_either("av_packet_unref", (void **) &p_av_packet_unref) &&
+        lookup_either("av_new_packet", (void **) &p_av_new_packet) &&
+        lookup_either("avcodec_send_packet", (void **) &p_avcodec_send_packet) &&
+        lookup_either("avcodec_receive_frame", (void **) &p_avcodec_receive_frame) &&
+        lookup_either("av_frame_unref", (void **) &p_av_frame_unref) &&
+        lookup_either("av_hwframe_transfer_data", (void **) &p_av_hwframe_transfer_data) &&
+        lookup_either("avcodec_parameters_alloc", (void **) &p_avcodec_parameters_alloc) &&
+        lookup_either("avcodec_parameters_free", (void **) &p_avcodec_parameters_free) &&
+        lookup_either("avcodec_parameters_to_context", (void **) &p_avcodec_parameters_to_context);
+    if (!load_ok) {
+        fprintf(stderr, "andy-mirror: failed to dlopen libavcodec/libavutil (%s)\n", dlerror());
+        if (libavcodec_handle) dlclose(libavcodec_handle);
+        if (libavutil_handle) dlclose(libavutil_handle);
+        libavcodec_handle = NULL;
+        libavutil_handle = NULL;
+    }
+    pthread_mutex_unlock(&load_lock);
+    return load_ok;
+}
+
+void *andy_av_malloc(size_t size) {
+    return andy_av_ensure() ? p_av_malloc(size) : NULL;
+}
+
+void andy_avcodec_free_context(AVCodecContext **avctx) {
+    if (andy_av_ensure() && p_avcodec_free_context) p_avcodec_free_context(avctx);
+}
+
+void andy_av_buffer_unref(AVBufferRef **buf) {
+    if (andy_av_ensure() && p_av_buffer_unref) p_av_buffer_unref(buf);
+}
+
+const AVCodec *andy_avcodec_find_decoder_by_name(const char *name) {
+    return andy_av_ensure() ? p_avcodec_find_decoder_by_name(name) : NULL;
+}
+
+AVCodecContext *andy_avcodec_alloc_context3(const AVCodec *codec) {
+    return andy_av_ensure() ? p_avcodec_alloc_context3(codec) : NULL;
+}
+
+int andy_av_hwdevice_ctx_create(AVBufferRef **device_ctx, enum AVHWDeviceType type, const char *device,
+                                AVDictionary *opts, int flags) {
+    return andy_av_ensure() ? p_av_hwdevice_ctx_create(device_ctx, type, device, opts, flags) : -1;
+}
+
+AVBufferRef *andy_av_buffer_ref(const AVBufferRef *buf) {
+    return andy_av_ensure() ? p_av_buffer_ref(buf) : NULL;
+}
+
+int andy_av_opt_set(void *obj, const char *name, const char *val, int search_flags) {
+    return andy_av_ensure() ? p_av_opt_set(obj, name, val, search_flags) : -1;
+}
+
+int andy_avcodec_open2(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options) {
+    return andy_av_ensure() ? p_avcodec_open2(avctx, codec, options) : -1;
+}
+
+AVPacket *andy_av_packet_alloc(void) {
+    return andy_av_ensure() ? p_av_packet_alloc() : NULL;
+}
+
+AVFrame *andy_av_frame_alloc(void) {
+    return andy_av_ensure() ? p_av_frame_alloc() : NULL;
+}
+
+void andy_av_packet_free(AVPacket **pkt) {
+    if (andy_av_ensure() && p_av_packet_free) p_av_packet_free(pkt);
+}
+
+void andy_av_frame_free(AVFrame **frame) {
+    if (andy_av_ensure() && p_av_frame_free) p_av_frame_free(frame);
+}
+
+void andy_avcodec_flush_buffers(AVCodecContext *avctx) {
+    if (andy_av_ensure() && p_avcodec_flush_buffers) p_avcodec_flush_buffers(avctx);
+}
+
+void andy_av_packet_unref(AVPacket *pkt) {
+    if (andy_av_ensure() && p_av_packet_unref) p_av_packet_unref(pkt);
+}
+
+int andy_av_new_packet(AVPacket *pkt, int size) {
+    return andy_av_ensure() ? p_av_new_packet(pkt, size) : -1;
+}
+
+int andy_avcodec_send_packet(AVCodecContext *avctx, const AVPacket *avpkt) {
+    return andy_av_ensure() ? p_avcodec_send_packet(avctx, avpkt) : -1;
+}
+
+int andy_avcodec_receive_frame(AVCodecContext *avctx, AVFrame *frame) {
+    return andy_av_ensure() ? p_avcodec_receive_frame(avctx, frame) : -1;
+}
+
+void andy_av_frame_unref(AVFrame *frame) {
+    if (andy_av_ensure() && p_av_frame_unref) p_av_frame_unref(frame);
+}
+
+int andy_av_hwframe_transfer_data(AVFrame *dst, const AVFrame *src, int flags) {
+    return andy_av_ensure() ? p_av_hwframe_transfer_data(dst, src, flags) : -1;
+}
+
+int andy_avcodec_parameters_from_extradata(AVCodecContext *avctx, const uint8_t *extradata, int extradata_size) {
+    if (!andy_av_ensure() || !avctx || !extradata || extradata_size <= 0) return -1;
+    AVCodecParameters *par = p_avcodec_parameters_alloc();
+    if (!par) return -1;
+    par->codec_type = AVMEDIA_TYPE_VIDEO;
+    par->codec_id = AV_CODEC_ID_H264;
+    uint8_t *copy = (uint8_t *) p_av_malloc((size_t) extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
+    if (!copy) {
+        p_avcodec_parameters_free(&par);
+        return -1;
+    }
+    memcpy(copy, extradata, (size_t) extradata_size);
+    memset(copy + extradata_size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
+    par->extradata = copy;
+    par->extradata_size = extradata_size;
+    const int rc = p_avcodec_parameters_to_context(avctx, par);
+    p_avcodec_parameters_free(&par);
+    return rc;
+}

--- a/native/andy-mirror/jni/linux/andy_mirror_av.h
+++ b/native/andy-mirror/jni/linux/andy_mirror_av.h
@@ -1,0 +1,44 @@
+#ifndef ANDY_MIRROR_AV_H
+#define ANDY_MIRROR_AV_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <libavcodec/avcodec.h>
+#include <libavutil/dict.h>
+#include <libavutil/buffer.h>
+#include <libavutil/frame.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/mem.h>
+#include <libavutil/opt.h>
+#include <libavutil/pixfmt.h>
+#include <libavutil/rational.h>
+
+/** Loads libavutil/libavcodec via dlopen so the JNI .so has no FFmpeg DT_NEEDED. */
+bool andy_av_ensure(void);
+
+void *andy_av_malloc(size_t size);
+void andy_avcodec_free_context(AVCodecContext **avctx);
+void andy_av_buffer_unref(AVBufferRef **buf);
+const AVCodec *andy_avcodec_find_decoder_by_name(const char *name);
+AVCodecContext *andy_avcodec_alloc_context3(const AVCodec *codec);
+int andy_av_hwdevice_ctx_create(AVBufferRef **device_ctx, enum AVHWDeviceType type, const char *device,
+                                AVDictionary *opts, int flags);
+AVBufferRef *andy_av_buffer_ref(const AVBufferRef *buf);
+int andy_av_opt_set(void *obj, const char *name, const char *val, int search_flags);
+int andy_avcodec_open2(AVCodecContext *avctx, const AVCodec *codec, AVDictionary **options);
+AVPacket *andy_av_packet_alloc(void);
+AVFrame *andy_av_frame_alloc(void);
+void andy_av_packet_free(AVPacket **pkt);
+void andy_av_frame_free(AVFrame **frame);
+void andy_avcodec_flush_buffers(AVCodecContext *avctx);
+void andy_av_packet_unref(AVPacket *pkt);
+int andy_av_new_packet(AVPacket *pkt, int size);
+int andy_avcodec_send_packet(AVCodecContext *avctx, const AVPacket *avpkt);
+int andy_avcodec_receive_frame(AVCodecContext *avctx, AVFrame *frame);
+void andy_av_frame_unref(AVFrame *frame);
+int andy_av_hwframe_transfer_data(AVFrame *dst, const AVFrame *src, int flags);
+int andy_avcodec_parameters_from_extradata(AVCodecContext *avctx, const uint8_t *extradata, int extradata_size);
+
+#endif

--- a/native/andy-mirror/jni/linux/andy_mirror_av.h
+++ b/native/andy-mirror/jni/linux/andy_mirror_av.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #include <libavcodec/avcodec.h>
+#include <libavcodec/version.h>
 #include <libavutil/dict.h>
 #include <libavutil/buffer.h>
 #include <libavutil/frame.h>
@@ -14,6 +15,7 @@
 #include <libavutil/opt.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/rational.h>
+#include <libavutil/version.h>
 
 /** Loads libavutil/libavcodec via dlopen so the JNI .so has no FFmpeg DT_NEEDED. */
 bool andy_av_ensure(void);

--- a/native/andy-mirror/jni/linux/andy_mirror_hub.h
+++ b/native/andy-mirror/jni/linux/andy_mirror_hub.h
@@ -58,6 +58,12 @@ void andy_hub_set_ios_decoder(int64_t decoder_id);
 void andy_hub_clear_ios_decoder(int64_t decoder_id);
 int64_t andy_hub_ios_decoder(void);
 
+int andy_hub_window_desktop(int parent_window_number);
+void andy_hub_refresh_all_presenters(void);
+void andy_hub_suppress_presenters_for_desktop_switch(void);
+bool andy_hub_should_resume_presenters_after_desktop_switch(void);
+void andy_hub_resume_presenters_after_desktop_switch(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/native/andy-mirror/jni/linux/andy_mirror_hub_linux.c
+++ b/native/andy-mirror/jni/linux/andy_mirror_hub_linux.c
@@ -59,6 +59,14 @@ typedef struct {
     int pending_h;
     double pending_scale;
     int pending_parent_window;
+    bool desktop_suppressed;
+    bool frame_applied;
+    int applied_x;
+    int applied_y;
+    int applied_w;
+    int applied_h;
+    int applied_parent;
+    bool applied_mapped;
 } GpuPresenter;
 
 static GpuDecoder decoders[ANDY_MAX_DECODERS];
@@ -183,10 +191,13 @@ static void remember_latest(GpuDecoder *decoder, const AndyFrameStore *frame) {
     pthread_mutex_unlock(&decoder->latest_lock);
 }
 
+static void apply_presenter_frame(GpuPresenter *presenter);
+
 static bool render_to_presenter(GpuPresenter *presenter, GpuDecoder *decoder, const AndyFrameStore *frame,
                                 bool input_changed_probe, uint64_t packet_ticks, uint64_t transport_ticks,
                                 bool record_presentation_metrics) {
     if (!presenter->overlay_open || !presenter->visible || !presenter->vk || !frame || !frame->plane0) return false;
+    if (!presenter->desktop_suppressed) apply_presenter_frame(presenter);
     pthread_mutex_lock(&render_lock);
     if (!presenter->overlay_open || !presenter->vk) {
         pthread_mutex_unlock(&render_lock);
@@ -222,9 +233,26 @@ static void apply_presenter_frame(GpuPresenter *presenter) {
     if (!presenter->overlay_open || !presenter->window) return;
     const int w = presenter->pending_w > 0 ? presenter->pending_w : 1;
     const int h = presenter->pending_h > 0 ? presenter->pending_h : 1;
-    andy_x11_configure(presenter->window, presenter->pending_x, presenter->pending_y, w, h,
-                       (unsigned long) (uint32_t) presenter->pending_parent_window, presenter->visible);
+    const bool want_map = presenter->visible && !presenter->desktop_suppressed;
+    const int parent = presenter->pending_parent_window;
+    if (presenter->frame_applied && presenter->applied_x == presenter->pending_x &&
+        presenter->applied_y == presenter->pending_y && presenter->applied_w == w && presenter->applied_h == h &&
+        presenter->applied_parent == parent && presenter->applied_mapped == want_map) {
+        return;
+    }
+    const bool restack = want_map;
+    // Record the real map result. If the parent is not viewable yet (boot / desktop
+    // return), configure unmaps — leaving frame_applied false so later frames retry.
+    const bool mapped = andy_x11_configure(presenter->window, presenter->pending_x, presenter->pending_y, w, h,
+                                           (unsigned long) (uint32_t) parent, want_map, restack);
     if (presenter->vk) andy_vk_note_resize(presenter->vk, w, h);
+    presenter->applied_x = presenter->pending_x;
+    presenter->applied_y = presenter->pending_y;
+    presenter->applied_w = w;
+    presenter->applied_h = h;
+    presenter->applied_parent = parent;
+    presenter->applied_mapped = mapped;
+    presenter->frame_applied = mapped == want_map;
 }
 
 static bool open_presenter_window(GpuPresenter *presenter) {
@@ -388,8 +416,17 @@ void andy_hub_set_presenter_visible(int64_t presenter_id, bool visible) {
     GpuPresenter *presenter = find_presenter(presenter_id);
     if (!presenter || !presenter->window) return;
     presenter->visible = visible;
-    andy_x11_set_visible(presenter->window, visible);
-    if (visible) apply_presenter_frame(presenter);
+    if (visible) {
+        // Do not clear desktop_suppressed here. Geometry refresh / applyVisible(true)
+        // fires during Plasma desktop switches and would remount the floating overlay.
+        // Attach/warmResume/desktop-guard call resume_presenters to clear suppress.
+        presenter->frame_applied = false;
+        apply_presenter_frame(presenter);
+    } else {
+        presenter->frame_applied = false;
+        presenter->applied_mapped = false;
+        andy_x11_set_visible(presenter->window, false);
+    }
 }
 
 void andy_hub_update_presenter_geometry(int64_t presenter_id, int x, int y, int width, int height, double scale,
@@ -435,6 +472,7 @@ void andy_hub_repaint_presenter(int64_t presenter_id) {
     if (!presenter) return;
     GpuDecoder *decoder = find_decoder(presenter->decoder_id);
     if (!decoder) return;
+    if (!presenter->desktop_suppressed) apply_presenter_frame(presenter);
     pthread_mutex_lock(&decoder->latest_lock);
     AndyFrameStore copy = {0};
     const bool ok = andy_frame_store_clone(&copy, &decoder->latest);
@@ -769,4 +807,73 @@ void andy_hub_clear_ios_decoder(int64_t decoder_id) {
 
 int64_t andy_hub_ios_decoder(void) {
     return ios_decoder_id;
+}
+
+int andy_hub_window_desktop(int parent_window_number) {
+    if (parent_window_number <= 0) return -1;
+    return andy_x11_window_desktop((unsigned long) (uint32_t) parent_window_number);
+}
+
+void andy_hub_refresh_all_presenters(void) {
+    pthread_mutex_lock(&hub_lock);
+    for (int i = 0; i < ANDY_MAX_PRESENTERS; ++i) {
+        GpuPresenter *presenter = &presenters[i];
+        if (presenter->active && presenter->overlay_open) {
+            apply_presenter_frame(presenter);
+        }
+    }
+    pthread_mutex_unlock(&hub_lock);
+}
+
+void andy_hub_suppress_presenters_for_desktop_switch(void) {
+    pthread_mutex_lock(&hub_lock);
+    for (int i = 0; i < ANDY_MAX_PRESENTERS; ++i) {
+        GpuPresenter *presenter = &presenters[i];
+        if (!presenter->active || !presenter->overlay_open || !presenter->window) continue;
+        presenter->desktop_suppressed = true;
+        presenter->frame_applied = false;
+        presenter->applied_mapped = false;
+        andy_x11_set_visible(presenter->window, false);
+    }
+    pthread_mutex_unlock(&hub_lock);
+}
+
+bool andy_hub_should_resume_presenters_after_desktop_switch(void) {
+    pthread_mutex_lock(&hub_lock);
+    bool resume = false;
+    for (int i = 0; i < ANDY_MAX_PRESENTERS; ++i) {
+        GpuPresenter *presenter = &presenters[i];
+        if (!presenter->active || !presenter->overlay_open || !presenter->visible) continue;
+        const Window parent =
+            presenter->pending_parent_window ? (Window) (unsigned long) (uint32_t) presenter->pending_parent_window
+                                             : None;
+        if (parent && andy_x11_window_viewable((unsigned long) parent)) {
+            resume = true;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&hub_lock);
+    return resume;
+}
+
+void andy_hub_resume_presenters_after_desktop_switch(void) {
+    pthread_mutex_lock(&hub_lock);
+    for (int i = 0; i < ANDY_MAX_PRESENTERS; ++i) {
+        GpuPresenter *presenter = &presenters[i];
+        if (!presenter->active || !presenter->overlay_open || !presenter->window) continue;
+        // Never force visible=true: warm-detached presenters (tab leave) stay hidden.
+        // Only clear desktop suppress for presenters the host still wants shown.
+        if (!presenter->visible) {
+            presenter->desktop_suppressed = false;
+            presenter->frame_applied = false;
+            presenter->applied_mapped = false;
+            continue;
+        }
+        presenter->desktop_suppressed = false;
+        presenter->frame_applied = false;
+        presenter->applied_mapped = false;
+        apply_presenter_frame(presenter);
+        andy_hub_repaint_presenter(presenter->id);
+    }
+    pthread_mutex_unlock(&hub_lock);
 }

--- a/native/andy-mirror/jni/linux/andy_mirror_internal.h
+++ b/native/andy-mirror/jni/linux/andy_mirror_internal.h
@@ -48,8 +48,13 @@ bool andy_x11_init(void);
 Display *andy_x11_display(void);
 bool andy_x11_create_overlay(Window *out_window);
 void andy_x11_destroy_overlay(Window window);
-void andy_x11_configure(Window window, int x, int y, int width, int height, unsigned long parent, bool visible);
+/** Returns true when the overlay is mapped after the configure. */
+bool andy_x11_configure(Window window, int x, int y, int width, int height, unsigned long parent, bool visible,
+                        bool restack);
 void andy_x11_set_visible(Window window, bool visible);
+bool andy_x11_should_map(Window window, Window parent, bool visible);
+bool andy_x11_window_viewable(unsigned long window_id);
+int andy_x11_window_desktop(unsigned long window_id);
 
 typedef struct AndyVkSwapchain AndyVkSwapchain;
 

--- a/native/andy-mirror/jni/linux/andy_mirror_jni_linux.c
+++ b/native/andy-mirror/jni/linux/andy_mirror_jni_linux.c
@@ -213,3 +213,33 @@ JNIEXPORT jboolean JNICALL GPU_JNI_METHOD(nativeLatestFrameSize)(JNIEnv *env, jc
     (*env)->SetIntArrayRegion(env, out_size, 0, 2, values);
     return JNI_TRUE;
 }
+
+JNIEXPORT jint JNICALL GPU_JNI_METHOD(nativeReadWindowDesktop)(JNIEnv *env, jclass clazz, jint window_number) {
+    (void) env;
+    (void) clazz;
+    return (jint) andy_hub_window_desktop(window_number);
+}
+
+JNIEXPORT void JNICALL GPU_JNI_METHOD(nativeRefreshAllPresenters)(JNIEnv *env, jclass clazz) {
+    (void) env;
+    (void) clazz;
+    andy_hub_refresh_all_presenters();
+}
+
+JNIEXPORT void JNICALL GPU_JNI_METHOD(nativeSuppressForDesktopSwitch)(JNIEnv *env, jclass clazz) {
+    (void) env;
+    (void) clazz;
+    andy_hub_suppress_presenters_for_desktop_switch();
+}
+
+JNIEXPORT jboolean JNICALL GPU_JNI_METHOD(nativeShouldResumePresentersAfterDesktopSwitch)(JNIEnv *env, jclass clazz) {
+    (void) env;
+    (void) clazz;
+    return andy_hub_should_resume_presenters_after_desktop_switch() ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT void JNICALL GPU_JNI_METHOD(nativeResumeAfterDesktopSwitch)(JNIEnv *env, jclass clazz) {
+    (void) env;
+    (void) clazz;
+    andy_hub_resume_presenters_after_desktop_switch();
+}

--- a/native/andy-mirror/jni/linux/andy_mirror_nvdec.c
+++ b/native/andy-mirror/jni/linux/andy_mirror_nvdec.c
@@ -1,9 +1,6 @@
 #include "andy_mirror_internal.h"
+#include "andy_mirror_av.h"
 
-#include <libavcodec/avcodec.h>
-#include <libavutil/hwcontext.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/opt.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,7 +25,7 @@ static uint8_t *make_annexb_extradata(const uint8_t *sps, size_t sps_size, const
                                       int *out_size) {
     const uint8_t start[4] = {0, 0, 0, 1};
     const int size = (int) (8 + sps_size + pps_size);
-    uint8_t *data = (uint8_t *) av_malloc((size_t) size + AV_INPUT_BUFFER_PADDING_SIZE);
+    uint8_t *data = (uint8_t *) malloc((size_t) size + AV_INPUT_BUFFER_PADDING_SIZE);
     if (!data) return NULL;
     memset(data, 0, (size_t) size + AV_INPUT_BUFFER_PADDING_SIZE);
     memcpy(data, start, 4);
@@ -41,8 +38,8 @@ static uint8_t *make_annexb_extradata(const uint8_t *sps, size_t sps_size, const
 
 static void close_codec(AndyNvdec *decoder) {
     if (!decoder) return;
-    if (decoder->ctx) avcodec_free_context(&decoder->ctx);
-    if (decoder->hw_device) av_buffer_unref(&decoder->hw_device);
+    if (decoder->ctx) andy_avcodec_free_context(&decoder->ctx);
+    if (decoder->hw_device) andy_av_buffer_unref(&decoder->hw_device);
     decoder->ctx = NULL;
     decoder->hw_device = NULL;
     decoder->hardware = false;
@@ -50,30 +47,36 @@ static void close_codec(AndyNvdec *decoder) {
 
 static bool open_named(AndyNvdec *decoder, const char *name, enum AVHWDeviceType hw, const uint8_t *sps,
                        size_t sps_size, const uint8_t *pps, size_t pps_size) {
-    const AVCodec *codec = avcodec_find_decoder_by_name(name);
+    const AVCodec *codec = andy_avcodec_find_decoder_by_name(name);
     if (!codec) return false;
     close_codec(decoder);
-    decoder->ctx = avcodec_alloc_context3(codec);
+    decoder->ctx = andy_avcodec_alloc_context3(codec);
     if (!decoder->ctx) return false;
-    decoder->ctx->pkt_timebase = (AVRational){1, 90};
-    decoder->ctx->flags |= AV_CODEC_FLAG_LOW_DELAY;
-    decoder->ctx->flags2 |= AV_CODEC_FLAG2_FAST;
+    andy_av_opt_set(decoder->ctx, "flags", "+low_delay", 0);
+    andy_av_opt_set(decoder->ctx, "flags2", "+fast", 0);
     int extra_size = 0;
-    decoder->ctx->extradata = make_annexb_extradata(sps, sps_size, pps, pps_size, &extra_size);
-    decoder->ctx->extradata_size = extra_size;
+    uint8_t *extra = make_annexb_extradata(sps, sps_size, pps, pps_size, &extra_size);
+    if (!extra) {
+        close_codec(decoder);
+        return false;
+    }
+    if (andy_avcodec_parameters_from_extradata(decoder->ctx, extra, extra_size) < 0) {
+        free(extra);
+        close_codec(decoder);
+        return false;
+    }
+    free(extra);
     if (hw != AV_HWDEVICE_TYPE_NONE) {
-        if (av_hwdevice_ctx_create(&decoder->hw_device, hw, NULL, NULL, 0) < 0) {
+        if (andy_av_hwdevice_ctx_create(&decoder->hw_device, hw, NULL, NULL, 0) < 0) {
             close_codec(decoder);
             return false;
         }
-        decoder->ctx->hw_device_ctx = av_buffer_ref(decoder->hw_device);
+        decoder->ctx->hw_device_ctx = andy_av_buffer_ref(decoder->hw_device);
         decoder->ctx->get_format = pick_hw_format;
     }
-    if (decoder->ctx->priv_data) {
-        av_opt_set(decoder->ctx->priv_data, "tune", "zerolatency", 0);
-        av_opt_set(decoder->ctx->priv_data, "deint", "weave", 0);
-    }
-    if (avcodec_open2(decoder->ctx, codec, NULL) < 0) {
+    andy_av_opt_set(decoder->ctx, "tune", "zerolatency", AV_OPT_SEARCH_CHILDREN);
+    andy_av_opt_set(decoder->ctx, "deint", "weave", AV_OPT_SEARCH_CHILDREN);
+    if (andy_avcodec_open2(decoder->ctx, codec, NULL) < 0) {
         close_codec(decoder);
         return false;
     }
@@ -82,12 +85,12 @@ static bool open_named(AndyNvdec *decoder, const char *name, enum AVHWDeviceType
 }
 
 AndyNvdec *andy_nvdec_open(const uint8_t *sps, size_t sps_size, const uint8_t *pps, size_t pps_size) {
-    if (!sps || !pps || !sps_size || !pps_size) return NULL;
+    if (!sps || !pps || !sps_size || !pps_size || !andy_av_ensure()) return NULL;
     AndyNvdec *decoder = (AndyNvdec *) calloc(1, sizeof(AndyNvdec));
     if (!decoder) return NULL;
-    decoder->packet = av_packet_alloc();
-    decoder->frame = av_frame_alloc();
-    decoder->sw_frame = av_frame_alloc();
+    decoder->packet = andy_av_packet_alloc();
+    decoder->frame = andy_av_frame_alloc();
+    decoder->sw_frame = andy_av_frame_alloc();
     if (!decoder->packet || !decoder->frame || !decoder->sw_frame) {
         andy_nvdec_close(decoder);
         return NULL;
@@ -104,15 +107,15 @@ AndyNvdec *andy_nvdec_open(const uint8_t *sps, size_t sps_size, const uint8_t *p
 void andy_nvdec_close(AndyNvdec *decoder) {
     if (!decoder) return;
     close_codec(decoder);
-    av_packet_free(&decoder->packet);
-    av_frame_free(&decoder->frame);
-    av_frame_free(&decoder->sw_frame);
+    andy_av_packet_free(&decoder->packet);
+    andy_av_frame_free(&decoder->frame);
+    andy_av_frame_free(&decoder->sw_frame);
     free(decoder);
 }
 
 void andy_nvdec_reset(AndyNvdec *decoder) {
     if (!decoder || !decoder->ctx) return;
-    avcodec_flush_buffers(decoder->ctx);
+    andy_avcodec_flush_buffers(decoder->ctx);
 }
 
 bool andy_nvdec_is_hardware(const AndyNvdec *decoder) {
@@ -137,22 +140,22 @@ static bool copy_decoded_frame(const AVFrame *frame, AndyFrameStore *out) {
 
 bool andy_nvdec_decode(AndyNvdec *decoder, const uint8_t *annexb, size_t length, AndyFrameStore *out) {
     if (!decoder || !decoder->ctx || !annexb || !length || !out) return false;
-    av_packet_unref(decoder->packet);
-    if (av_new_packet(decoder->packet, (int) length) < 0) return false;
+    andy_av_packet_unref(decoder->packet);
+    if (andy_av_new_packet(decoder->packet, (int) length) < 0) return false;
     memcpy(decoder->packet->data, annexb, length);
     decoder->packet->flags |= AV_PKT_FLAG_KEY;
-    int send = avcodec_send_packet(decoder->ctx, decoder->packet);
+    int send = andy_avcodec_send_packet(decoder->ctx, decoder->packet);
     if (send < 0 && send != AVERROR(EAGAIN)) return false;
     bool got = false;
     while (true) {
-        av_frame_unref(decoder->frame);
-        int rec = avcodec_receive_frame(decoder->ctx, decoder->frame);
+        andy_av_frame_unref(decoder->frame);
+        int rec = andy_avcodec_receive_frame(decoder->ctx, decoder->frame);
         if (rec == AVERROR(EAGAIN) || rec == AVERROR_EOF) break;
         if (rec < 0) return got;
         const AVFrame *usable = decoder->frame;
         if (decoder->frame->hw_frames_ctx || decoder->frame->format == AV_PIX_FMT_CUDA) {
-            av_frame_unref(decoder->sw_frame);
-            if (av_hwframe_transfer_data(decoder->sw_frame, decoder->frame, 0) < 0) continue;
+            andy_av_frame_unref(decoder->sw_frame);
+            if (andy_av_hwframe_transfer_data(decoder->sw_frame, decoder->frame, 0) < 0) continue;
             usable = decoder->sw_frame;
         }
         if (copy_decoded_frame(usable, out)) got = true;

--- a/native/andy-mirror/jni/linux/andy_mirror_x11.c
+++ b/native/andy-mirror/jni/linux/andy_mirror_x11.c
@@ -13,7 +13,88 @@ static Display *display = NULL;
 static int screen = 0;
 static Window root = None;
 static Atom wm_delete = None;
+static Atom net_wm_desktop = None;
+static Atom net_wm_state = None;
+static Atom net_wm_state_skip_taskbar = None;
+static Atom net_wm_state_skip_pager = None;
+static Atom net_wm_window_type = None;
+static Atom net_wm_window_type_utility = None;
+static Atom motif_wm_hints = None;
 static bool threads_ready = false;
+
+typedef struct {
+    unsigned long flags;
+    unsigned long functions;
+    unsigned long decorations;
+    long input_mode;
+    unsigned long status;
+} MotifWmHints;
+
+static void ensure_wm_atoms(void) {
+    if (net_wm_desktop != None) return;
+    net_wm_desktop = XInternAtom(display, "_NET_WM_DESKTOP", False);
+    net_wm_state = XInternAtom(display, "_NET_WM_STATE", False);
+    net_wm_state_skip_taskbar = XInternAtom(display, "_NET_WM_STATE_SKIP_TASKBAR", False);
+    net_wm_state_skip_pager = XInternAtom(display, "_NET_WM_STATE_SKIP_PAGER", False);
+    net_wm_window_type = XInternAtom(display, "_NET_WM_WINDOW_TYPE", False);
+    net_wm_window_type_utility = XInternAtom(display, "_NET_WM_WINDOW_TYPE_UTILITY", False);
+    motif_wm_hints = XInternAtom(display, "_MOTIF_WM_HINTS", False);
+}
+
+static bool read_cardinal(Window window, Atom property, unsigned long *out) {
+    if (!out) return false;
+    *out = 0;
+    ensure_wm_atoms();
+    Atom actual_type = None;
+    int actual_format = 0;
+    unsigned long nitems = 0;
+    unsigned long bytes_after = 0;
+    unsigned char *prop = NULL;
+    if (XGetWindowProperty(display, window, property, 0, 1, False, XA_CARDINAL, &actual_type, &actual_format,
+                           &nitems, &bytes_after, &prop) != Success ||
+        !prop || nitems == 0) {
+        if (prop) XFree(prop);
+        return false;
+    }
+    *out = *(unsigned long *) prop;
+    XFree(prop);
+    return true;
+}
+
+static bool window_is_viewable(Window window) {
+    if (!window) return false;
+    XWindowAttributes attrs;
+    if (!XGetWindowAttributes(display, window, &attrs)) return false;
+    return attrs.map_state == IsViewable;
+}
+
+static void mark_overlay_chromeless(Window overlay) {
+    ensure_wm_atoms();
+    Atom states[2] = {net_wm_state_skip_taskbar, net_wm_state_skip_pager};
+    XChangeProperty(display, overlay, net_wm_state, XA_ATOM, 32, PropModeReplace, (unsigned char *) states, 2);
+    XChangeProperty(display, overlay, net_wm_window_type, XA_ATOM, 32, PropModeReplace,
+                    (unsigned char *) &net_wm_window_type_utility, 1);
+    MotifWmHints hints = {.flags = 2, .functions = 0, .decorations = 0, .input_mode = 0, .status = 0};
+    XChangeProperty(display, overlay, motif_wm_hints, motif_wm_hints, 32, PropModeReplace, (unsigned char *) &hints, 5);
+}
+
+static void sync_desktop_from_parent(Window overlay, Window parent) {
+    if (!overlay || !parent) return;
+    ensure_wm_atoms();
+    Atom actual_type = None;
+    int actual_format = 0;
+    unsigned long nitems = 0;
+    unsigned long bytes_after = 0;
+    unsigned char *prop = NULL;
+    if (XGetWindowProperty(display, parent, net_wm_desktop, 0, 1, False, XA_CARDINAL, &actual_type,
+                           &actual_format, &nitems, &bytes_after, &prop) != Success ||
+        !prop || nitems == 0) {
+        if (prop) XFree(prop);
+        return;
+    }
+    XChangeProperty(display, overlay, net_wm_desktop, XA_CARDINAL, 32, PropModeReplace, prop, 1);
+    XFree(prop);
+}
 
 bool andy_x11_init(void) {
     pthread_mutex_lock(&x11_lock);
@@ -33,12 +114,24 @@ bool andy_x11_init(void) {
     screen = DefaultScreen(display);
     root = RootWindow(display, screen);
     wm_delete = XInternAtom(display, "WM_DELETE_WINDOW", False);
+    ensure_wm_atoms();
     pthread_mutex_unlock(&x11_lock);
     return true;
 }
 
 Display *andy_x11_display(void) {
     return display;
+}
+
+int andy_x11_window_desktop(unsigned long window_id) {
+    if (!window_id || !andy_x11_init()) return -1;
+    pthread_mutex_lock(&x11_lock);
+    unsigned long desktop = 0;
+    const bool ok = read_cardinal((Window) window_id, net_wm_desktop, &desktop);
+    pthread_mutex_unlock(&x11_lock);
+    if (!ok) return -1;
+    if (desktop == 0xFFFFFFFFUL) return -2;
+    return (int) desktop;
 }
 
 static void apply_input_shape(Window window) {
@@ -73,6 +166,7 @@ bool andy_x11_create_overlay(Window *out_window) {
     }
     XStoreName(display, window, "Andy Live overlay");
     XSetWMProtocols(display, window, &wm_delete, 1);
+    mark_overlay_chromeless(window);
     apply_input_shape(window);
     XFlush(display);
     pthread_mutex_unlock(&x11_lock);
@@ -89,30 +183,55 @@ void andy_x11_destroy_overlay(Window window) {
     pthread_mutex_unlock(&x11_lock);
 }
 
-static void restack_above_parent(Window window, unsigned long parent) {
+static void restack_above_parent(Window window, Window parent) {
     if (parent && parent != window) {
         XWindowChanges changes;
         memset(&changes, 0, sizeof(changes));
-        changes.sibling = (Window) parent;
+        changes.sibling = parent;
         changes.stack_mode = Above;
         XConfigureWindow(display, window, CWSibling | CWStackMode, &changes);
     }
     XRaiseWindow(display, window);
 }
 
-void andy_x11_configure(Window window, int x, int y, int width, int height, unsigned long parent, bool visible) {
-    if (!display || !window) return;
+bool andy_x11_window_viewable(unsigned long window_id) {
+    if (!window_id || !andy_x11_init()) return false;
+    pthread_mutex_lock(&x11_lock);
+    const bool viewable = window_is_viewable((Window) window_id);
+    pthread_mutex_unlock(&x11_lock);
+    return viewable;
+}
+
+bool andy_x11_should_map(Window window, Window parent, bool visible) {
+    (void) window;
+    (void) parent;
+    // Do not gate on parent viewability: XWayland often reports Andy's window as
+    // non-viewable during layout / desktop transitions, which left the overlay
+    // permanently unmapped (black Live). Virtual-desktop floating is handled by
+    // andy_hub_suppress_presenters_for_desktop_switch instead.
+    return visible && display != NULL;
+}
+
+bool andy_x11_configure(Window window, int x, int y, int width, int height, unsigned long parent, bool visible,
+                        bool restack) {
+    if (!display || !window) return false;
     if (width < 1) width = 1;
     if (height < 1) height = 1;
     pthread_mutex_lock(&x11_lock);
+    const Window parent_window = parent ? (Window) parent : None;
     XMoveResizeWindow(display, window, x, y, (unsigned) width, (unsigned) height);
     apply_input_shape(window);
-    if (visible) {
+    const bool map = andy_x11_should_map(window, parent_window, visible);
+    if (map) {
+        sync_desktop_from_parent(window, parent_window);
         XMapWindow(display, window);
-        restack_above_parent(window, parent);
+        if (restack) restack_above_parent(window, parent_window);
+    } else {
+        XUnmapWindow(display, window);
     }
     XFlush(display);
     pthread_mutex_unlock(&x11_lock);
+    return map;
 }
 
 void andy_x11_set_visible(Window window, bool visible) {

--- a/native/andy-mirror/jni/linux/build.sh
+++ b/native/andy-mirror/jni/linux/build.sh
@@ -66,8 +66,10 @@ else
   exit 1
 fi
 
-PKGS="vulkan x11 xfixes xext libavcodec libavutil"
-CFLAGS="$(pkg-config --cflags $PKGS)"
+# Headers only: linking libavcodec would DT_NEEDED Ubuntu's SONAME and break Fedora/CachyOS.
+PKGS="vulkan x11 xfixes xext"
+AV_CFLAGS="$(pkg-config --cflags libavcodec libavutil)"
+CFLAGS="$(pkg-config --cflags $PKGS) $AV_CFLAGS"
 LIBS="$(pkg-config --libs $PKGS)"
 VK_HEADERS="$ROOT/../../third_party"
 
@@ -80,10 +82,17 @@ cc -shared -fPIC -O2 -std=c11 -DVK_USE_PLATFORM_XLIB_KHR \
   $CFLAGS \
   "$ROOT"/andy_mirror_frame.c \
   "$ROOT"/andy_mirror_x11.c \
+  "$ROOT"/andy_mirror_av.c \
   "$ROOT"/andy_mirror_nvdec.c \
   "$ROOT"/andy_mirror_vk.c \
   "$ROOT"/andy_mirror_hub_linux.c \
   "$ROOT"/andy_mirror_jni_linux.c \
   $LIBS \
-  -lm -lpthread \
+  -ldl -lm -lpthread \
+  -Wl,--as-needed \
   -o "$OUT"
+
+if readelf -d "$OUT" | grep -E 'NEEDED.*libav(codec|util)'; then
+  echo "andy-mirror: libandy-mirror-jni.so must not DT_NEEDED libavcodec/libavutil" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Harden Linux desktop mirror (X11/NVDEC/AV path), git/login-shell discovery, and ACP launch environment for more reliable Linux runs.
- Replace in-turn recursive ACP stall retries with durable, bounded `connectionRecovery` state that survives daemon/client restarts.
- Surface quiet recovery status in the chat UI (auto-reconnect vs capacity wait vs paused + Resume), with reason-aware exponential backoff.

## Test plan
- [ ] Unit: `AgentConnectionRecoveryTest`, `DesktopAgentTaskStoreTest` recovery persistence
- [ ] Stall a live ACP chat and confirm scheduled reconnect UI + automatic resume
- [ ] Exhaust automatic attempts and confirm paused state + Resume continues
- [ ] Restart `andyd`/desktop mid-scheduled recovery and confirm the job is restored
- [ ] Smoke Linux mirror attach on a machine with Vulkan/display where available


Made with [Cursor](https://cursor.com)