### PR TITLE
Avoid duplicating ACP permission responses

### DIFF
--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -1823,7 +1823,6 @@ class DesktopAgentRunService(
         if (request.origin == app.andy.model.AgentUserInputOrigin.AcpPermission) {
             val answer = normalizedAnswers.values.firstOrNull().orEmpty()
             if (!acpManager.respondPermission(taskId, requestId, answer)) return
-            appendEvents(taskId, listOf(AgentEvent.UserMessage(System.currentTimeMillis(), answer)))
             return
         }
 

--- a/data/agents/src/desktopMain/resources/webchat/app.js
+++ b/data/agents/src/desktopMain/resources/webchat/app.js
@@ -606,7 +606,7 @@
   }
 
   function isVisibleTranscriptEvent(type) {
-    return type === "user" || type === "assistant" || type === "thinking" || type === "error";
+    return type === "user" || type === "assistant" || type === "thinking" || type === "error" || type === "permission-resolved";
   }
 
   function renderTranscript() {
@@ -632,6 +632,10 @@
       } else if (type === "error") {
         el.className = "bubble error";
         el.textContent = ev.text || "error";
+      } else if (type === "permission-resolved") {
+        el.className = "bubble permission-resolved";
+        el.textContent = `Permission ${ev.allowed ? "allowed" : "rejected"}: ${ev.optionId || "unknown option"}`;
+        if (ev.note) el.textContent += ` (${ev.note})`;
       }
       root.appendChild(el);
     }

--- a/data/agents/src/desktopMain/resources/webchat/styles.css
+++ b/data/agents/src/desktopMain/resources/webchat/styles.css
@@ -353,6 +353,13 @@ details.group > summary.group-header::-webkit-details-marker {
   border: none;
   padding: 4px;
 }
+.bubble.permission-resolved {
+  align-self: flex-start;
+  color: var(--muted);
+  background: #1a1f26;
+  border: 1px dashed var(--border);
+  font-size: 0.85rem;
+}
 .bubble.thinking {
   align-self: flex-start;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- stop appending ACP permission answers as duplicate user transcript events
- keep normal user-input responses unchanged

## Tests
- ./gradlew compileKotlinDesktop
- ./gradlew :data:agents:desktopTest --tests '*AcpLaneTest'