### PR TITLE
Fix broken Andy logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="src/desktopMain/resources/icons/andy.png" alt="Andy logo" width="128">
+  <img src="composeApp/src/desktopMain/resources/icons/andy.png" alt="Andy logo" width="128">
 </p>
 
 # Andy


### PR DESCRIPTION
The README referenced the Andy logo at `src/desktopMain/resources/icons/andy.png`, but the actual file lives under `composeApp/`. Fixed the path so the logo renders at the top of the README.