### PR TITLE
Plan-mode approval flow across Android, web, and CLI; auth + VNC viewer fixes

### DIFF
--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/AndroidChatNotificationService.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/AndroidChatNotificationService.kt
@@ -35,7 +35,7 @@ class AndroidChatNotificationService(
 
     fun show(event: ChatAttentionEvent) {
         ensureChannel()
-        val subtitle = ChatAttentionTracker.subtitle(event.kind)
+        val subtitle = ChatAttentionTracker.subtitle(event.kind, event.planMode)
         val open = Intent(appContext, MainActivity::class.java).apply {
             action = Intent.ACTION_VIEW
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/AttentionPushService.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/AttentionPushService.kt
@@ -160,6 +160,31 @@ class AttentionPushService : Service() {
     private fun isUnauthorized(e: Throwable): Boolean =
         (e as? NetworkAccessException)?.unauthorized == true
 
+    private fun isAuthRejection(e: Throwable): Boolean {
+        if (isUnauthorized(e)) return true
+        val msg = e.message.orEmpty()
+        return msg.contains("too many failed auth", ignoreCase = true)
+    }
+
+    /**
+     * Expired / wiped host sessions must not keep polling — each 401 counts toward the
+     * host IP auth rate limit and can lock the phone out of password login for minutes.
+     */
+    private fun stopForExpiredSession(source: String) {
+        Log.w(TAG, "$source session expired — stopping listener")
+        pushStatus.set("session expired · sign in again")
+        pullStatus.set("session expired · sign in again")
+        publishStatus()
+        clearSession(this)
+        listenJob?.cancel()
+        listenJob = null
+        client?.close()
+        client = null
+        connectedBaseUrl = null
+        connectedToken = null
+        stopSelf()
+    }
+
     private suspend fun pushLoop(client: NetworkAccessClient) {
         var backoffMs = 1_000L
         while (currentCoroutineContext().isActive) {
@@ -180,15 +205,15 @@ class AttentionPushService : Service() {
                 publishStatus()
             } catch (e: Exception) {
                 Log.w(TAG, "attention push failed: ${e.message}", e)
-                if (isUnauthorized(e)) {
-                    pushStatus.set("push session expired · sign in again")
-                } else {
-                    val short = e.message?.take(48)?.replace('\n', ' ').orEmpty()
-                    pushStatus.set(
-                        if (short.isBlank()) "push down · retrying"
-                        else "push down · $short",
-                    )
+                if (isAuthRejection(e)) {
+                    stopForExpiredSession("push")
+                    return
                 }
+                val short = e.message?.take(48)?.replace('\n', ' ').orEmpty()
+                pushStatus.set(
+                    if (short.isBlank()) "push down · retrying"
+                    else "push down · $short",
+                )
                 publishStatus()
             }
             if (!currentCoroutineContext().isActive) break
@@ -215,11 +240,11 @@ class AttentionPushService : Service() {
                 publishStatus()
             }.onFailure { e ->
                 Log.w(TAG, "attention pull failed: ${e.message}")
-                if (isUnauthorized(e)) {
-                    pullStatus.set("pull session expired · sign in again")
-                } else {
-                    pullStatus.set("pull down")
+                if (isAuthRejection(e)) {
+                    stopForExpiredSession("pull")
+                    return
                 }
+                pullStatus.set("pull down")
                 publishStatus()
             }
             delay(PULL_INTERVAL_MS)

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/ChatAttentionTracker.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/ChatAttentionTracker.kt
@@ -20,6 +20,7 @@ data class ChatAttentionEvent(
     val projectId: String?,
     val title: String,
     val kind: ChatAttentionKind,
+    val planMode: Boolean = false,
 )
 
 class ChatAttentionTracker(
@@ -30,6 +31,7 @@ class ChatAttentionTracker(
         val status: String,
         val inputRequestId: String?,
         val finishedAtMillis: Long,
+        val planMode: Boolean,
     )
 
     private val previous = mutableMapOf<String, Tracked>()
@@ -79,6 +81,7 @@ class ChatAttentionTracker(
                 projectId = chat.projectId.takeIf { it.isNotBlank() },
                 title = notificationTitle(chat),
                 kind = kind,
+                planMode = kind == ChatAttentionKind.Done && chat.planMode,
             )
         }
         previous.keys.retainAll(chats.map { it.id }.toSet())
@@ -128,9 +131,9 @@ class ChatAttentionTracker(
             return if (flat.length <= 60) flat else flat.take(59) + "…"
         }
 
-        fun subtitle(kind: ChatAttentionKind): String = when (kind) {
+        fun subtitle(kind: ChatAttentionKind, planMode: Boolean = false): String = when (kind) {
             ChatAttentionKind.Blocked -> "Needs your input"
-            ChatAttentionKind.Done -> "Agent completed"
+            ChatAttentionKind.Done -> if (planMode) "Plan ready" else "Agent completed"
             ChatAttentionKind.Error -> "Agent failed"
         }
 
@@ -138,6 +141,7 @@ class ChatAttentionTracker(
             status = chat.status.trim(),
             inputRequestId = chat.userInputRequest?.id,
             finishedAtMillis = chat.finishedAtMillis,
+            planMode = chat.planMode,
         )
     }
 }

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessApi.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessApi.kt
@@ -2,6 +2,7 @@ package com.joetr.andy.mobile.data.networkaccess
 
 import com.joetr.andy.mobile.data.attention.ChatAttentionEvent
 import com.joetr.andy.mobile.data.attention.ChatAttentionKind
+import app.andy.model.IMPLEMENT_PLAN_PROMPT
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
@@ -174,6 +175,35 @@ class NetworkAccessClient(
         return response.body()
     }
 
+    /**
+     * Exit plan mode and resume with the desktop Implement prompt.
+     *
+     * Prefers `POST …/implement-plan` when the host supports it. Older hosts return 404 for
+     * that route — fall back to optional `…/plan-mode` + `…/reply`, which every Network Access
+     * build already serves.
+     */
+    suspend fun implementPlan(chatId: String): OkResponse {
+        val response = rawRequest(HttpMethod.Post, "/api/chats/${chatId.encodeURL()}/implement-plan") {
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        if (response.status == HttpStatusCode.NotFound || response.status.value == 404) {
+            runCatching { updatePlanMode(chatId, planMode = false) }
+            return reply(chatId, IMPLEMENT_PLAN_PROMPT)
+        }
+        ensureOk(response)
+        return response.body()
+    }
+
+    suspend fun updatePlanMode(chatId: String, planMode: Boolean): OkResponse {
+        val response = rawRequest(HttpMethod.Post, "/api/chats/${chatId.encodeURL()}/plan-mode") {
+            contentType(ContentType.Application.Json)
+            setBody(UpdatePlanModeRequest(planMode = planMode))
+        }
+        ensureOk(response)
+        return response.body()
+    }
+
     suspend fun respond(chatId: String, requestId: String, answers: Map<String, String>): OkResponse {
         val response = rawRequest(HttpMethod.Post, "/api/chats/${chatId.encodeURL()}/respond") {
             contentType(ContentType.Application.Json)
@@ -261,18 +291,24 @@ class NetworkAccessClient(
             throw e
         } catch (e: Exception) {
             val msg = e.message.orEmpty()
+            val sessionExpired = msg.contains("401") ||
+                msg.contains("unauthorized", ignoreCase = true) ||
+                msg.contains("4401")
             val hint = when {
                 msg.contains("404", ignoreCase = true) ||
                     msg.contains("Connection refused", ignoreCase = true) ->
                     " (restart Andy Desktop / andyd with the latest build)"
-                msg.contains("401") || msg.contains("unauthorized", ignoreCase = true) ||
-                    msg.contains("4401") ->
+                sessionExpired ->
                     " (session expired — sign in again)"
                 msg.contains("Handshake", ignoreCase = true) ->
                     " (TLS/WebSocket upgrade failed — check Network Access URL)"
                 else -> ""
             }
-            throw NetworkAccessException("Attention push failed: ${msg.take(120)}$hint", cause = e)
+            throw NetworkAccessException(
+                "Attention push failed: ${msg.take(120)}$hint",
+                unauthorized = sessionExpired,
+                cause = e,
+            )
         }
     }
 
@@ -284,11 +320,13 @@ class NetworkAccessClient(
             ?: return null
         val title = (obj["title"] as? JsonPrimitive)?.content.orEmpty().ifBlank { "Chat" }
         val projectId = (obj["projectId"] as? JsonPrimitive)?.content?.takeIf { it.isNotBlank() }
+        val planMode = (obj["planMode"] as? JsonPrimitive)?.booleanOrNull == true
         return ChatAttentionEvent(
             chatId = taskId,
             projectId = projectId,
             title = title,
             kind = kind,
+            planMode = planMode,
         )
     }
 

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessModels.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessModels.kt
@@ -28,6 +28,8 @@ data class ChatDto(
     val status: String = "",
     val projectId: String = "",
     val autonomy: String = "Standard",
+    val planMode: Boolean = false,
+    val workflowStage: String = "",
     val unread: Boolean = false,
     val archived: Boolean = false,
     val createdAtMillis: Long = 0L,
@@ -36,6 +38,35 @@ data class ChatDto(
     val resumable: Boolean = false,
     val errorMessage: String = "",
     val userInputRequest: UserInputRequestDto? = null,
+)
+
+/** Matches desktop [app.andy.ui.agents.isAwaitingPlanConfirmation] for Network Access chats. */
+fun ChatDto.awaitingPlanConfirmation(hasPendingPlanEntries: Boolean = false): Boolean =
+    status.equals("Done", ignoreCase = true) &&
+        userInputRequest == null &&
+        (planMode || hasPendingPlanEntries)
+
+fun ChatDto.showImplementPlan(hasPendingPlanEntries: Boolean = false): Boolean =
+    awaitingPlanConfirmation(hasPendingPlanEntries) &&
+        !workflowStage.equals("Spec", ignoreCase = true)
+
+fun ChatDto.displayStatusLabel(hasPendingPlanEntries: Boolean = false): String = when {
+    awaitingPlanConfirmation(hasPendingPlanEntries) -> "plan ready"
+    status.isNotBlank() -> status
+    else -> ""
+}
+
+/** True when the chat list should surface a status marker (blocked / error / plan ready). */
+fun ChatDto.hasListAttentionMarker(): Boolean =
+    userInputRequest != null ||
+        status.equals("Blocked", ignoreCase = true) ||
+        status.equals("Error", ignoreCase = true) ||
+        awaitingPlanConfirmation()
+
+@Serializable
+data class PlanEntryDto(
+    val content: String = "",
+    val status: String = "pending",
 )
 
 @Serializable
@@ -79,6 +110,10 @@ data class ChatEventDto(
     val note: String = "",
     val success: Boolean? = null,
     val finalText: String = "",
+    /** Plan-update markdown when [type] is `plan`. */
+    val markdown: String = "",
+    /** Plan checklist entries when [type] is `plan`. */
+    val entries: List<PlanEntryDto> = emptyList(),
     /** Catch-all so unknown event fields don't break decoding. */
     val sessionId: String = "",
     val model: String = "",
@@ -135,6 +170,9 @@ data class StartChatResponse(
 data class ReplyRequest(val message: String)
 
 @Serializable
+data class UpdatePlanModeRequest(val planMode: Boolean)
+
+@Serializable
 data class RespondRequest(
     val requestId: String,
     val answers: Map<String, String>,
@@ -179,7 +217,29 @@ fun groupChatsByProject(
 
 fun ChatEventDto.isVisibleTranscript(): Boolean =
     type == "user" || type == "assistant" || type == "thinking" ||
-        type == "error" || type == "permission-resolved"
+        type == "error" || type == "permission-resolved" || type == "plan"
+
+/**
+ * Mirrors [app.andy.model.latestPlanHasPendingEntries] for Network Access wire events.
+ * Cursor Create Plan can end_turn with pending rows while Andy [ChatDto.planMode] stays off.
+ */
+fun List<ChatEventDto>.latestPlanHasPendingEntries(): Boolean {
+    val planIndex = indexOfLast { it.type == "plan" }
+    if (planIndex < 0) return false
+    if (withIndex().any { (index, event) -> index > planIndex && event.type == "user" }) {
+        return false
+    }
+    val plan = this[planIndex]
+    if (plan.entries.isEmpty()) {
+        return plan.markdown.isNotBlank()
+    }
+    return plan.entries.any { entry ->
+        when (entry.status.trim().lowercase()) {
+            "completed", "complete", "done", "cancelled", "canceled", "file" -> false
+            else -> true
+        }
+    }
+}
 
 fun List<ChatEventDto>.coalesceStreams(): List<ChatEventDto> {
     if (isEmpty()) return this

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ChatScreen.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ChatScreen.kt
@@ -58,9 +58,15 @@ import com.joetr.andy.mobile.data.networkaccess.ChatDto
 import com.joetr.andy.mobile.data.networkaccess.ChatEventDto
 import com.joetr.andy.mobile.data.networkaccess.NetworkAccessClient
 import com.joetr.andy.mobile.data.networkaccess.NetworkAccessException
+import com.joetr.andy.mobile.data.networkaccess.PlanEntryDto
 import com.joetr.andy.mobile.data.networkaccess.UserInputRequestDto
+import com.joetr.andy.mobile.data.networkaccess.awaitingPlanConfirmation
 import com.joetr.andy.mobile.data.networkaccess.coalesceStreams
+import com.joetr.andy.mobile.data.networkaccess.displayStatusLabel
 import com.joetr.andy.mobile.data.networkaccess.isVisibleTranscript
+import com.joetr.andy.mobile.data.networkaccess.latestPlanHasPendingEntries
+import com.joetr.andy.mobile.data.networkaccess.showImplementPlan
+import app.andy.ui.theme.Yellow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -87,6 +93,10 @@ fun ChatScreen(
     val agentId = chat?.agent.orEmpty()
     val slashCommands = rememberSlashCommands(client, agentId)
     val slashToken = remember(draft) { findActiveSlashToken(draft) }
+    val hasPendingPlanEntries = remember(events) { events.latestPlanHasPendingEntries() }
+    val awaitingPlan = chat?.awaitingPlanConfirmation(hasPendingPlanEntries) == true
+    val showImplement = chat?.showImplementPlan(hasPendingPlanEntries) == true
+    val statusLabel = chat?.displayStatusLabel(hasPendingPlanEntries).orEmpty()
 
     suspend fun loadOnce() {
         val detail = client.chatDetail(chatId)
@@ -167,7 +177,10 @@ fun ChatScreen(
                     maxLines = 1,
                 )
                 Text(
-                    listOfNotNull(chat?.agent, chat?.status).joinToString(" · "),
+                    listOfNotNull(
+                        chat?.agent,
+                        statusLabel.takeIf { it.isNotBlank() },
+                    ).joinToString(" · "),
                     style = MaterialTheme.typography.bodySmall,
                     color = tokens.palette.textTertiary,
                 )
@@ -192,7 +205,15 @@ fun ChatScreen(
                         key = { "${it.atMillis}-${it.type}-${it.text.hashCode()}" },
                         contentType = { it.type },
                     ) { event ->
-                        TranscriptBubble(event)
+                        if (event.type == "plan") {
+                            PlanDocumentCard(
+                                entries = event.entries,
+                                markdown = event.markdown,
+                                awaitingApproval = awaitingPlan,
+                            )
+                        } else {
+                            TranscriptBubble(event)
+                        }
                     }
                     optimistic?.let { text ->
                         item(key = "optimistic") {
@@ -228,6 +249,37 @@ fun ChatScreen(
             )
         }
 
+        if (awaitingPlan && pendingInput == null) {
+            PlanApprovalCard(
+                showImplementAction = showImplement,
+                onImplement = {
+                    scope.launch {
+                        try {
+                            client.implementPlan(chatId)
+                            chat = chat?.copy(planMode = false, status = "Working")
+                        } catch (e: Exception) {
+                            error = e.message
+                        }
+                    }
+                },
+                onRefine = { feedback ->
+                    scope.launch {
+                        sending = true
+                        error = null
+                        optimistic = feedback
+                        try {
+                            client.reply(chatId, feedback)
+                        } catch (e: Exception) {
+                            optimistic = null
+                            error = e.message
+                        } finally {
+                            sending = false
+                        }
+                    }
+                },
+            )
+        }
+
         if (slashToken != null && agentId.isNotBlank()) {
             SlashCommandSuggestions(
                 query = slashToken.query,
@@ -256,7 +308,11 @@ fun ChatScreen(
                     label = "Message",
                     value = draft,
                     onValueChange = { draft = it },
-                    placeholder = "Follow up… Type / for commands",
+                    placeholder = if (awaitingPlan) {
+                        "Refine the plan…"
+                    } else {
+                        "Follow up… Type / for commands"
+                    },
                     singleLine = false,
                     modifier = Modifier.weight(1f),
                 )
@@ -290,6 +346,179 @@ fun ChatScreen(
                         contentDescription = "Send",
                         tint = if (draft.isNotBlank() && !sending) tokens.accent else tokens.palette.textTertiary,
                     )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlanDocumentCard(
+    entries: List<PlanEntryDto>,
+    markdown: String,
+    awaitingApproval: Boolean,
+) {
+    val tokens = andyTokens()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(AndyShape.Sheet)
+            .background(tokens.palette.surfaceRaised)
+            .border(1.dp, Yellow.copy(alpha = 0.85f), AndyShape.Sheet)
+            .padding(AndySpace.Space3),
+        verticalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+        ) {
+            Text("≡", color = Yellow, fontFamily = MonoFont, style = MaterialTheme.typography.labelMedium)
+            Text(
+                "Plan",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = DisplayFont,
+                fontWeight = FontWeight.SemiBold,
+                color = tokens.palette.textPrimary,
+            )
+            if (awaitingApproval) {
+                Text(
+                    "Awaiting approval",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = tokens.palette.textSecondary,
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(AndyShape.Interactive)
+                .background(tokens.palette.surfaceHover)
+                .padding(AndySpace.Space3),
+            verticalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+        ) {
+            if (markdown.isNotBlank()) {
+                Text(
+                    markdown,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = tokens.palette.textPrimary,
+                )
+            }
+            entries.forEachIndexed { index, entry ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+                ) {
+                    Text(
+                        "${index + 1}.",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = MonoFont,
+                        color = tokens.palette.textTertiary,
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            entry.content,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = tokens.palette.textPrimary,
+                        )
+                        if (entry.status.isNotBlank() && !entry.status.equals("pending", ignoreCase = true)) {
+                            Text(
+                                entry.status,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontFamily = MonoFont,
+                                color = tokens.palette.textTertiary,
+                            )
+                        }
+                    }
+                }
+            }
+            if (markdown.isBlank() && entries.isEmpty()) {
+                Text(
+                    "Plan ready",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = tokens.palette.textSecondary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlanApprovalCard(
+    showImplementAction: Boolean,
+    onImplement: () -> Unit,
+    onRefine: (String) -> Unit,
+) {
+    val tokens = andyTokens()
+    var feedback by remember { mutableStateOf("") }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(AndySpace.Space3),
+        shape = AndyShape.Sheet,
+        backgroundColor = tokens.palette.surfaceRaised,
+        borderColor = Yellow.copy(alpha = 0.85f),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(AndySpace.Space3),
+            verticalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+            ) {
+                Text("≡", color = Yellow, fontFamily = MonoFont, style = MaterialTheme.typography.labelMedium)
+                Text(
+                    "Plan",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = DisplayFont,
+                    fontWeight = FontWeight.SemiBold,
+                    color = tokens.palette.textPrimary,
+                )
+                Text(
+                    "Awaiting approval",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = tokens.palette.textSecondary,
+                )
+            }
+            Text(
+                if (showImplementAction) {
+                    "This turn finished in plan mode. Nothing was changed. Implement when you're ready, or leave feedback and refine below."
+                } else {
+                    "This turn finished in plan mode. Nothing was changed. Review the plan in Projects, or leave feedback and refine below."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = tokens.palette.textSecondary,
+            )
+            MobileField(
+                label = "Feedback",
+                value = feedback,
+                onValueChange = { feedback = it },
+                placeholder = "Optional feedback if refining…",
+                singleLine = true,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2, Alignment.End),
+            ) {
+                OutlinedButton(
+                    onClick = {
+                        val trimmed = feedback.trim()
+                        if (trimmed.isNotEmpty()) {
+                            onRefine(trimmed)
+                            feedback = ""
+                        }
+                    },
+                    enabled = feedback.isNotBlank(),
+                    shape = AndyShape.Interactive,
+                ) {
+                    Text("Refine")
+                }
+                if (showImplementAction) {
+                    Button(onClick = onImplement, shape = AndyShape.Interactive) {
+                        Text("Implement plan")
+                    }
                 }
             }
         }

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ProjectsScreen.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ProjectsScreen.kt
@@ -73,6 +73,8 @@ import com.joetr.andy.mobile.data.networkaccess.ChatDto
 import com.joetr.andy.mobile.data.networkaccess.NetworkAccessClient
 import com.joetr.andy.mobile.data.networkaccess.NetworkAccessException
 import com.joetr.andy.mobile.data.networkaccess.ProjectGroup
+import com.joetr.andy.mobile.data.networkaccess.awaitingPlanConfirmation
+import com.joetr.andy.mobile.data.networkaccess.displayStatusLabel
 import com.joetr.andy.mobile.data.networkaccess.groupChatsByProject
 import kotlinx.coroutines.launch
 
@@ -143,7 +145,11 @@ fun ProjectsScreen(
             signedIn = true
         } catch (e: NetworkAccessException) {
             error = e.message
-            if (e.unauthorized) {
+            // 401 or IP auth cooldown from a dead stored session — drop it so the user
+            // can password-login cleanly (and so AttentionPushService is stopped).
+            val authDead = e.unauthorized ||
+                e.message.orEmpty().contains("too many failed auth", ignoreCase = true)
+            if (authDead) {
                 signedIn = false
                 repository.saveNetworkAccessSession(host.id, null)
                 onSignedOut()
@@ -514,11 +520,12 @@ private fun ProjectSection(
 @Composable
 private fun ChatRow(chat: ChatDto, onClick: () -> Unit) {
     val tokens = andyTokens()
-    val statusVariant = when (chat.status) {
-        "completed" -> StatusDotVariant.Success
-        "error" -> StatusDotVariant.Error
-        "running", "in_progress" -> StatusDotVariant.Warning
-        else -> StatusDotVariant.Neutral
+    val attentionVariant = when {
+        chat.userInputRequest != null ||
+            chat.status.equals("Blocked", ignoreCase = true) -> StatusDotVariant.Warning
+        chat.status.equals("Error", ignoreCase = true) -> StatusDotVariant.Error
+        chat.awaitingPlanConfirmation() -> StatusDotVariant.Success
+        else -> null
     }
     Row(
         modifier = Modifier
@@ -533,7 +540,11 @@ private fun ChatRow(chat: ChatDto, onClick: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(AndySpace.Space3),
     ) {
-        StatusDot(variant = statusVariant)
+        if (attentionVariant != null) {
+            StatusDot(variant = attentionVariant)
+        } else {
+            Spacer(modifier = Modifier.size(8.dp))
+        }
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 chat.title.ifBlank { chat.prompt.take(48).ifBlank { chat.id } },
@@ -546,7 +557,7 @@ private fun ChatRow(chat: ChatDto, onClick: () -> Unit) {
             Text(
                 listOfNotNull(
                     chat.agent.takeIf { it.isNotBlank() },
-                    chat.status.takeIf { it.isNotBlank() },
+                    chat.displayStatusLabel().takeIf { it.isNotBlank() },
                 ).joinToString(" · "),
                 style = MaterialTheme.typography.bodySmall,
                 color = tokens.palette.textTertiary,

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/RemoteDisplay.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/RemoteDisplay.kt
@@ -73,12 +73,28 @@ internal fun displayCrop(
     return DisplayCrop(index, x, 0, width.coerceAtLeast(1), h)
 }
 
-internal fun fitScale(viewport: IntSize, crop: DisplayCrop): Float {
+/**
+ * Cover scale — fills the viewport on both axes (zoom = 1 baseline).
+ * Widescreen remotes on a portrait phone overflow horizontally and stay finger-sized.
+ */
+internal fun fillScale(viewport: IntSize, crop: DisplayCrop): Float {
     if (viewport.width <= 0 || viewport.height <= 0) return 0f
-    return min(
+    return max(
         viewport.width.toFloat() / crop.width.toFloat(),
         viewport.height.toFloat() / crop.height.toFloat(),
     )
+}
+
+internal fun drawnSize(viewport: IntSize, crop: DisplayCrop, zoom: Float): Pair<Float, Float> {
+    val fill = fillScale(viewport, crop)
+    if (fill <= 0f) return 0f to 0f
+    return crop.width * fill * zoom to crop.height * fill * zoom
+}
+
+/** True when the drawn image exceeds the viewport on either axis (panning can move it). */
+internal fun canPan(viewport: IntSize, crop: DisplayCrop, zoom: Float): Boolean {
+    val (drawW, drawH) = drawnSize(viewport, crop, zoom)
+    return drawW > viewport.width + 0.5f || drawH > viewport.height + 0.5f
 }
 
 internal fun computeMapping(
@@ -87,10 +103,8 @@ internal fun computeMapping(
     zoom: Float,
     pan: Offset,
 ): ViewMapping {
-    val fit = fitScale(viewport, crop)
-    if (fit <= 0f) return ViewMapping(crop, 0f, 0f, 0f, 0f)
-    val drawW = crop.width * fit * zoom
-    val drawH = crop.height * fit * zoom
+    val (drawW, drawH) = drawnSize(viewport, crop, zoom)
+    if (drawW <= 0f || drawH <= 0f) return ViewMapping(crop, 0f, 0f, 0f, 0f)
     val left = (viewport.width - drawW) / 2f + pan.x
     val top = (viewport.height - drawH) / 2f + pan.y
     return ViewMapping(crop, left, top, drawW, drawH)
@@ -104,10 +118,8 @@ internal fun panForCorner(
     left: Float,
     top: Float,
 ): Offset {
-    val fit = fitScale(viewport, crop)
-    if (fit <= 0f) return Offset.Zero
-    val drawW = crop.width * fit * zoom
-    val drawH = crop.height * fit * zoom
+    val (drawW, drawH) = drawnSize(viewport, crop, zoom)
+    if (drawW <= 0f || drawH <= 0f) return Offset.Zero
     return Offset(
         left - (viewport.width - drawW) / 2f,
         top - (viewport.height - drawH) / 2f,
@@ -119,13 +131,50 @@ internal fun panForCorner(
  * and it stays centred on any axis where it is smaller than the viewport.
  */
 internal fun clampPan(viewport: IntSize, crop: DisplayCrop, zoom: Float, pan: Offset): Offset {
-    val fit = fitScale(viewport, crop)
-    if (fit <= 0f) return Offset.Zero
-    val drawW = crop.width * fit * zoom
-    val drawH = crop.height * fit * zoom
+    val (drawW, drawH) = drawnSize(viewport, crop, zoom)
+    if (drawW <= 0f || drawH <= 0f) return Offset.Zero
     val maxX = max((drawW - viewport.width) / 2f, 0f)
     val maxY = max((drawH - viewport.height) / 2f, 0f)
     return Offset(pan.x.coerceIn(-maxX, maxX), pan.y.coerceIn(-maxY, maxY))
+}
+
+/**
+ * Pan that places remote pixel ([remoteX], [remoteY]) under view point ([viewX], [viewY]).
+ * Used to keep the same remote content on-screen when the viewport resizes (keyboard, chrome).
+ */
+internal fun panShowingRemoteAt(
+    viewport: IntSize,
+    crop: DisplayCrop,
+    zoom: Float,
+    remoteX: Int,
+    remoteY: Int,
+    viewX: Float,
+    viewY: Float,
+): Offset {
+    val (drawW, drawH) = drawnSize(viewport, crop, zoom)
+    if (drawW <= 0f || drawH <= 0f || crop.width <= 0 || crop.height <= 0) return Offset.Zero
+    val left = viewX - ((remoteX - crop.x + 0.5f) / crop.width.toFloat()) * drawW
+    val top = viewY - ((remoteY - crop.y + 0.5f) / crop.height.toFloat()) * drawH
+    return clampPan(viewport, crop, zoom, panForCorner(viewport, crop, zoom, left, top))
+}
+
+/**
+ * Zoom multiplier that keeps crop pixels the same size on screen after a viewport resize.
+ * Cover [fillScale] changes with keyboard/chrome height; compensate so the view does not
+ * appear to zoom in/out.
+ */
+internal fun zoomPreservingAbsoluteScale(
+    oldViewport: IntSize,
+    newViewport: IntSize,
+    crop: DisplayCrop,
+    oldZoom: Float,
+    minZoom: Float = 1f,
+    maxZoom: Float = Float.MAX_VALUE,
+): Float {
+    val oldFill = fillScale(oldViewport, crop)
+    val newFill = fillScale(newViewport, crop)
+    if (oldFill <= 0f || newFill <= 0f) return oldZoom.coerceIn(minZoom, maxZoom)
+    return (oldZoom * oldFill / newFill).coerceIn(minZoom, maxZoom)
 }
 
 private const val FIXED_BITS = 16

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ScreenViewerScreen.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ScreenViewerScreen.kt
@@ -80,13 +80,15 @@ import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -128,12 +130,9 @@ private const val SCROLL_STEP = 56f
 /** Pinch ceiling — high enough that ~12–24px remote controls become finger-sized. */
 private const val MAX_ZOOM = 20f
 
-/** Zoom at or below this counts as "fits the viewport", where panning is a no-op. */
-private const val FIT_ZOOM_EPSILON = 1.001f
-
 private data class ViewTransform(val viewport: IntSize, val zoom: Float, val pan: Offset)
 
-private enum class Gesture { Tap, LongPress, Drag, Multi }
+private enum class Gesture { Tap, LongPress, Pan, Multi }
 
 @Composable
 fun ScreenViewerScreen(
@@ -196,6 +195,7 @@ fun ScreenViewerScreen(
     val focusRequester = remember { FocusRequester() }
     val softKeyboard = LocalSoftwareKeyboardController.current
     val view = LocalView.current
+    val haptics = LocalHapticFeedback.current
 
     // ViewModel-owned clients outlive this composable across tab switches. Closing them here
     // called Inflater.end(), so returning to Screen failed with "Inflater has been closed".
@@ -374,6 +374,7 @@ fun ScreenViewerScreen(
                             selected = streamQuality == quality,
                             onClick = {
                                 if (streamQuality == quality) return@DisplayChip
+                                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                                 streamQuality = quality
                                 repository.saveVncStreamQuality(quality)
                                 scope.launch { runCatching { connectWithQuality(quality) } }
@@ -386,6 +387,7 @@ fun ScreenViewerScreen(
                             label = "All",
                             selected = selectedDisplay == null,
                             onClick = {
+                                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                                 selectedDisplay = null
                                 zoomState.floatValue = 1f
                                 panState.value = Offset.Zero
@@ -396,6 +398,7 @@ fun ScreenViewerScreen(
                                 label = "Display ${index + 1}",
                                 selected = selectedDisplay == index,
                                 onClick = {
+                                    haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                                     selectedDisplay = index
                                     zoomState.floatValue = 1f
                                     panState.value = Offset.Zero
@@ -413,7 +416,44 @@ fun ScreenViewerScreen(
                 .fillMaxWidth()
                 // Without this the zoomed image paints over the chrome and the bottom nav.
                 .clipToBounds()
-                .onSizeChanged { viewportState.value = it }
+                .onSizeChanged { newSize ->
+                    val old = viewportState.value
+                    val zoom = zoomState.floatValue
+                    if (old.width > 0 && old.height > 0 &&
+                        (old.width != newSize.width || old.height != newSize.height)
+                    ) {
+                        // Keyboard / chrome / immersive bars resize the viewport. Cover scale
+                        // tracks the new size, so re-zoom to keep remote pixels the same
+                        // on-screen size, and keep the old centre remote pixel centred.
+                        val remote = computeMapping(old, crop, zoom, panState.value)
+                            .toRemoteClamped(old.width / 2f, old.height / 2f)
+                        val newZoom = zoomPreservingAbsoluteScale(
+                            oldViewport = old,
+                            newViewport = newSize,
+                            crop = crop,
+                            oldZoom = zoom,
+                            minZoom = 1f,
+                            maxZoom = MAX_ZOOM,
+                        )
+                        viewportState.value = newSize
+                        zoomState.floatValue = newZoom
+                        if (remote != null) {
+                            panState.value = panShowingRemoteAt(
+                                viewport = newSize,
+                                crop = crop,
+                                zoom = newZoom,
+                                remoteX = remote.first,
+                                remoteY = remote.second,
+                                viewX = newSize.width / 2f,
+                                viewY = newSize.height / 2f,
+                            )
+                        } else {
+                            panState.value = clampPan(newSize, crop, newZoom, panState.value)
+                        }
+                    } else {
+                        viewportState.value = newSize
+                    }
+                }
                 .pointerInput(crop) {
                     val touchSlop = viewConfiguration.touchSlop
                     val longPressMs = viewConfiguration.longPressTimeoutMillis
@@ -426,6 +466,8 @@ fun ScreenViewerScreen(
                             panState = panState,
                             touchSlop = touchSlop,
                             longPressMs = longPressMs,
+                            haptics = haptics,
+                            view = view,
                         )
                     }
                 },
@@ -463,7 +505,7 @@ fun ScreenViewerScreen(
 
             if (!fullScreen && !isKeyboardOpen) {
                 Text(
-                    "Tap click · Drag click-drag · Hold right-click · Two fingers scroll & zoom",
+                    "Pan · Tap click · Hold right-click · Hold-drag mouse · Pinch zoom",
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .windowInsetsPadding(WindowInsets.navigationBars)
@@ -479,74 +521,36 @@ fun ScreenViewerScreen(
             if (fullScreen && !isKeyboardOpen) {
                 Row(
                     modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .fillMaxWidth()
+                        .align(Alignment.TopEnd)
                         .windowInsetsPadding(WindowInsets.statusBars)
-                        .padding(AndySpace.Space3),
+                        .padding(AndySpace.Space3)
+                        .clip(AndyShape.Interactive)
+                        .background(tokens.palette.sidebarBg.copy(alpha = 0.85f))
+                        .padding(horizontal = 4.dp, vertical = 2.dp),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .weight(1f)
-                            .clip(AndyShape.Interactive)
-                            .background(tokens.palette.sidebarBg.copy(alpha = 0.85f))
-                            .padding(horizontal = AndySpace.Space3, vertical = AndySpace.Space2),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+                    IconButton(
+                        onClick = { setKeyboardOpen(!isKeyboardOpen) },
+                        modifier = Modifier.size(36.dp),
                     ) {
-                        Text(
-                            host.displayName,
-                            color = tokens.palette.textPrimary,
-                            fontFamily = DisplayFont,
-                            fontWeight = FontWeight.SemiBold,
-                            style = MaterialTheme.typography.labelLarge,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false),
-                        )
-                        Text(
-                            when (state) {
-                                is VncConnectionState.Connected -> "Connected"
-                                is VncConnectionState.Connecting -> "Connecting…"
-                                is VncConnectionState.Error -> "Error"
-                                VncConnectionState.Disconnected -> "Disconnected"
-                            },
-                            color = tokens.palette.textTertiary,
-                            style = MaterialTheme.typography.labelSmall,
-                            maxLines = 1,
+                        Icon(
+                            Icons.Outlined.Keyboard,
+                            contentDescription = if (isKeyboardOpen) "Hide keyboard" else "Show keyboard",
+                            tint = if (isKeyboardOpen) tokens.accent else tokens.palette.textPrimary,
+                            modifier = Modifier.size(20.dp),
                         )
                     }
-                    Row(
-                        modifier = Modifier
-                            .clip(AndyShape.Interactive)
-                            .background(tokens.palette.sidebarBg.copy(alpha = 0.85f))
-                            .padding(horizontal = 4.dp, vertical = 2.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    IconButton(
+                        onClick = { onFullScreenChange(false) },
+                        modifier = Modifier.size(36.dp),
                     ) {
-                        IconButton(
-                            onClick = { setKeyboardOpen(!isKeyboardOpen) },
-                            modifier = Modifier.size(36.dp),
-                        ) {
-                            Icon(
-                                Icons.Outlined.Keyboard,
-                                contentDescription = if (isKeyboardOpen) "Hide keyboard" else "Show keyboard",
-                                tint = if (isKeyboardOpen) tokens.accent else tokens.palette.textPrimary,
-                                modifier = Modifier.size(20.dp),
-                            )
-                        }
-                        IconButton(
-                            onClick = { onFullScreenChange(false) },
-                            modifier = Modifier.size(36.dp),
-                        ) {
-                            Icon(
-                                Icons.Outlined.FullscreenExit,
-                                contentDescription = "Exit full screen",
-                                tint = tokens.accent,
-                                modifier = Modifier.size(20.dp),
-                            )
-                        }
+                        Icon(
+                            Icons.Outlined.FullscreenExit,
+                            contentDescription = "Exit full screen",
+                            tint = tokens.accent,
+                            modifier = Modifier.size(20.dp),
+                        )
                     }
                 }
             }
@@ -818,9 +822,10 @@ private fun DisplayChip(label: String, selected: Boolean, onClick: () -> Unit) {
 /**
  * One touch gesture, start to finish.
  *
- * One finger always drives the mouse (tap / hold / click-drag) at any zoom level, so a
- * drag never silently turns into a pan. Two fingers zoom, and pan when zoomed in or
- * scroll the wheel when the image already fits.
+ * Navigate-first: one-finger drag pans when the image overflows; tap left-clicks;
+ * long-press + release right-clicks; long-press then drag arms a mouse click-drag
+ * (haptic on arm). Two fingers pinch-zoom and pan, or scroll the wheel when nothing
+ * overflows.
  *
  * Every event goes to [RfbClient.postPointer], which is a plain ordered queue. The
  * previous code launched a coroutine per event, so button-down could reach the socket
@@ -835,8 +840,19 @@ private suspend fun AwaitPointerEventScope.handleViewerGesture(
     panState: MutableState<Offset>,
     touchSlop: Float,
     longPressMs: Long,
+    haptics: HapticFeedback,
+    view: android.view.View,
 ) {
     fun mapping() = computeMapping(viewportState.value, crop, zoomState.floatValue, panState.value)
+    fun applyPanDelta(delta: Offset) {
+        if (!canPan(viewportState.value, crop, zoomState.floatValue)) return
+        panState.value = clampPan(
+            viewportState.value,
+            crop,
+            zoomState.floatValue,
+            panState.value + delta,
+        )
+    }
 
     val down = awaitFirstDown(requireUnconsumed = false)
     var lastPos = down.position
@@ -848,15 +864,13 @@ private suspend fun AwaitPointerEventScope.handleViewerGesture(
             when {
                 pressed.size >= 2 -> return@withTimeoutOrNull Gesture.Multi
                 pressed.isEmpty() -> {
-                    // Prefer the lift position — fingers often settle a few pixels
-                    // between down and up, and that final spot is what you meant.
                     event.changes.firstOrNull()?.let { lastPos = it.position }
                     return@withTimeoutOrNull Gesture.Tap
                 }
                 else -> {
                     lastPos = pressed.first().position
                     if ((lastPos - down.position).getDistance() > touchSlop) {
-                        return@withTimeoutOrNull Gesture.Drag
+                        return@withTimeoutOrNull Gesture.Pan
                     }
                 }
             }
@@ -867,6 +881,7 @@ private suspend fun AwaitPointerEventScope.handleViewerGesture(
 
     if (classification == Gesture.Tap) {
         mapping().toRemote(lastPos.x, lastPos.y)?.let { (x, y) ->
+            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
             client.postPointer(x, y, BUTTON_LEFT)
             client.postPointer(x, y, 0)
         }
@@ -875,22 +890,19 @@ private suspend fun AwaitPointerEventScope.handleViewerGesture(
 
     var mode = classification
     var mouseDown = false
+    var longPressArmed = false
     val pinch = PinchState()
 
     when (mode) {
         Gesture.LongPress -> {
-            mapping().toRemote(lastPos.x, lastPos.y)?.let { (x, y) ->
-                client.postPointer(x, y, BUTTON_RIGHT)
-                client.postPointer(x, y, 0)
-            }
+            // View API — Compose LocalHapticFeedback often no-ops for LongPress during
+            // pointerInput coroutines; this is the "armed for right-click / hold-drag" cue.
+            view.performHapticFeedback(android.view.HapticFeedbackConstants.LONG_PRESS)
+            longPressArmed = true
+            lastPos = down.position
         }
-        Gesture.Drag -> {
-            // Press where the finger actually landed, then move — pressing at the
-            // slop-exceeded point loses the drag origin (text selection starts wrong).
-            mapping().toRemote(down.position.x, down.position.y)?.let { (x, y) ->
-                mouseDown = true
-                client.postPointer(x, y, BUTTON_LEFT)
-            }
+        Gesture.Pan -> {
+            applyPanDelta(lastPos - down.position)
         }
         else -> Unit
     }
@@ -898,7 +910,16 @@ private suspend fun AwaitPointerEventScope.handleViewerGesture(
     while (true) {
         val event = awaitPointerEvent()
         val pressed = event.changes.filter { it.pressed }
-        if (pressed.isEmpty()) break
+        if (pressed.isEmpty()) {
+            if (longPressArmed && !mouseDown) {
+                event.changes.firstOrNull()?.let { lastPos = it.position }
+                mapping().toRemote(lastPos.x, lastPos.y)?.let { (x, y) ->
+                    client.postPointer(x, y, BUTTON_RIGHT)
+                    client.postPointer(x, y, 0)
+                }
+            }
+            break
+        }
 
         if (pressed.size >= 2) {
             if (mouseDown) {
@@ -907,6 +928,7 @@ private suspend fun AwaitPointerEventScope.handleViewerGesture(
                 }
                 mouseDown = false
             }
+            longPressArmed = false
             mode = Gesture.Multi
             pinch.apply(
                 event = event,
@@ -917,22 +939,46 @@ private suspend fun AwaitPointerEventScope.handleViewerGesture(
                 zoomState = zoomState,
                 panState = panState,
                 touchSlop = touchSlop,
+                haptics = haptics,
             )
             continue
         }
 
-        if (mode == Gesture.Drag) {
-            val change = pressed.first()
-            lastPos = change.position
-            mapping().toRemoteClamped(lastPos.x, lastPos.y)?.let { (x, y) ->
-                // Covers the case where the press itself landed in the letterbox and so
-                // was never sent: the first in-bounds move becomes the button-down.
-                mouseDown = true
-                client.postPointer(x, y, BUTTON_LEFT)
+        val change = pressed.first()
+        val pos = change.position
+
+        when {
+            mouseDown -> {
+                lastPos = pos
+                mapping().toRemoteClamped(lastPos.x, lastPos.y)?.let { (x, y) ->
+                    client.postPointer(x, y, BUTTON_LEFT)
+                }
+                if (change.positionChanged()) change.consume()
             }
-            if (change.positionChanged()) change.consume()
-        } else {
-            pressed.forEach { if (it.positionChanged()) it.consume() }
+            longPressArmed -> {
+                lastPos = pos
+                if ((pos - down.position).getDistance() > touchSlop) {
+                    longPressArmed = false
+                    // Press at the original contact, then track to the current point.
+                    mapping().toRemote(down.position.x, down.position.y)?.let { (x, y) ->
+                        mouseDown = true
+                        client.postPointer(x, y, BUTTON_LEFT)
+                    }
+                    mapping().toRemoteClamped(pos.x, pos.y)?.let { (x, y) ->
+                        mouseDown = true
+                        client.postPointer(x, y, BUTTON_LEFT)
+                    }
+                }
+                if (change.positionChanged()) change.consume()
+            }
+            mode == Gesture.Pan -> {
+                applyPanDelta(pos - lastPos)
+                lastPos = pos
+                if (change.positionChanged()) change.consume()
+            }
+            mode == Gesture.Multi -> {
+                if (change.positionChanged()) change.consume()
+            }
         }
     }
 
@@ -948,6 +994,8 @@ private class PinchState {
     private var armed = false
     private var lastCentroidSize = 0f
     private var scrollAccum = 0f
+    private var hitMinZoom = false
+    private var hitMaxZoom = false
 
     @Suppress("LongParameterList")
     fun apply(
@@ -959,6 +1007,7 @@ private class PinchState {
         zoomState: MutableFloatState,
         panState: MutableState<Offset>,
         touchSlop: Float,
+        haptics: HapticFeedback,
     ) {
         val panChange = event.calculatePan()
         if (!armed) {
@@ -971,10 +1020,23 @@ private class PinchState {
 
         val centroid = event.calculateCentroid(useCurrent = true)
         val oldZoom = zoomState.floatValue
-        val newZoom = (oldZoom * event.calculateZoom()).coerceIn(1f, MAX_ZOOM)
+        val rawZoom = oldZoom * event.calculateZoom()
+        val newZoom = rawZoom.coerceIn(1f, MAX_ZOOM)
+        if (rawZoom < 1f && !hitMinZoom) {
+            hitMinZoom = true
+            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        } else if (rawZoom > MAX_ZOOM && !hitMaxZoom) {
+            hitMaxZoom = true
+            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        } else if (newZoom > 1f && newZoom < MAX_ZOOM) {
+            hitMinZoom = false
+            hitMaxZoom = false
+        }
 
-        if (newZoom <= FIT_ZOOM_EPSILON && oldZoom <= FIT_ZOOM_EPSILON) {
-            // Nothing to pan at fit-zoom, so two-finger travel drives the scroll wheel.
+        if (!canPan(viewport, crop, oldZoom) && !canPan(viewport, crop, newZoom) &&
+            newZoom <= 1.001f && oldZoom <= 1.001f
+        ) {
+            // Nothing to pan when the image already covers exactly, so scroll the wheel.
             scrollAccum += panChange.y
             val target = computeMapping(viewport, crop, oldZoom, panState.value)
                 .toRemoteClamped(centroid.x, centroid.y)

--- a/androidApp/src/test/kotlin/com/joetr/andy/mobile/data/networkaccess/ChatPlanModeTest.kt
+++ b/androidApp/src/test/kotlin/com/joetr/andy/mobile/data/networkaccess/ChatPlanModeTest.kt
@@ -1,0 +1,69 @@
+package com.joetr.andy.mobile.data.networkaccess
+
+import com.joetr.andy.mobile.data.networkaccess.ChatDto
+import com.joetr.andy.mobile.data.networkaccess.ChatEventDto
+import com.joetr.andy.mobile.data.networkaccess.PlanEntryDto
+import com.joetr.andy.mobile.data.networkaccess.awaitingPlanConfirmation
+import com.joetr.andy.mobile.data.networkaccess.displayStatusLabel
+import com.joetr.andy.mobile.data.networkaccess.hasListAttentionMarker
+import com.joetr.andy.mobile.data.networkaccess.latestPlanHasPendingEntries
+import com.joetr.andy.mobile.data.networkaccess.showImplementPlan
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatPlanModeTest {
+    @Test
+    fun donePlanModeShowsPlanReady() {
+        val chat = ChatDto(id = "1", status = "Done", planMode = true)
+        assertTrue(chat.awaitingPlanConfirmation())
+        assertTrue(chat.showImplementPlan())
+        assertEquals("plan ready", chat.displayStatusLabel())
+    }
+
+    @Test
+    fun pendingPlanEntriesShowPlanReadyWithoutPlanMode() {
+        val chat = ChatDto(id = "1", status = "Done", planMode = false)
+        val events = listOf(
+            ChatEventDto(
+                type = "plan",
+                entries = listOf(
+                    PlanEntryDto("Switch RemoteDisplay mapping", "pending"),
+                    PlanEntryDto("Rewrite handleViewerGesture", "pending"),
+                ),
+            ),
+        )
+        assertTrue(events.latestPlanHasPendingEntries())
+        assertTrue(chat.awaitingPlanConfirmation(hasPendingPlanEntries = true))
+        assertEquals("plan ready", chat.displayStatusLabel(hasPendingPlanEntries = true))
+    }
+
+    @Test
+    fun specStageHidesImplement() {
+        val chat = ChatDto(
+            id = "1",
+            status = "Done",
+            planMode = true,
+            workflowStage = "Spec",
+        )
+        assertTrue(chat.awaitingPlanConfirmation())
+        assertFalse(chat.showImplementPlan())
+    }
+
+    @Test
+    fun workingPlanModeIsNotAwaiting() {
+        val chat = ChatDto(id = "1", status = "Working", planMode = true)
+        assertFalse(chat.awaitingPlanConfirmation())
+        assertEquals("Working", chat.displayStatusLabel())
+    }
+
+    @Test
+    fun listAttentionOnlyForInterestingStates() {
+        assertFalse(ChatDto(id = "1", status = "Done").hasListAttentionMarker())
+        assertFalse(ChatDto(id = "1", status = "Working").hasListAttentionMarker())
+        assertTrue(ChatDto(id = "1", status = "Blocked").hasListAttentionMarker())
+        assertTrue(ChatDto(id = "1", status = "Error").hasListAttentionMarker())
+        assertTrue(ChatDto(id = "1", status = "Done", planMode = true).hasListAttentionMarker())
+    }
+}

--- a/androidApp/src/test/kotlin/com/joetr/andy/mobile/ui/RemoteDisplayTest.kt
+++ b/androidApp/src/test/kotlin/com/joetr/andy/mobile/ui/RemoteDisplayTest.kt
@@ -3,6 +3,7 @@ package com.joetr.andy.mobile.ui
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.math.abs
@@ -12,11 +13,14 @@ class RemoteDisplayTest {
     private val crop = DisplayCrop(0, 0, 0, 3448, 2346)
 
     @Test
-    fun atFitZoomTheImageIsLetterboxedInsideTheViewport() {
+    fun atFillZoomWideCropCoversViewportAndAllowsHorizontalPan() {
         val mapping = computeMapping(viewport, crop, zoom = 1f, pan = Offset.Zero)
-        assertEquals(0f, mapping.left, 0.5f)
-        assertTrue("image must not exceed the viewport", mapping.width <= viewport.width + 0.5f)
-        assertTrue(mapping.height <= viewport.height + 0.5f)
+        assertTrue("image must cover viewport width", mapping.width >= viewport.width - 0.5f)
+        assertTrue("image must cover viewport height", mapping.height >= viewport.height - 0.5f)
+        assertTrue(canPan(viewport, crop, zoom = 1f))
+        val clamped = clampPan(viewport, crop, zoom = 1f, Offset(100_000f, 0f))
+        assertTrue(abs(clamped.x) > 1f)
+        assertEquals(0f, clamped.y, 0.001f)
     }
 
     /** Pinch-zoom used to let the image be dragged off-screen entirely. */
@@ -30,11 +34,14 @@ class RemoteDisplayTest {
     }
 
     @Test
-    fun panIsZeroedOnAnAxisWhereTheImageIsSmallerThanTheViewport() {
-        // The wide crop never fills the tall viewport vertically, so it stays centred.
-        val clamped = clampPan(viewport, crop, zoom = 1f, pan = Offset(500f, 500f))
+    fun panIsZeroedOnAnAxisWhereTheImageDoesNotOverflow() {
+        // Matched aspect: cover equals fit, no overflow, pan stays centred.
+        val squareCrop = DisplayCrop(null, 0, 0, 100, 100)
+        val squareViewport = IntSize(200, 200)
+        val clamped = clampPan(squareViewport, squareCrop, zoom = 1f, Offset(500f, 500f))
         assertEquals(0f, clamped.x, 0.001f)
         assertEquals(0f, clamped.y, 0.001f)
+        assertFalse(canPan(squareViewport, squareCrop, zoom = 1f))
     }
 
     @Test
@@ -59,7 +66,7 @@ class RemoteDisplayTest {
 
     @Test
     fun touchMapsToTheRemotePixelUnderTheViewPoint() {
-        // A 4×2 crop fitted into an 8×4 viewport → each remote pixel is 2×2 view pixels.
+        // A 4×2 crop covered into an 8×4 viewport → each remote pixel is 2×2 view pixels.
         val tiny = DisplayCrop(null, 0, 0, 4, 2)
         val mapping = computeMapping(IntSize(8, 4), tiny, zoom = 1f, pan = Offset.Zero)
         // Just inside the top-left remote pixel's view rect should stay on (0,0),
@@ -72,9 +79,18 @@ class RemoteDisplayTest {
 
     @Test
     fun touchesOutsideTheImageDoNotMapButClampedTouchesDo() {
-        val mapping = computeMapping(viewport, crop, zoom = 1f, pan = Offset.Zero)
-        assertEquals(null, mapping.toRemote(mapping.left - 40f, mapping.top + 10f))
-        assertEquals(crop.x, mapping.toRemoteClamped(mapping.left - 40f, mapping.top + 10f)!!.first)
+        val mapping = computeMapping(viewport, crop, zoom = 2f, pan = Offset.Zero)
+        // At cover zoom the image already fills the viewport; pan left so left edge is past 0.
+        val panned = computeMapping(
+            viewport,
+            crop,
+            zoom = 2f,
+            pan = clampPan(viewport, crop, 2f, Offset(10_000f, 0f)),
+        )
+        assertEquals(null, panned.toRemote(panned.left - 40f, panned.top + 10f))
+        assertEquals(crop.x, panned.toRemoteClamped(panned.left - 40f, panned.top + 10f)!!.first)
+        // Sanity: centre still maps.
+        assertTrue(mapping.toRemote(viewport.width / 2f, viewport.height / 2f) != null)
     }
 
     @Test
@@ -98,7 +114,8 @@ class RemoteDisplayTest {
     }
 
     @Test
-    fun samplerBlacksOutLetterboxBarsInsteadOfLeavingStalePixels() {
+    fun samplerBlacksOutUncoveredBarsInsteadOfLeavingStalePixels() {
+        // Force a letterboxed mapping (narrower than cover) so uncovered rows stay black.
         val srcW = 8
         val srcH = 2
         val src = IntArray(srcW * srcH) { 0xFFFFFFFF.toInt() }
@@ -106,13 +123,13 @@ class RemoteDisplayTest {
         val dstW = 8
         val dstH = 8
         val dst = IntArray(dstW * dstH) { 0xFF00FF00.toInt() } // stale green
-        val mapping = computeMapping(IntSize(dstW, dstH), fullCrop, 1f, Offset.Zero)
+        val mapping = ViewMapping(fullCrop, left = 0f, top = 3f, width = 8f, height = 2f)
 
         sampleFrame(src, srcW, srcH, mapping, dst, dstW, dstH)
 
         assertEquals(0xFF000000.toInt(), dst[0]) // top bar
         assertEquals(0xFF000000.toInt(), dst[dst.size - 1]) // bottom bar
-        assertEquals(0xFFFFFFFF.toInt(), dst[dstH / 2 * dstW + dstW / 2]) // image band
+        assertEquals(0xFFFFFFFF.toInt(), dst[4 * dstW + 4]) // image band
     }
 
     @Test
@@ -131,6 +148,53 @@ class RemoteDisplayTest {
 
         assertTrue(dst.none { it == LEFT })
         assertTrue(dst.any { it == RIGHT })
+    }
+
+    @Test
+    fun viewportResizePreservesAbsoluteScale() {
+        val oldViewport = IntSize(1080, 1920)
+        val newViewport = IntSize(1080, 900)
+        val oldZoom = 2f
+        val newZoom = zoomPreservingAbsoluteScale(oldViewport, newViewport, crop, oldZoom, maxZoom = 20f)
+        val oldFill = fillScale(oldViewport, crop)
+        val newFill = fillScale(newViewport, crop)
+        assertEquals(oldZoom * oldFill, newZoom * newFill, 0.001f)
+    }
+
+    @Test
+    fun panShowingRemoteAtKeepsRemotePixelUnderViewPoint() {
+        val zoom = 3f // both axes overflow so any in-crop pixel can sit at centre
+        val remoteX = crop.x + crop.width / 3
+        val remoteY = crop.y + crop.height / 4
+        val viewX = viewport.width / 2f
+        val viewY = viewport.height / 2f
+        val pan = panShowingRemoteAt(viewport, crop, zoom, remoteX, remoteY, viewX, viewY)
+        val mapped = computeMapping(viewport, crop, zoom, pan).toRemote(viewX, viewY)!!
+        assertTrue(abs(mapped.first - remoteX) <= 1)
+        assertTrue(abs(mapped.second - remoteY) <= 1)
+    }
+
+    @Test
+    fun viewportResizeCanPreserveCentreRemotePixel() {
+        val zoom = 1.5f
+        val oldViewport = IntSize(1080, 1920)
+        val newViewport = IntSize(1080, 900) // keyboard ate the bottom
+        val oldPan = clampPan(oldViewport, crop, zoom, Offset(200f, -150f))
+        val remote = computeMapping(oldViewport, crop, zoom, oldPan)
+            .toRemoteClamped(oldViewport.width / 2f, oldViewport.height / 2f)!!
+        val newPan = panShowingRemoteAt(
+            newViewport,
+            crop,
+            zoom,
+            remote.first,
+            remote.second,
+            newViewport.width / 2f,
+            newViewport.height / 2f,
+        )
+        val mapped = computeMapping(newViewport, crop, zoom, newPan)
+            .toRemote(newViewport.width / 2f, newViewport.height / 2f)!!
+        assertTrue(abs(mapped.first - remote.first) <= 1)
+        assertTrue(abs(mapped.second - remote.second) <= 1)
     }
 
     private companion object {

--- a/cli/andy/src/acp_view.rs
+++ b/cli/andy/src/acp_view.rs
@@ -851,8 +851,37 @@ fn is_active_status(status: &str) -> bool {
 
 fn awaiting_plan_confirmation(state: &ViewState) -> bool {
     state.status.eq_ignore_ascii_case("Done")
-        && state.plan_mode
+        && (state.plan_mode || latest_plan_has_pending_entries(&state.events))
         && state.pending_input.is_none()
+}
+
+/// Mirrors `latestPlanHasPendingEntries` (Android/web): a Create Plan turn can end with
+/// pending rows while `planMode` stays off. The latest plan is "pending" unless a user turn
+/// followed it and every entry (or the markdown) reads as resolved.
+fn latest_plan_has_pending_entries(events: &[AgentEvent]) -> bool {
+    let Some(plan_index) = events.iter().rposition(|e| matches!(e, AgentEvent::Plan { .. })) else {
+        return false;
+    };
+    if events
+        .iter()
+        .enumerate()
+        .any(|(i, e)| i > plan_index && matches!(e, AgentEvent::User { .. }))
+    {
+        return false;
+    }
+    let AgentEvent::Plan { entries, markdown, .. } = &events[plan_index] else {
+        return false;
+    };
+    if entries.is_empty() {
+        return markdown.as_deref().is_some_and(|m| !m.trim().is_empty());
+    }
+    entries.iter().any(|(_, status)| {
+        let s = status.trim().to_lowercase();
+        !matches!(
+            s.as_str(),
+            "completed" | "complete" | "done" | "cancelled" | "canceled" | "file"
+        )
+    })
 }
 
 fn display_status_label(state: &ViewState) -> String {
@@ -864,7 +893,9 @@ fn display_status_label(state: &ViewState) -> String {
 }
 
 /// Transcript presence line mirroring the desktop Working orb.
-fn presence_label(status: &str, pending: Option<&PendingUserInput>, plan_mode: bool) -> Option<String> {
+/// `plan_ready` is the precomputed "Done awaiting plan approval" flag (see
+/// [`awaiting_plan_confirmation`]).
+fn presence_label(status: &str, pending: Option<&PendingUserInput>, plan_ready: bool) -> Option<String> {
     match status {
         "Working" => Some("Working".into()),
         "Blocked" => {
@@ -875,7 +906,7 @@ fn presence_label(status: &str, pending: Option<&PendingUserInput>, plan_mode: b
             }
         }
         "Stopping" => Some("Stopping".into()),
-        "Done" if plan_mode && pending.is_none() => {
+        "Done" if plan_ready => {
             Some("Plan ready — Ctrl-i implement · type to refine".into())
         }
         _ => None,
@@ -894,9 +925,9 @@ fn presence_line(
     status: &str,
     started: Instant,
     pending: Option<&PendingUserInput>,
-    plan_mode: bool,
+    plan_ready: bool,
 ) -> Option<Line<'static>> {
-    let label = presence_label(status, pending, plan_mode)?;
+    let label = presence_label(status, pending, plan_ready)?;
     // Keep presence to one row; long delete paths truncate rather than wrap.
     let max = 120usize;
     let display = if label.chars().count() > max {
@@ -915,7 +946,7 @@ fn presence_line(
         text,
         Style::default().fg(if pending.is_some() {
             Color::Magenta
-        } else if status.eq_ignore_ascii_case("Done") && plan_mode {
+        } else if status.eq_ignore_ascii_case("Done") && plan_ready {
             Color::Green
         } else {
             Color::DarkGray
@@ -1023,7 +1054,9 @@ fn map_key_action(state: &ViewState, key: KeyEvent) -> MappedKey {
             MappedKey::Exit
         }
         KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => MappedKey::Stop,
-        KeyCode::Char('i')
+        // Ctrl-I is encoded as Tab (0x09) on standard terminals, so accept both the literal
+        // 'i' (kitty-enhanced terminals disambiguate) and Tab-with-CONTROL.
+        KeyCode::Char('i') | KeyCode::Tab
             if key.modifiers.contains(KeyModifiers::CONTROL)
                 && awaiting_plan_confirmation(state)
                 && !state.workflow_stage.eq_ignore_ascii_case("Spec") =>
@@ -1237,7 +1270,7 @@ fn draw(
         &state.status,
         state.presence_started,
         state.pending_input.as_ref(),
-        state.plan_mode,
+        awaiting_plan_confirmation(state),
     );
     let presence_h = if presence.is_some() { 1u16 } else { 0 };
     let transcript_parts = Layout::default()
@@ -2377,6 +2410,96 @@ mod tests {
             Some("Plan ready — Ctrl-i implement · type to refine")
         );
         assert_eq!(presence_label("Idle", None, false), None);
+    }
+
+    #[test]
+    fn plan_pending_entries_are_detected_like_android_web() {
+        // Cursor Create Plan can end with pending rows while planMode stays off.
+        let pending = vec![
+            AgentEvent::Plan {
+                at_millis: 0,
+                entries: vec![
+                    ("Step one".into(), "pending".into()),
+                    ("Step two".into(), "completed".into()),
+                ],
+                markdown: None,
+            },
+        ];
+        assert!(latest_plan_has_pending_entries(&pending));
+        // A user turn after the plan supersedes it.
+        let superseded = vec![
+            AgentEvent::Plan {
+                at_millis: 0,
+                entries: vec![("Step one".into(), "pending".into())],
+                markdown: None,
+            },
+            AgentEvent::User {
+                at_millis: 1,
+                text: "refine".into(),
+                images: vec![],
+            },
+        ];
+        assert!(!latest_plan_has_pending_entries(&superseded));
+        // All-completed entries are not pending.
+        let done = vec![AgentEvent::Plan {
+            at_millis: 0,
+            entries: vec![
+                ("Step one".into(), "completed".into()),
+                ("Step two".into(), "done".into()),
+            ],
+            markdown: None,
+        }];
+        assert!(!latest_plan_has_pending_entries(&done));
+        // Empty entries fall back to the markdown body.
+        let markdown_only = vec![AgentEvent::Plan {
+            at_millis: 0,
+            entries: vec![],
+            markdown: Some("  ".into()),
+        }];
+        assert!(!latest_plan_has_pending_entries(&markdown_only));
+        let markdown_body = vec![AgentEvent::Plan {
+            at_millis: 0,
+            entries: vec![],
+            markdown: Some("Step one".into()),
+        }];
+        assert!(latest_plan_has_pending_entries(&markdown_body));
+    }
+
+    #[test]
+    fn awaiting_plan_confirmation_accepts_pending_plan_entries_without_plan_mode() {
+        let mut state = empty_state();
+        state.status = "Done".into();
+        state.plan_mode = false;
+        state.events = vec![AgentEvent::Plan {
+            at_millis: 0,
+            entries: vec![("Step one".into(), "pending".into())],
+            markdown: None,
+        }];
+        assert!(awaiting_plan_confirmation(&state));
+        assert_eq!(display_status_label(&state), "plan ready");
+    }
+
+    #[test]
+    fn implement_shortcut_accepts_tab_encoding_of_ctrl_i() {
+        // Standard terminals encode Ctrl-I as Tab (0x09); ensure it maps to ImplementPlan.
+        let mut state = empty_state();
+        state.status = "Done".into();
+        state.plan_mode = true;
+        state.events = vec![];
+        let mapped = map_key_action(
+            &state,
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL),
+        );
+        assert_eq!(mapped, MappedKey::ImplementPlan);
+        // And still not when the plan-mode predicate is unsatisfied.
+        state.plan_mode = false;
+        assert_eq!(
+            map_key_action(
+                &state,
+                KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL),
+            ),
+            MappedKey::None
+        );
     }
 
     #[test]

--- a/cli/andy/src/acp_view.rs
+++ b/cli/andy/src/acp_view.rs
@@ -46,6 +46,8 @@ struct ChatMeta {
     id: String,
     title: String,
     status: String,
+    plan_mode: bool,
+    workflow_stage: String,
     queued_follow_ups: Vec<QueuedFollowUp>,
     agent: Option<String>,
     #[allow(dead_code)]
@@ -62,6 +64,8 @@ struct QueuedFollowUp {
 #[derive(Debug, Clone)]
 struct LiveSnapshot {
     status: String,
+    plan_mode: bool,
+    workflow_stage: String,
     queued_follow_ups: Vec<QueuedFollowUp>,
     /// True when workspace delivery mode is Queue (vs Immediate inject).
     prefer_queue: bool,
@@ -78,6 +82,8 @@ enum ConnectionIssue {
 struct ViewState {
     events: Vec<AgentEvent>,
     status: String,
+    plan_mode: bool,
+    workflow_stage: String,
     queued_follow_ups: Vec<QueuedFollowUp>,
     /// Workspace AgentMessageDeliveryMode == Queue.
     prefer_queue: bool,
@@ -155,6 +161,8 @@ pub async fn run_acp_viewer(client: &mut McpClient, task_id: &str) -> Result<()>
         let mut state = ViewState {
             events: Vec::new(),
             status: meta.status.clone(),
+            plan_mode: meta.plan_mode,
+            workflow_stage: meta.workflow_stage.clone(),
             queued_follow_ups: meta.queued_follow_ups.clone(),
             prefer_queue: false,
             input: String::new(),
@@ -489,6 +497,44 @@ async fn handle_key(
                 }
             }
         }
+        MappedKey::ImplementPlan => {
+            if !awaiting_plan_confirmation(state) {
+                state.status_flash = Some("not awaiting plan approval".into());
+            } else if state.workflow_stage.eq_ignore_ascii_case("Spec") {
+                state.status_flash = Some("spec runs stay in plan mode — review in Projects".into());
+            } else {
+                match client
+                    .call_tool(
+                        "chat.update_plan_mode",
+                        json!({ "taskId": meta.id, "planMode": false }),
+                    )
+                    .await
+                {
+                    Ok(_) => {
+                        state.plan_mode = false;
+                        match client
+                            .call_tool(
+                                "chat.resume",
+                                json!({ "taskId": meta.id, "followUp": "Implement the plan." }),
+                            )
+                            .await
+                        {
+                            Ok(_) => {
+                                state.status = "Working".into();
+                                state.status_flash = Some("implementing plan".into());
+                                state.presence_started = Instant::now();
+                            }
+                            Err(err) => {
+                                state.status_flash = Some(format!("implement failed: {err:#}"));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        state.status_flash = Some(format!("plan mode update failed: {err:#}"));
+                    }
+                }
+            }
+        }
         MappedKey::PickImage => {
             let start = if !meta.cwd.is_empty() {
                 PathBuf::from(&meta.cwd)
@@ -624,6 +670,7 @@ enum MappedKey {
     Exit,
     Retry,
     Stop,
+    ImplementPlan,
     PickImage,
     ToggleExpand,
     ToggleDetails,
@@ -712,6 +759,15 @@ fn parse_live_snapshot(v: &Value) -> LiveSnapshot {
             .and_then(|s| s.as_str())
             .unwrap_or("")
             .to_string(),
+        plan_mode: v
+            .get("planMode")
+            .and_then(|b| b.as_bool())
+            .unwrap_or(false),
+        workflow_stage: v
+            .get("workflowStage")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_string(),
         queued_follow_ups: parse_queued_follow_ups(v.get("queuedFollowUps")),
         prefer_queue: v
             .get("messageDeliveryMode")
@@ -746,6 +802,8 @@ async fn refresh_live_state(client: &mut McpClient, task_id: &str, state: &mut V
         return;
     };
     state.prefer_queue = snap.prefer_queue;
+    state.plan_mode = snap.plan_mode;
+    state.workflow_stage = snap.workflow_stage;
     if !snap.status.is_empty()
         && !matches!(state.status.as_str(), "Stopping")
         && state.status != snap.status
@@ -791,8 +849,22 @@ fn is_active_status(status: &str) -> bool {
     matches!(status, "Working" | "Blocked" | "Stopping")
 }
 
+fn awaiting_plan_confirmation(state: &ViewState) -> bool {
+    state.status.eq_ignore_ascii_case("Done")
+        && state.plan_mode
+        && state.pending_input.is_none()
+}
+
+fn display_status_label(state: &ViewState) -> String {
+    if awaiting_plan_confirmation(state) {
+        "plan ready".into()
+    } else {
+        state.status.clone()
+    }
+}
+
 /// Transcript presence line mirroring the desktop Working orb.
-fn presence_label(status: &str, pending: Option<&PendingUserInput>) -> Option<String> {
+fn presence_label(status: &str, pending: Option<&PendingUserInput>, plan_mode: bool) -> Option<String> {
     match status {
         "Working" => Some("Working".into()),
         "Blocked" => {
@@ -803,6 +875,9 @@ fn presence_label(status: &str, pending: Option<&PendingUserInput>) -> Option<St
             }
         }
         "Stopping" => Some("Stopping".into()),
+        "Done" if plan_mode && pending.is_none() => {
+            Some("Plan ready — Ctrl-i implement · type to refine".into())
+        }
         _ => None,
     }
 }
@@ -819,20 +894,29 @@ fn presence_line(
     status: &str,
     started: Instant,
     pending: Option<&PendingUserInput>,
+    plan_mode: bool,
 ) -> Option<Line<'static>> {
-    let label = presence_label(status, pending)?;
+    let label = presence_label(status, pending, plan_mode)?;
     // Keep presence to one row; long delete paths truncate rather than wrap.
     let max = 120usize;
     let display = if label.chars().count() > max {
         let truncated: String = label.chars().take(max.saturating_sub(1)).collect();
         format!("{truncated}…")
     } else {
-        format!("{label}…")
+        label
+    };
+    let spinning = matches!(status, "Working" | "Blocked" | "Stopping");
+    let text = if spinning {
+        format!("  {} {display}…", presence_spinner(started))
+    } else {
+        format!("  {display}")
     };
     Some(Line::from(Span::styled(
-        format!("  {} {display}", presence_spinner(started)),
+        text,
         Style::default().fg(if pending.is_some() {
             Color::Magenta
+        } else if status.eq_ignore_ascii_case("Done") && plan_mode {
+            Color::Green
         } else {
             Color::DarkGray
         }),
@@ -939,6 +1023,13 @@ fn map_key_action(state: &ViewState, key: KeyEvent) -> MappedKey {
             MappedKey::Exit
         }
         KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => MappedKey::Stop,
+        KeyCode::Char('i')
+            if key.modifiers.contains(KeyModifiers::CONTROL)
+                && awaiting_plan_confirmation(state)
+                && !state.workflow_stage.eq_ignore_ascii_case("Spec") =>
+        {
+            MappedKey::ImplementPlan
+        }
         // Ctrl-+ (and Ctrl-= on US layouts where + is Shift-=) — avoid letter chords.
         KeyCode::Char('+') | KeyCode::Char('=')
             if key.modifiers.contains(KeyModifiers::CONTROL) && state.composer_enabled =>
@@ -1116,7 +1207,12 @@ fn draw(
         ])
         .split(area);
 
-    let header = viewer_chrome::format_header(&meta.id, &meta.title, &state.status, Lane::Acp);
+    let header = viewer_chrome::format_header(
+        &meta.id,
+        &meta.title,
+        &display_status_label(state),
+        Lane::Acp,
+    );
     frame.render_widget(
         Paragraph::new(header).block(
             Block::default()
@@ -1141,6 +1237,7 @@ fn draw(
         &state.status,
         state.presence_started,
         state.pending_input.as_ref(),
+        state.plan_mode,
     );
     let presence_h = if presence.is_some() { 1u16 } else { 0 };
     let transcript_parts = Layout::default()
@@ -1659,6 +1756,19 @@ async fn load_meta(client: &mut McpClient, task_id: &str) -> Result<ChatMeta> {
         } else {
             snap.status
         },
+        plan_mode: snap.plan_mode
+            || row
+                .and_then(|r| r.get("planMode"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+        workflow_stage: if snap.workflow_stage.is_empty() {
+            row.and_then(|r| r.get("workflowStage"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        } else {
+            snap.workflow_stage
+        },
         queued_follow_ups: queued,
         agent: row
             .and_then(|r| r.get("agent"))
@@ -1737,6 +1847,8 @@ mod tests {
         ViewState {
             events: Vec::new(),
             status: "Idle".into(),
+            plan_mode: false,
+            workflow_stage: String::new(),
             queued_follow_ups: Vec::new(),
             prefer_queue: false,
             input: String::new(),
@@ -2238,11 +2350,11 @@ mod tests {
     #[test]
     fn presence_label_for_active_statuses() {
         assert_eq!(
-            presence_label("Working", None).as_deref(),
+            presence_label("Working", None, false).as_deref(),
             Some("Working")
         );
         assert_eq!(
-            presence_label("Blocked", None).as_deref(),
+            presence_label("Blocked", None, false).as_deref(),
             Some("Blocked — waiting")
         );
         let pending = PendingUserInput::from_permission_event(
@@ -2252,15 +2364,19 @@ mod tests {
             vec![],
         );
         assert_eq!(
-            presence_label("Blocked", Some(&pending)).as_deref(),
+            presence_label("Blocked", Some(&pending), false).as_deref(),
             Some("Blocked — delete: Delete tmp.txt?")
         );
         assert_eq!(
-            presence_label("Stopping", None).as_deref(),
+            presence_label("Stopping", None, false).as_deref(),
             Some("Stopping")
         );
-        assert_eq!(presence_label("Done", None), None);
-        assert_eq!(presence_label("Idle", None), None);
+        assert_eq!(presence_label("Done", None, false), None);
+        assert_eq!(
+            presence_label("Done", None, true).as_deref(),
+            Some("Plan ready — Ctrl-i implement · type to refine")
+        );
+        assert_eq!(presence_label("Idle", None, false), None);
     }
 
     #[test]
@@ -2421,7 +2537,7 @@ mod tests {
 
     #[test]
     fn presence_line_renders_outside_transcript() {
-        let line = presence_line("Working", Instant::now(), None).expect("presence");
+        let line = presence_line("Working", Instant::now(), None, false).expect("presence");
         let plain: String = line
             .spans
             .iter()

--- a/cli/andy/src/chats.rs
+++ b/cli/andy/src/chats.rs
@@ -6,6 +6,7 @@ pub struct ChatRow {
     pub id: String,
     pub title: String,
     pub status: String,
+    pub plan_mode: bool,
     pub project_id: String,
     pub tmux_alive: bool,
     pub queued_count: usize,
@@ -61,6 +62,10 @@ pub fn parse_chats(raw: &str) -> Vec<ChatRow> {
                     .and_then(|v| v.as_str())
                     .unwrap_or("?")
                     .to_string(),
+                plan_mode: el
+                    .get("planMode")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
                 project_id: el
                     .get("projectId")
                     .and_then(|v| v.as_str())
@@ -180,13 +185,22 @@ fn project_label(project_id: &str) -> String {
 
 /// `[Working live · 2 queued]` style badge for list rows.
 pub fn format_status_badge(chat: &ChatRow) -> String {
+    let status = display_status_label(chat);
     let live = if chat.tmux_alive { " live" } else { "" };
     let queue = if chat.queued_count > 0 {
         format!(" · {} queued", chat.queued_count)
     } else {
         String::new()
     };
-    format!("[{}{}{}]", chat.status, live, queue)
+    format!("[{status}{live}{queue}]")
+}
+
+pub fn display_status_label(chat: &ChatRow) -> &str {
+    if chat.status.eq_ignore_ascii_case("Done") && chat.plan_mode {
+        "plan ready"
+    } else {
+        chat.status.as_str()
+    }
 }
 
 fn project_sort_key(project_id: &str) -> (u8, String) {
@@ -214,6 +228,14 @@ mod tests {
             format_status_badge(&chats[0]),
             "[Working live · 2 queued]"
         );
+    }
+
+    #[test]
+    fn format_status_badge_shows_plan_ready() {
+        let chats = parse_chats(
+            r#"[{"id":"t1","title":"Demo","status":"Done","planMode":true}]"#,
+        );
+        assert_eq!(format_status_badge(&chats[0]), "[plan ready]");
     }
 
     #[test]

--- a/cli/andy/src/viewer_chrome.rs
+++ b/cli/andy/src/viewer_chrome.rs
@@ -32,7 +32,7 @@ impl Lane {
 
     pub fn hotkey_hint(self) -> &'static str {
         match self {
-            Self::Acp => "Esc/q quit · Ctrl-s stop · Ctrl-+ image · v details · Enter send",
+            Self::Acp => "Esc/q quit · Ctrl-s stop · Ctrl-i implement · Ctrl-+ image · v details · Enter send",
             Self::Terminal => "F12/Alt+d/Ctrl-b d detach",
         }
     }

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
@@ -1047,6 +1047,8 @@ fun Server.registerAgentProjectTools(
                 put("status", task?.status?.name.orEmpty())
                 put("lane", task?.lane?.name.orEmpty())
                 put("autonomy", task?.autonomy?.name.orEmpty())
+                put("planMode", task?.planMode == true)
+                put("workflowStage", task?.workflowStage?.name.orEmpty())
                 put("statusConfident", task?.statusConfident ?: false)
                 put(
                     "tmuxAlive",

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/AttentionHub.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/AttentionHub.kt
@@ -84,7 +84,13 @@ class AttentionHub(
             if (task.automationSuppressOsNotify) continue
             if (task.automationNotifyFailedOnly && kind == AgentAttentionKind.Done) continue
             if (!tryMarkNotified(task.id, kind.name)) continue
-            val event = AgentAttentionEvent(task.id, task.projectId, task.notificationTitle, kind)
+            val event = AgentAttentionEvent(
+                taskId = task.id,
+                projectId = task.projectId,
+                title = task.notificationTitle,
+                kind = kind,
+                planMode = kind == AgentAttentionKind.Done && task.planMode,
+            )
             _events.tryEmit(event)
             emitted += event
         }
@@ -110,9 +116,9 @@ class AttentionHub(
     companion object {
         private const val SAME_KIND_WINDOW_MS = 5_000L
 
-        fun subtitle(kind: AgentAttentionKind): String = when (kind) {
+        fun subtitle(kind: AgentAttentionKind, planMode: Boolean = false): String = when (kind) {
             AgentAttentionKind.Blocked -> "Needs your input"
-            AgentAttentionKind.Done -> "Agent completed"
+            AgentAttentionKind.Done -> if (planMode) "Plan ready" else "Agent completed"
             AgentAttentionKind.Error -> "Agent failed"
         }
 
@@ -122,7 +128,8 @@ class AttentionHub(
                 put("taskId", event.taskId)
                 put("projectId", event.projectId.orEmpty())
                 put("title", event.title)
-                put("subtitle", subtitle(event.kind))
+                put("subtitle", subtitle(event.kind, event.planMode))
+                put("planMode", event.planMode)
             }.toString()
     }
 }

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/NetworkAccessAuth.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/NetworkAccessAuth.kt
@@ -123,15 +123,10 @@ internal val NetworkAccessAuthPlugin = createApplicationPlugin(
             return@onCall
         }
 
+        // Resolve credentials before enforcing the IP cooldown. Mobile clients that keep a
+        // dead session (e.g. AttentionPushService after a desktop restart) can trip the
+        // limiter; a freshly exchanged password session must still be able to get through.
         val limiter = if (path == "/api/auth/login") loginLimiter else ipLimiter
-        if (limiter.isBlocked(remote)) {
-            call.respondText(
-                """{"error":"too many failed auth attempts"}""",
-                status = HttpStatusCode.TooManyRequests,
-            )
-            return@onCall
-        }
-
         val expectedMaster = pluginConfig.tokenProvider().trim()
         val provided = call.request.extractAccessToken()
         val resolved = pluginConfig.sessionStore.resolveAuth(provided, expectedMaster)
@@ -157,6 +152,14 @@ internal val NetworkAccessAuthPlugin = createApplicationPlugin(
             call.attributes.put(
                 NetworkAccessAuthFingerprintKey,
                 resolved.fingerprint,
+            )
+            return@onCall
+        }
+
+        if (limiter.isBlocked(remote)) {
+            call.respondText(
+                """{"error":"too many failed auth attempts"}""",
+                status = HttpStatusCode.TooManyRequests,
             )
             return@onCall
         }
@@ -335,12 +338,15 @@ internal fun evaluateNetworkAccessAuth(
         return HttpStatusCode.Forbidden
     }
     if (loopback && !networkAccessEnabled) return null
-    if (limiter.isBlocked(remoteHost)) return HttpStatusCode.TooManyRequests
     val resolved = sessionStore.resolveAuth(tokenHeaderOrQuery, expectedToken)
-        ?: return HttpStatusCode.Unauthorized.also { limiter.recordFailure(remoteHost) }
-    if (!scopeAllows(requiredScope, resolved.scope)) return HttpStatusCode.Forbidden
-    limiter.clear(remoteHost)
-    return null
+    if (resolved != null) {
+        if (!scopeAllows(requiredScope, resolved.scope)) return HttpStatusCode.Forbidden
+        limiter.clear(remoteHost)
+        return null
+    }
+    if (limiter.isBlocked(remoteHost)) return HttpStatusCode.TooManyRequests
+    limiter.recordFailure(remoteHost)
+    return HttpStatusCode.Unauthorized
 }
 
 internal class AuthFailureLimiter(

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebChatRoutes.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebChatRoutes.kt
@@ -11,7 +11,9 @@ import app.andy.model.AgentModelCatalog
 import app.andy.model.AgentStatus
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskDraft
+import app.andy.model.IMPLEMENT_PLAN_PROMPT
 import app.andy.model.LocalAgentRuntime
+import app.andy.model.ProjectWorkflowStage
 import app.andy.model.acpSupported
 import app.andy.model.hasVendorCli
 import app.andy.model.isLocalModelBackend
@@ -51,8 +53,10 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -453,6 +457,73 @@ internal fun Application.installWebChatRoutes(
                 )
             }
 
+            post("/chats/{id}/plan-mode") {
+                val agents = agentRuns()
+                    ?: return@post call.respondJsonError(
+                        HttpStatusCode.ServiceUnavailable,
+                        "agent services unavailable",
+                    )
+                val id = call.parameters["id"].orEmpty()
+                val task = agents.tasks.value.excludingTemporary().firstOrNull { it.id == id }
+                    ?: return@post call.respondJsonError(HttpStatusCode.NotFound, "chat not found")
+                if (task.lane != AgentLaneKind.Acp) {
+                    return@post call.respondJsonError(
+                        HttpStatusCode.Conflict,
+                        "plan mode requires an ACP-lane session",
+                    )
+                }
+                val body = call.receiveJsonObject()
+                    ?: return@post call.respondJsonError(HttpStatusCode.BadRequest, "invalid json")
+                val planModeEl = body["planMode"]
+                    ?: return@post call.respondJsonError(HttpStatusCode.BadRequest, "planMode required")
+                val planMode = when (planModeEl) {
+                    is JsonPrimitive -> planModeEl.booleanOrNull
+                        ?: planModeEl.contentOrNull?.toBooleanStrictOrNull()
+                    else -> null
+                } ?: return@post call.respondJsonError(HttpStatusCode.BadRequest, "planMode must be boolean")
+                agents.updatePlanMode(id, planMode)
+                call.respondText(
+                    buildJsonObject {
+                        put("ok", true)
+                        put("id", id)
+                        put("planMode", planMode)
+                    }.toString(),
+                    ContentType.Application.Json,
+                )
+            }
+
+            post("/chats/{id}/implement-plan") {
+                val agents = agentRuns()
+                    ?: return@post call.respondJsonError(
+                        HttpStatusCode.ServiceUnavailable,
+                        "agent services unavailable",
+                    )
+                val id = call.parameters["id"].orEmpty()
+                val task = agents.tasks.value.excludingTemporary().firstOrNull { it.id == id }
+                    ?: return@post call.respondJsonError(HttpStatusCode.NotFound, "chat not found")
+                if (task.lane != AgentLaneKind.Acp) {
+                    return@post call.respondJsonError(
+                        HttpStatusCode.Conflict,
+                        "implement plan requires an ACP-lane session",
+                    )
+                }
+                if (task.workflowStage == ProjectWorkflowStage.Spec) {
+                    return@post call.respondJsonError(
+                        HttpStatusCode.Conflict,
+                        "spec runs stay in plan mode — review the plan in Projects",
+                    )
+                }
+                agents.updatePlanMode(id, false)
+                agents.resume(id, IMPLEMENT_PLAN_PROMPT)
+                call.respondText(
+                    buildJsonObject {
+                        put("ok", true)
+                        put("id", id)
+                    }.toString(),
+                    ContentType.Application.Json,
+                )
+            }
+
             post("/chats/start") {
                 val agents = agentRuns()
                     ?: return@post call.respondJsonError(
@@ -707,6 +778,7 @@ internal fun Application.installWebChatRoutes(
                 replaceFrom: Int? = null,
                 terminalStatus: String? = null,
             ) {
+                val currentTask = agents.tasks.value.excludingTemporary().firstOrNull { it.id == id }
                 val payload = buildJsonObject {
                     put("taskId", id)
                     putJsonArray("events") { events.forEach { add(it.toWire()) } }
@@ -714,8 +786,12 @@ internal fun Application.installWebChatRoutes(
                     if (done) put("done", true)
                     if (error != null) put("error", error)
                     if (terminalStatus != null) put("terminalStatus", terminalStatus)
+                    // Keep remote clients in sync on status / planMode / input prompts.
+                    if (currentTask != null) {
+                        put("chat", currentTask.toChatJson())
+                    }
                     // Include pending user-input so the client can render approve/deny UI.
-                    agents.tasks.value.excludingTemporary().firstOrNull { it.id == id }?.userInputRequest?.let { request ->
+                    currentTask?.userInputRequest?.let { request ->
                         putJsonObject("userInputRequest") {
                             put("id", request.id)
                             put("origin", request.origin.name)
@@ -814,6 +890,8 @@ private fun app.andy.model.AgentTask.toChatJson(): JsonObject = buildJsonObject 
     put("status", status?.name.orEmpty())
     put("projectId", projectId.orEmpty())
     put("autonomy", autonomy.name)
+    put("planMode", planMode)
+    put("workflowStage", workflowStage?.name.orEmpty())
     put("unread", unread)
     put("archived", archived)
     put("createdAtMillis", createdAtMillis)

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebPushService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebPushService.kt
@@ -88,7 +88,7 @@ class WebPushService(
     suspend fun sendAttention(event: AgentAttentionEvent) {
         val body = when (event.kind) {
             AgentAttentionKind.Blocked -> "Andy needs your input."
-            AgentAttentionKind.Done -> "Agent completed."
+            AgentAttentionKind.Done -> if (event.planMode) "Plan ready." else "Agent completed."
             AgentAttentionKind.Error -> "Agent failed."
         }
         val payload = buildJsonObject {

--- a/data/agents/src/desktopMain/resources/webchat/app.js
+++ b/data/agents/src/desktopMain/resources/webchat/app.js
@@ -366,7 +366,7 @@
           btn.innerHTML = `
             <strong>${escapeHtml(chat.title || chat.id)}</strong>
             <div class="row-meta">
-              <span class="badge">${escapeHtml(chat.status || "?")}</span>
+              <span class="badge">${escapeHtml(displayStatusLabel(chat))}</span>
               <span>${escapeHtml(chat.agent || "")}</span>
               ${chat.unread ? "<span>unread</span>" : ""}
             </div>`;
@@ -387,6 +387,54 @@
     }
   }
 
+  function awaitingPlanConfirmation(chat, eventList) {
+    if (!chat) return false;
+    if (String(chat.status || "").toLowerCase() !== "done") return false;
+    if (chat.userInputRequest) return false;
+    if (chat.planMode) return true;
+    return latestPlanHasPendingEntries(eventList || events);
+  }
+
+  function latestPlanHasPendingEntries(list) {
+    const items = Array.isArray(list) ? list : [];
+    let planIndex = -1;
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (items[i]?.type === "plan") {
+        planIndex = i;
+        break;
+      }
+    }
+    if (planIndex < 0) return false;
+    for (let i = planIndex + 1; i < items.length; i++) {
+      if (items[i]?.type === "user") return false;
+    }
+    const plan = items[planIndex] || {};
+    const entries = Array.isArray(plan.entries) ? plan.entries : [];
+    if (!entries.length) return !!(plan.markdown || "").trim();
+    return entries.some((entry) => {
+      const status = String(entry?.status || "").trim().toLowerCase();
+      return !["completed", "complete", "done", "cancelled", "canceled", "file"].includes(status);
+    });
+  }
+
+  function showImplementPlan(chat, eventList) {
+    return awaitingPlanConfirmation(chat, eventList) &&
+      String(chat?.workflowStage || "").toLowerCase() !== "spec";
+  }
+
+  function displayStatusLabel(chat, eventList) {
+    if (awaitingPlanConfirmation(chat, eventList)) return "plan ready";
+    return chat?.status || "?";
+  }
+
+  function setChatMetaLabel() {
+    if (!chatMeta) return;
+    const status = chatWorking
+      ? "Working"
+      : displayStatusLabel(chatMeta, events);
+    $("chat-meta").textContent = `${chatMeta.agent || ""} · ${status}`;
+  }
+
   function setChatLoading(loading) {
     chatLoading = loading;
     $("chat-loading").classList.toggle("hidden", !loading);
@@ -396,10 +444,11 @@
   function setChatWorking(working, label) {
     chatWorking = !!working;
     if (chatMeta) {
-      const status = working ? (label || "Working") : (chatMeta.status || "done");
-      $("chat-meta").textContent = `${chatMeta.agent || ""} · ${status}`;
+      if (working) chatMeta.status = label || "Working";
+      setChatMetaLabel();
     }
     renderTranscript();
+    renderPlanApproval();
   }
 
   function shouldShowThinkingIndicator() {
@@ -446,14 +495,17 @@
       const body = await api(`/api/chats/${encodeURIComponent(id)}`);
       chatMeta = body.chat;
       $("chat-title").textContent = chatMeta.title || id;
-      const status = chatMeta.status || "";
-      $("chat-meta").textContent = `${chatMeta.agent || ""} · ${status}`;
       events = Array.isArray(body.events) ? body.events : [];
       pendingInput = chatMeta.userInputRequest || null;
-      chatWorking = /^(working|starting|queued)$/i.test(status);
+      chatWorking = /^(working|starting|queued)$/i.test(chatMeta.status || "");
+      setChatMetaLabel();
       setChatLoading(false);
       renderTranscript();
       renderPermission();
+      renderPlanApproval();
+      $("composer-input").placeholder = awaitingPlanConfirmation(chatMeta, events)
+        ? "Refine the plan…"
+        : "Message…";
       await refreshSlashCommandsForChat();
       connectSocket(id);
     } catch (err) {
@@ -546,25 +598,34 @@
       if (events.some((e) => e.type === "user")) {
         optimisticUserText = null;
       }
+      if (batch.chat) {
+        chatMeta = Object.assign(chatMeta || {}, batch.chat);
+      }
       if (Object.prototype.hasOwnProperty.call(batch, "userInputRequest")) {
         pendingInput = batch.userInputRequest;
+        if (chatMeta) chatMeta.userInputRequest = batch.userInputRequest;
       }
       if (batch.done) {
         pendingInput = null;
         chatWorking = false;
-        if (chatMeta) chatMeta.status = batch.terminalStatus || "done";
-        $("chat-meta").textContent = `${chatMeta?.agent || ""} · ${batch.terminalStatus || "done"}`;
+        if (chatMeta) {
+          if (!batch.chat) {
+            chatMeta.status = batch.terminalStatus === "error" ? "Error" : "Done";
+          }
+          chatMeta.userInputRequest = null;
+        }
       } else if (Array.isArray(batch.events) && batch.events.length && chatMeta) {
         chatWorking = true;
-        if (chatMeta) chatMeta.status = "Working";
-        $("chat-meta").textContent = `${chatMeta.agent || ""} · Working`;
+        if (!batch.chat) chatMeta.status = "Working";
       }
+      setChatMetaLabel();
       const maybeCommands = commandsFromEvents(batch.events || []);
       if (maybeCommands.length) {
         refreshSlashCommandsForChat();
       }
       renderTranscript();
       renderPermission();
+      renderPlanApproval();
     };
     socket.onclose = (ev) => {
       socketConnecting = false;
@@ -606,7 +667,7 @@
   }
 
   function isVisibleTranscriptEvent(type) {
-    return type === "user" || type === "assistant" || type === "thinking" || type === "error" || type === "permission-resolved";
+    return type === "user" || type === "assistant" || type === "thinking" || type === "error" || type === "permission-resolved" || type === "plan";
   }
 
   function renderTranscript() {
@@ -636,6 +697,22 @@
         el.className = "bubble permission-resolved";
         el.textContent = `Permission ${ev.allowed ? "allowed" : "rejected"}: ${ev.optionId || "unknown option"}`;
         if (ev.note) el.textContent += ` (${ev.note})`;
+      } else if (type === "plan") {
+        el.className = "bubble plan";
+        const entries = Array.isArray(ev.entries) ? ev.entries : [];
+        const md = (ev.markdown || "").trim();
+        const awaiting = awaitingPlanConfirmation(chatMeta, events);
+        let body = `<div class="plan-header"><span class="plan-mark">≡</span> Plan${
+          awaiting ? ' <span class="muted">Awaiting approval</span>' : ""
+        }</div>`;
+        if (md) body += `<pre class="plan-body">${escapeHtml(md)}</pre>`;
+        if (entries.length) {
+          body += `<ol class="plan-entries">${entries.map((entry) =>
+            `<li>${escapeHtml(entry.content || "")}</li>`
+          ).join("")}</ol>`;
+        }
+        if (!md && !entries.length) body += `<div class="plan-body">Plan ready</div>`;
+        el.innerHTML = body;
       }
       root.appendChild(el);
     }
@@ -661,6 +738,7 @@
       box.innerHTML = "";
       return;
     }
+    $("plan-approval")?.classList.add("hidden");
     box.classList.remove("hidden");
     const questions = pendingInput.questions;
     const answers = {};
@@ -769,6 +847,100 @@
     syncSubmit();
   }
 
+  function renderPlanApproval() {
+    const box = $("plan-approval");
+    if (!box) return;
+    if (pendingInput || !awaitingPlanConfirmation(chatMeta, events) || chatWorking) {
+      box.classList.add("hidden");
+      box.innerHTML = "";
+      return;
+    }
+    const canImplement = showImplementPlan(chatMeta, events);
+    box.classList.remove("hidden");
+    box.innerHTML = `
+      <h2>Plan · Awaiting approval</h2>
+      <p>${canImplement
+        ? "This turn finished in plan mode. Nothing was changed. Implement when you're ready, or leave feedback and refine below."
+        : "This turn finished in plan mode. Nothing was changed. Review the plan in Projects, or leave feedback and refine below."}</p>
+      <input id="plan-feedback" type="text" placeholder="Optional feedback if refining…" autocomplete="off" />
+      <div class="plan-approval-actions">
+        <button id="plan-refine" type="button" class="ghost" disabled>Refine</button>
+        ${canImplement ? '<button id="plan-implement" type="button" class="primary">Implement plan</button>' : ""}
+      </div>`;
+    const feedback = $("plan-feedback");
+    const refine = $("plan-refine");
+    const implement = $("plan-implement");
+    feedback.addEventListener("input", () => {
+      refine.disabled = !feedback.value.trim();
+    });
+    refine.addEventListener("click", async () => {
+      const message = feedback.value.trim();
+      if (!message || !currentChatId) return;
+      feedback.value = "";
+      refine.disabled = true;
+      try {
+        optimisticUserText = message;
+        setChatWorking(true);
+        await api(`/api/chats/${encodeURIComponent(currentChatId)}/reply`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message }),
+        });
+        renderTranscript();
+      } catch (err) {
+        optimisticUserText = null;
+        if (err.message !== "unauthorized") {
+          $("chat-error").textContent = err.message || "Refine failed";
+          $("chat-error").classList.remove("hidden");
+        }
+        setChatWorking(false);
+      }
+    });
+    if (implement) {
+      implement.addEventListener("click", async () => {
+        try {
+          setChatWorking(true);
+          try {
+            await api(`/api/chats/${encodeURIComponent(currentChatId)}/implement-plan`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: "{}",
+            });
+          } catch (err) {
+            // Older hosts lack /implement-plan — mirror desktop via plan-mode + reply.
+            if (err.status !== 404) throw err;
+            try {
+              await api(`/api/chats/${encodeURIComponent(currentChatId)}/plan-mode`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ planMode: false }),
+              });
+            } catch (_) {
+              // plan-mode may also be missing; still send the implement follow-up.
+            }
+            await api(`/api/chats/${encodeURIComponent(currentChatId)}/reply`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ message: "Implement the plan." }),
+            });
+          }
+          if (chatMeta) {
+            chatMeta.planMode = false;
+            chatMeta.status = "Working";
+          }
+          renderPlanApproval();
+          setChatMetaLabel();
+        } catch (err) {
+          setChatWorking(false);
+          if (err.message !== "unauthorized") {
+            $("chat-error").textContent = err.message || "Implement failed";
+            $("chat-error").classList.remove("hidden");
+          }
+        }
+      });
+    }
+  }
+
   async function respond(requestId, answers) {
     try {
       ensureSocket();
@@ -779,7 +951,12 @@
         body: JSON.stringify({ requestId, answers }),
       });
       pendingInput = null;
+      if (chatMeta) chatMeta.userInputRequest = null;
       renderPermission();
+      renderPlanApproval();
+      $("composer-input").placeholder = awaitingPlanConfirmation(chatMeta, events)
+        ? "Refine the plan…"
+        : "Message…";
     } catch (err) {
       if (err.message !== "unauthorized") {
         $("chat-error").textContent = err.message || "Respond failed";

--- a/data/agents/src/desktopMain/resources/webchat/app.js
+++ b/data/agents/src/desktopMain/resources/webchat/app.js
@@ -79,6 +79,10 @@
   let chatWorking = false;
   let chatLoading = false;
   let optimisticUserText = null;
+  // Authoritative status captured before an optimistic "Working" override, so a failed
+  // request can restore it instead of leaving a stale "Working" (which would hide the
+  // plan-approval card and mislabel the chat until a reload).
+  let optimisticStatus = null;
   let socketPreferQueryAuth = false;
   let socketConnecting = false;
 
@@ -392,7 +396,9 @@
     if (String(chat.status || "").toLowerCase() !== "done") return false;
     if (chat.userInputRequest) return false;
     if (chat.planMode) return true;
-    return latestPlanHasPendingEntries(eventList || events);
+    // Only trust an explicit transcript. Falling back to the module-level `events`
+    // would leak one chat's plan into list rows (which don't pass a transcript).
+    return latestPlanHasPendingEntries(eventList);
   }
 
   function latestPlanHasPendingEntries(list) {
@@ -444,7 +450,16 @@
   function setChatWorking(working, label) {
     chatWorking = !!working;
     if (chatMeta) {
-      if (working) chatMeta.status = label || "Working";
+      if (working) {
+        if (optimisticStatus === null) optimisticStatus = chatMeta.status;
+        chatMeta.status = label || "Working";
+      } else if (optimisticStatus !== null) {
+        // Restore the authoritative status only if our optimistic value still owns the
+        // field; a fresher socket value (e.g. the server really did start) wins.
+        const optimistic = label || "Working";
+        if (chatMeta.status === optimistic) chatMeta.status = optimisticStatus;
+        optimisticStatus = null;
+      }
       setChatMetaLabel();
     }
     renderTranscript();
@@ -927,6 +942,7 @@
           if (chatMeta) {
             chatMeta.planMode = false;
             chatMeta.status = "Working";
+            optimisticStatus = null; // real state change; don't restore the stale capture
           }
           renderPlanApproval();
           setChatMetaLabel();

--- a/data/agents/src/desktopMain/resources/webchat/index.html
+++ b/data/agents/src/desktopMain/resources/webchat/index.html
@@ -58,6 +58,7 @@
         </div>
       </header>
       <div id="permission" class="permission hidden"></div>
+      <div id="plan-approval" class="plan-approval hidden"></div>
       <div id="transcript" class="transcript"></div>
       <p id="chat-loading" class="muted empty hidden">Loading chat…</p>
       <p id="chat-error" class="error hidden"></p>

--- a/data/agents/src/desktopMain/resources/webchat/styles.css
+++ b/data/agents/src/desktopMain/resources/webchat/styles.css
@@ -449,6 +449,65 @@ details.group > summary.group-header::-webkit-details-marker {
   align-self: flex-start;
 }
 
+.plan-approval {
+  margin: 12px;
+  padding: 14px;
+  border-radius: var(--radius);
+  border: 1px solid #e2a400;
+  background: color-mix(in srgb, #e2a400 12%, var(--panel));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.plan-approval h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+.plan-approval p { margin: 0; color: var(--muted); font-size: 0.9rem; }
+.plan-approval-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.plan-approval input {
+  width: 100%;
+  box-sizing: border-box;
+}
+.bubble.plan {
+  border-color: #e2a400;
+  background: color-mix(in srgb, #e2a400 10%, var(--panel));
+  white-space: normal;
+  font-size: 0.9rem;
+  max-width: 100%;
+  font-family: inherit;
+}
+.plan-header {
+  font-weight: 600;
+  margin-bottom: 8px;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+.plan-mark {
+  color: #e2a400;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+.plan-body {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.85rem;
+}
+.plan-entries {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .composer-wrap {
   position: relative;
   flex-shrink: 0;

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/webchat/NetworkAccessAuthTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/webchat/NetworkAccessAuthTest.kt
@@ -153,12 +153,36 @@ class NetworkAccessAuthTest {
                 evaluateNetworkAccessAuth("10.0.0.8", "bad", "secret", limiter),
             )
         }
+        // Further bad credentials stay rate-limited…
         assertEquals(
             HttpStatusCode.TooManyRequests,
-            evaluateNetworkAccessAuth("10.0.0.8", "secret", "secret", limiter),
+            evaluateNetworkAccessAuth("10.0.0.8", "still-bad", "secret", limiter),
         )
+        // …but a valid credential must still succeed and clear the cooldown.
+        assertNull(evaluateNetworkAccessAuth("10.0.0.8", "secret", "secret", limiter))
         now += 61_000
         assertNull(evaluateNetworkAccessAuth("10.0.0.8", "secret", "secret", limiter))
+    }
+
+    @Test
+    fun rateLimitDoesNotBlockValidCredentialsDuringCooldown() {
+        var now = 1_000L
+        val limiter = AuthFailureLimiter(maxFailures = 2, windowMillis = 60_000, cooldownMillis = 60_000) { now }
+        val store = NetworkAccessSessionStore(clock = { now })
+        val session = store.exchangeMasterToken("secret", "secret")!!
+        repeat(2) {
+            assertEquals(
+                HttpStatusCode.Unauthorized,
+                evaluateNetworkAccessAuth("10.0.0.8", "bad", "secret", limiter, sessionStore = store),
+            )
+        }
+        assertEquals(
+            HttpStatusCode.TooManyRequests,
+            evaluateNetworkAccessAuth("10.0.0.8", "bad", "secret", limiter, sessionStore = store),
+        )
+        assertNull(
+            evaluateNetworkAccessAuth("10.0.0.8", session, "secret", limiter, sessionStore = store),
+        )
     }
 
     @Test

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/webchat/WebChatHttpServerTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/webchat/WebChatHttpServerTest.kt
@@ -191,6 +191,35 @@ class WebChatHttpServerTest {
     }
 
     @Test
+    fun chatJsonIncludesPlanModeAndImplementPlanEndpoint() = runBlocking {
+        agents.setPlanMode("acp-1", true)
+        val client = HttpClient(CIO)
+        try {
+            val detail = client.get("http://127.0.0.1:$port/api/chats/acp-1") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+            }
+            assertEquals(HttpStatusCode.OK, detail.status)
+            val body = detail.bodyAsText()
+            assertTrue(body.contains("\"planMode\":true"), body)
+            assertTrue(body.contains("\"status\":\"Done\""), body)
+
+            val implement = client.post("http://127.0.0.1:$port/api/chats/acp-1/implement-plan") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                contentType(ContentType.Application.Json)
+                setBody("{}")
+            }
+            assertEquals(HttpStatusCode.OK, implement.status, implement.bodyAsText())
+            assertEquals("acp-1" to "Implement the plan.", agents.lastResume)
+            assertTrue(
+                agents.tasks.value.first { it.id == "acp-1" }.planMode.not(),
+                "implement should clear plan mode",
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun authPluginRejectsMissingTokenForNonLoopback() {
         val limiter = AuthFailureLimiter(10, 60_000, 60_000) { 0L }
         assertEquals(
@@ -854,6 +883,37 @@ class WebChatHttpServerTest {
                 } else {
                     it
                 }
+            }
+        }
+
+        override fun updatePlanMode(taskId: String, planMode: Boolean) {
+            _tasks.value = _tasks.value.map { task ->
+                if (task.id == taskId) task.copy(planMode = planMode) else task
+            }
+        }
+
+        var lastResume: Pair<String, String>? = null
+        override fun resume(
+            taskId: String,
+            followUp: String,
+            imagePaths: List<String>,
+            skills: List<app.andy.model.AgentSkill>,
+            contextBundleIds: List<String>,
+            provenance: app.andy.model.AgentContextualProvenance?,
+        ) {
+            lastResume = taskId to followUp
+            _tasks.value = _tasks.value.map { task ->
+                if (task.id == taskId) {
+                    task.copy(status = AgentStatus.Working, planMode = false)
+                } else {
+                    task
+                }
+            }
+        }
+
+        fun setPlanMode(taskId: String, planMode: Boolean) {
+            _tasks.value = _tasks.value.map { task ->
+                if (task.id == taskId) task.copy(planMode = planMode, status = AgentStatus.Done) else task
             }
         }
 

--- a/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/AgentAttentionCoordinator.kt
+++ b/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/AgentAttentionCoordinator.kt
@@ -61,7 +61,13 @@ class DesktopAgentAttentionCoordinator(
             val prefs = workspace()
             if (prefs.agentNotificationTiming == AgentNotificationTiming.BackgroundOnly && isForeground()) return@forEach
             if (!AgentNotificationDedup.tryMarkNotified(task.id, kind.name)) return@forEach
-            val event = AgentAttentionEvent(task.id, task.projectId, task.notificationTitle, kind)
+            val event = AgentAttentionEvent(
+                task.id,
+                task.projectId,
+                task.notificationTitle,
+                kind,
+                planMode = kind == AgentAttentionKind.Done && task.planMode,
+            )
             // When the chat is already open, skip the OS banner (redundant) but keep sound.
             val showOs = prefs.agentOsNotificationsEnabled && !isViewing(task.id)
             if (showOs) notifications.show(event)

--- a/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/DesktopNotificationServices.kt
+++ b/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/DesktopNotificationServices.kt
@@ -39,7 +39,7 @@ class DesktopOsNotificationService : OsNotificationService {
     override fun show(event: AgentAttentionEvent) {
         val subtitle = when (event.kind) {
             AgentAttentionKind.Blocked -> "Needs your input"
-            AgentAttentionKind.Done -> "Agent completed"
+            AgentAttentionKind.Done -> if (event.planMode) "Plan ready" else "Agent completed"
             AgentAttentionKind.Error -> "Agent failed"
         }
         val os = System.getProperty("os.name").orEmpty()

--- a/domain/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/domain/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -500,7 +500,14 @@ enum class AgentAttentionKind {
     Error,
 }
 
-data class AgentAttentionEvent(val taskId: String, val projectId: String?, val title: String, val kind: AgentAttentionKind)
+data class AgentAttentionEvent(
+    val taskId: String,
+    val projectId: String?,
+    val title: String,
+    val kind: AgentAttentionKind,
+    /** When [kind] is Done and the turn finished in Andy plan mode. */
+    val planMode: Boolean = false,
+)
 data class OpenAgentTaskRequest(val taskId: String, val projectId: String?)
 
 /**


### PR DESCRIPTION
## Summary

Productizes the plan-mode workflow that was recently added at the model/runtime layer. When an agent turn finishes in **plan mode**, every client now surfaces a distinct **"Plan ready / Awaiting approval"** state and lets the user **Implement the plan** or **Refine** it before any changes are applied.

Also bundles two scoped mobile/server fixes: an auth-cooldown self-heal and an Android VNC viewer gesture/scaling rework.

## Changes

**Desktop HTTP API** (`WebChatRoutes.kt`)
- `POST /chats/{id}/plan-mode` — set/unset plan mode on an ACP-lane chat (409 for non-ACP).
- `POST /chats/{id}/implement-plan` — clears plan mode and resumes with the Implement prompt; rejects non-ACP lane and `Spec`-stage runs (409).
- WS chat batches now stream the full `chat` object (incl. `planMode`/`workflowStage`) so remote clients stay in sync.

**Notifications** — a Done attention when `planMode` reads **"Plan ready"** instead of "Agent completed" (OS banner, attention hub, web push).

**Web chat** (`app.js`/`index.html`/`styles.css`)
- Amber plan-approval panel with **Implement plan** (POST, falls back to plan-mode=false + reply for older hosts) and **Refine** (send feedback).
- In-transcript plan bubbles (markdown + checklist), plan-aware status labels, and `latestPlanHasPendingEntries` so Cursor Create Plan turns that end with pending rows surface even with planMode off.

**CLI viewer** (`acp_view.rs`, `chats.rs`, `viewer_chrome.rs`)
- `Ctrl-i` implements the plan; "plan ready" presence + header label; `[plan ready]` badge in the chat list.

**Android** (`ChatScreen`, `NetworkAccess*`, attention push)
- Plan document + plan-approval cards with Implement/Refine; plan-aware status/labels/markers; `Implement` endpoint with 404 fallback; `planMode`/`workflowStage` threaded through Network Access; push shows "Plan ready".

**Auth fix** (`NetworkAccessAuth.kt`, `AttentionPushService.kt`)
- Resolve credentials before enforcing the IP cooldown so a valid session is not locked out; a valid credential clears the limiter. `AttentionPushService` now self-heals on expired sessions (stops polling instead of ratcheting the host cooldown).

**Android VNC viewer** (`RemoteDisplay.kt`, `ScreenViewerScreen.kt`)
- Cover-scale, navigate-first gestures (drag to pan, tap click, long-press right-click, long-press-drag click-drag), haptics, and viewport-resize stability that preserves the centre remote pixel + absolute scale.

## Tests run
- `cargo test` (CLI): 77 unit + 4 integration pass.
- `:androidApp:testDebugUnitTest`: new `ChatPlanModeTest` (5) + `RemoteDisplayTest` (13) pass.
- `:data:agents:desktopTest` (`NetworkAccessAuthTest`, `WebChatHttpServerTest`): pass.

## Known risks
- Plan-detection heuristics (`latestPlanHasPendingEntries`) are mirrored across Kotlin, JS, and Rust and could drift; behavior is covered per-platform.
- VNC gesture FSM is hand-implemented and only partially unit-tested (pure math covered; gesture state machine not).
- Auth-limiter reorder intentionally lets a valid token bypass an active IP cooldown (token limiter still applies on failure).