### PR TITLE
Worktree environment: test worktrees in place with terminal, runbook, and branch-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Dispatch tasks to Claude Code, Codex, Cursor, Antigravity, OpenCode, Pi, Hermes,
 
 - Compose prompts with images, `@file` mentions, and `/` skills.
 - Choose model, autonomy, and provider sandbox or approvals.
-- Isolate a run in a git worktree when you need a clean boundary.
+- Isolate a run in a git worktree when you need a clean boundary. Pick the branch it forks from, then test it in place: the chat's worktree card and the project's Worktrees tab open a terminal or run any runbook action rooted in that worktree.
 - Toggle plan mode. Set a persistent `/goal` for Codex and Claude Code.
 - Import a vendor thread or session id to resume an existing conversation.
 - Attach Andy MCP so the agent can drive Android and iOS targets ([device tools](#10-mcp-for-device-control)).

--- a/composeApp/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
+++ b/composeApp/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
@@ -717,8 +717,8 @@ internal object ScreenshotServices {
 
     private object ScreenshotActionRuns : ActionRunService {
         override val running: StateFlow<List<RunningAction>> = MutableStateFlow(listOf(RunningAction("run-1", "garden", "test", "Run unit tests", "run", "./gradlew test", "/workspace/sample-app", ActionRunStatus.Running, startedAtMillis = now - 9_000)))
-        override fun openShell(project: ActionProject) = "shell-1"
-        override fun run(project: ActionProject, action: ProjectAction) = "run-1"
+        override fun openShell(project: ActionProject, cwdOverride: String?) = "shell-1"
+        override fun run(project: ActionProject, action: ProjectAction, cwdOverride: String?) = "run-1"
         override fun stop(runId: String) = Unit
         override fun clear(runId: String) = Unit
     }

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopActionRunService.kt
@@ -75,7 +75,7 @@ class DesktopActionRunService(
         })
     }
 
-    override fun openShell(project: ActionProject): String = start(
+    override fun openShell(project: ActionProject, cwdOverride: String?): String = start(
         project = project,
         action = ProjectAction(
             id = "terminal",
@@ -84,14 +84,17 @@ class DesktopActionRunService(
             command = "",
         ),
         initialCommand = null,
+        cwdOverride = cwdOverride,
     )
 
-    override fun run(project: ActionProject, action: ProjectAction): String {
+    override fun run(project: ActionProject, action: ProjectAction, cwdOverride: String?): String {
         val command = action.command.takeIf { it.isNotBlank() }
+        val cwd = resolveCwd(project, action, cwdOverride)
         synchronized(lifecycleLock) {
             val existing = _running.value.lastOrNull {
                 it.projectId == project.id &&
                     it.actionId == action.id &&
+                    it.cwd == cwd &&
                     it.status in ACTIVE_STATUSES
             }
             if (existing != null) {
@@ -99,17 +102,23 @@ class DesktopActionRunService(
                 return existing.runId
             }
         }
-        clearExistingRuns(project.id, action.id)
+        clearExistingRuns(project.id, action.id, cwd)
         return start(
             project = project,
             action = action,
             initialCommand = command,
+            cwdOverride = cwdOverride,
         )
     }
 
-    private fun start(project: ActionProject, action: ProjectAction, initialCommand: String?): String {
+    private fun start(
+        project: ActionProject,
+        action: ProjectAction,
+        initialCommand: String?,
+        cwdOverride: String? = null,
+    ): String {
         val runId = "run-${nextRun.getAndIncrement()}"
-        val remoteCwd = resolveCwd(project, action)
+        val remoteCwd = resolveCwd(project, action, cwdOverride)
         val snapshot = RunningAction(
             runId = runId,
             projectId = project.id,
@@ -240,9 +249,10 @@ class DesktopActionRunService(
         }
     }
 
-    private fun clearExistingRuns(projectId: String, actionId: String) {
+    /** Only clears prior runs in the same directory — a worktree run must not evict the checkout's. */
+    private fun clearExistingRuns(projectId: String, actionId: String, cwd: String) {
         _running.value
-            .filter { it.projectId == projectId && it.actionId == actionId }
+            .filter { it.projectId == projectId && it.actionId == actionId && it.cwd == cwd }
             .forEach { clear(it.runId) }
     }
 
@@ -300,12 +310,17 @@ class DesktopActionRunService(
         }
     }
 
-    private fun resolveCwd(project: ActionProject, action: ProjectAction): String {
+    /**
+     * [cwdOverride] (a worktree path) replaces the project root entirely; an action's relative
+     * `cwd` still applies on top of it so `./gradlew` in `androidApp/` lands in the worktree copy.
+     */
+    private fun resolveCwd(project: ActionProject, action: ProjectAction, cwdOverride: String? = null): String {
+        val root = cwdOverride?.takeIf { it.isNotBlank() } ?: project.contextDir
         val override = action.cwd?.takeIf { it.isNotBlank() }
         return when {
-            override == null -> project.contextDir
+            override == null -> root
             File(override).isAbsolute -> override
-            else -> File(project.contextDir, override).path
+            else -> File(root, override).path
         }
     }
 }

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
@@ -500,6 +500,14 @@ fun Server.registerAgentProjectTools(
                 put("type", "string")
                 put("description", "Optional Andy task id whose worktree branch to fork from")
             },
+            "baseRef" to buildJsonObject {
+                put("type", "string")
+                put(
+                    "description",
+                    "Optional branch the new worktree forks from (defaults to the project's current HEAD). " +
+                        "Ignored when baseWorktreeTaskId is set.",
+                )
+            },
             "parentChatTaskId" to buildJsonObject {
                 put("type", "string")
                 put(
@@ -643,6 +651,7 @@ fun Server.registerAgentProjectTools(
                 useWorktree = useWorktree,
                 existingWorktreePath = existingWorktreePath,
                 baseWorktreeTaskId = str(args, "baseWorktreeTaskId")?.takeIf { it.isNotBlank() },
+                baseRef = str(args, "baseRef")?.takeIf { it.isNotBlank() },
                 parentChatTaskId = str(args, "parentChatTaskId")?.takeIf { it.isNotBlank() }
                     ?: parentTask?.id,
                 attachAndyMcp = attachAndyMcp,

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -1421,8 +1421,10 @@ class DesktopAgentRunService(
                 persist()
                 return task
             }
+            // A base task's branch wins; otherwise the draft's explicit base ref, else current HEAD.
+            val startPoint = baseTask?.branchName ?: draft.baseRef?.trim()?.takeIf { it.isNotBlank() }
             val created = withContext(Dispatchers.IO) {
-                worktrees.create(originDir, task.id, task.agent, task.title, startPoint = baseTask?.branchName)
+                worktrees.create(originDir, task.id, task.agent, task.title, startPoint = startPoint)
             }
             task = created.fold(
                 onSuccess = {

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/DesktopActionRunServiceTest.kt
@@ -104,6 +104,55 @@ class DesktopActionRunServiceTest {
     }
 
     @Test
+    fun runsTheSameActionInAWorktreeWithoutEvictingTheCheckoutRun() = runBlocking {
+        val service = DesktopActionRunService(CoroutineScope(SupervisorJob() + Dispatchers.IO))
+        val root = createTempDirectory("andy-worktree-action-root").toString()
+        val worktree = createTempDirectory("andy-worktree-action-tree").toString()
+        val project = ActionProject(id = "project", name = "Project", contextDir = root)
+        val action = ProjectAction(id = "run", name = "Run", command = "echo hello")
+
+        val rootRunId = service.run(project, action)
+        val worktreeRunId = service.run(project, action, cwdOverride = worktree)
+        try {
+            // Same project + action, different directories: two live runs, not a reused one.
+            assertTrue(rootRunId != worktreeRunId)
+            assertEquals(
+                listOf(root, worktree),
+                service.running.value.map { it.cwd },
+            )
+            // Re-running against the worktree still reuses that worktree's shell.
+            assertEquals(worktreeRunId, service.run(project, action, cwdOverride = worktree))
+            assertEquals(2, service.running.value.size)
+        } finally {
+            service.stop(rootRunId)
+            service.stop(worktreeRunId)
+            awaitRunFinished(service, rootRunId)
+            awaitRunFinished(service, worktreeRunId)
+        }
+    }
+
+    @Test
+    fun worktreeOverrideRebasesAnActionsRelativeCwd() = runBlocking {
+        val service = DesktopActionRunService(CoroutineScope(SupervisorJob() + Dispatchers.IO))
+        val root = createTempDirectory("andy-relative-cwd-root").toString()
+        val worktree = createTempDirectory("andy-relative-cwd-tree").toString()
+        java.io.File(worktree, "androidApp").mkdirs()
+        val project = ActionProject(id = "project", name = "Project", contextDir = root)
+        val action = ProjectAction(id = "run", name = "Run", command = "echo hello", cwd = "androidApp")
+
+        val runId = service.run(project, action, cwdOverride = worktree)
+        try {
+            assertEquals(
+                java.io.File(worktree, "androidApp").path,
+                service.running.value.single().cwd,
+            )
+        } finally {
+            service.stop(runId)
+            awaitRunFinished(service, runId)
+        }
+    }
+
+    @Test
     fun remotedOpenShellSpawnsSshInsteadOfLocalShell() = runBlocking {
         val spawned = AtomicReference<List<String>?>(null)
         val service = DesktopActionRunService(

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/NestedWorktreeServiceTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/NestedWorktreeServiceTest.kt
@@ -67,6 +67,44 @@ class NestedWorktreeServiceTest {
     }
 
     @Test
+    fun baseRefForksFromThatBranchWithoutMovingTheCheckout() = runBlocking {
+        withHarness { harness ->
+            val featureTip = harness.commitOnBranch("feature", "feature.txt", "feature\n")
+            harness.checkout("main")
+            val mainTip = revParse(harness.repo, "main")
+
+            val task = harness.startWorktreeTask(title = "tint color", baseRef = "feature")
+
+            val branch = assertNotNull(task.branchName)
+            assertEquals(featureTip, revParse(harness.repo, branch))
+            assertTrue(featureTip != mainTip)
+            // Picking a base must not switch the branch the user has checked out.
+            assertEquals("main", harness.service.currentBranch(harness.repo.absolutePath))
+        }
+    }
+
+    @Test
+    fun baseWorktreeTaskIdWinsOverBaseRef() = runBlocking {
+        withHarness { harness ->
+            harness.commitOnBranch("feature", "feature.txt", "feature\n")
+            harness.checkout("main")
+
+            val parent = harness.startWorktreeTask(title = "parent")
+            val parentBranch = assertNotNull(parent.branchName)
+            val child = harness.startWorktreeTask(
+                title = "child",
+                baseWorktreeTaskId = parent.id,
+                baseRef = "feature",
+            )
+
+            assertEquals(
+                revParse(harness.repo, parentBranch),
+                revParse(harness.repo, assertNotNull(child.branchName)),
+            )
+        }
+    }
+
+    @Test
     fun parentWorktreeTaskIdRoundTripsThroughStoreRestart() = runBlocking {
         withHarness { harness ->
             val parent = harness.startWorktreeTask(title = "parent")
@@ -384,6 +422,7 @@ class NestedWorktreeServiceTest {
         suspend fun startWorktreeTask(
             title: String,
             baseWorktreeTaskId: String? = null,
+            baseRef: String? = null,
         ): AgentTask {
             val task = service.createAndStart(
                 AgentTaskDraft(
@@ -394,6 +433,7 @@ class NestedWorktreeServiceTest {
                     directory = repo.absolutePath,
                     useWorktree = true,
                     baseWorktreeTaskId = baseWorktreeTaskId,
+                    baseRef = baseRef,
                 ),
             )
             withTimeout(15_000) {

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
@@ -727,6 +727,7 @@ class McpAgentRunClient(
                     put("existingWorktreePath", JsonPrimitive(it))
                 }
                 draft.baseWorktreeTaskId?.let { put("baseWorktreeTaskId", JsonPrimitive(it)) }
+                draft.baseRef?.takeIf { it.isNotBlank() }?.let { put("baseRef", JsonPrimitive(it)) }
                 put("attachAndyMcp", JsonPrimitive(draft.attachAndyMcp))
                 put("autonomy", JsonPrimitive(draft.autonomy.name))
                 draft.model?.takeIf { it.isNotBlank() }?.let { put("model", JsonPrimitive(it)) }

--- a/domain/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -792,6 +792,12 @@ data class AgentTaskDraft(
     val existingBranchName: String? = null,
     /** When set (and useWorktree = true), the new worktree forks from this task's branch instead of originDir's current HEAD. */
     val baseWorktreeTaskId: String? = null,
+    /**
+     * Git ref (branch name) the new worktree forks from when [baseWorktreeTaskId] is unset.
+     * Null keeps originDir's current HEAD. Lets a chat build on a branch the user picked without
+     * having to check that branch out in the main working tree first.
+     */
+    val baseRef: String? = null,
     /** Chat this draft is a side chat of, if launched from a dock Chat pane. */
     val parentChatTaskId: String? = null,
     val workflowTaskId: String? = null,

--- a/domain/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/domain/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -561,9 +561,17 @@ interface ActionConfigStore {
 
 interface ActionRunService {
     val running: StateFlow<List<RunningAction>>
-    /** Opens an interactive login shell rooted at the project's context directory. */
-    fun openShell(project: ActionProject): String
-    fun run(project: ActionProject, action: ProjectAction): String
+    /**
+     * Opens an interactive login shell rooted at the project's context directory, or at
+     * [cwdOverride] when set — used to drop a shell straight into one of the project's worktrees.
+     */
+    fun openShell(project: ActionProject, cwdOverride: String? = null): String
+    /**
+     * Runs [action] in the project's context directory (or the action's own `cwd`), unless
+     * [cwdOverride] redirects it — e.g. running a build against a worktree instead of the checkout.
+     * Runs are deduplicated per directory, so the same action can be live in several worktrees.
+     */
+    fun run(project: ActionProject, action: ProjectAction, cwdOverride: String? = null): String
     fun stop(runId: String)
     fun clear(runId: String)
     /** Best-effort root pid for a project terminal PTY (for local-server attribution). */

--- a/domain/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
+++ b/domain/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
@@ -307,8 +307,8 @@ object UnavailableMcpService : McpServerService {
 
 object UnavailableActionRunService : ActionRunService {
     override val running: StateFlow<List<RunningAction>> = MutableStateFlow(emptyList())
-    override fun openShell(project: ActionProject) = ""
-    override fun run(project: ActionProject, action: ProjectAction) = ""
+    override fun openShell(project: ActionProject, cwdOverride: String?) = ""
+    override fun run(project: ActionProject, action: ProjectAction, cwdOverride: String?) = ""
     override fun stop(runId: String) = Unit
     override fun clear(runId: String) = Unit
 }

--- a/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -864,6 +864,12 @@ private fun ProjectCockpit(
                                         canvas = ProjectCanvas.Chat
                                         services.agentRuns.setChatViewing(taskId, viewing = true)
                                     },
+                                    onOpenTerminalIn = { dir ->
+                                        onNotifyTerminalRun(services.actionRuns.openShell(current, dir))
+                                    },
+                                    onRunActionIn = { action, dir ->
+                                        onNotifyTerminalRun(services.actionRuns.run(current, action, dir))
+                                    },
                                     onConfirm = { pendingConfirmation = it },
                                     modifier = Modifier.fillMaxSize(),
                                 )
@@ -1700,6 +1706,8 @@ private fun ProjectWorktrees(
     services: AndyServices,
     project: ActionProject,
     onOpenTask: (String) -> Unit,
+    onOpenTerminalIn: (String) -> Unit,
+    onRunActionIn: (ProjectAction, String) -> Unit,
     onConfirm: (PendingConfirmation) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -1787,6 +1795,8 @@ private fun ProjectWorktrees(
                             project = project,
                             services = services,
                             onOpenTask = onOpenTask,
+                            onOpenTerminalIn = onOpenTerminalIn,
+                            onRunActionIn = onRunActionIn,
                             onCopyPath = { copyText(it) },
                             onMerge = { taskId, sourcePath, branch, targetDir, targetLabel ->
                                 onConfirm(
@@ -1886,6 +1896,8 @@ private fun WorktreeTreeRow(
     project: ActionProject,
     services: AndyServices,
     onOpenTask: (String) -> Unit,
+    onOpenTerminalIn: (String) -> Unit,
+    onRunActionIn: (ProjectAction, String) -> Unit,
     onCopyPath: (String) -> Unit,
     onMerge: (taskId: String, sourcePath: String, branch: String, targetDir: String, targetLabel: String) -> Unit,
     onDelete: (String) -> Unit,
@@ -1895,6 +1907,7 @@ private fun WorktreeTreeRow(
     val taskId = node.taskId
     val branch = node.branch
     val indent = (row.depth * 16).dp
+    var runMenuOpen by remember(node.path) { mutableStateOf(false) }
     Column(
         Modifier
             .fillMaxWidth()
@@ -1949,6 +1962,39 @@ private fun WorktreeTreeRow(
             modifier = Modifier.clickable { onCopyPath(node.path) },
         )
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Testing a worktree shouldn't mean leaving Andy: both of these spawn in node.path.
+            OutlinedButton(
+                onClick = { onOpenTerminalIn(node.path) },
+                modifier = Modifier.height(28.dp).testTag("worktree-terminal"),
+                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+            ) { Text("terminal", fontSize = 10.sp) }
+            if (project.actions.isNotEmpty()) {
+                Box {
+                    OutlinedButton(
+                        onClick = { runMenuOpen = true },
+                        modifier = Modifier.height(28.dp).testTag("worktree-run"),
+                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                    ) { Text("run…", fontSize = 10.sp) }
+                    DropdownMenu(expanded = runMenuOpen, onDismissRequest = { runMenuOpen = false }) {
+                        project.actions.forEach { action ->
+                            DropdownMenuItem(
+                                text = { Text(action.name, fontFamily = MonoFont, fontSize = 11.sp) },
+                                onClick = {
+                                    runMenuOpen = false
+                                    onRunActionIn(action, node.path)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+            if (taskId != null) {
+                OutlinedButton(
+                    onClick = { onOpenTask(taskId) },
+                    modifier = Modifier.height(28.dp),
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                ) { Text("open chat", fontSize = 10.sp) }
+            }
             OutlinedButton(
                 onClick = { onCopyPath(node.path) },
                 modifier = Modifier.height(28.dp),

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
@@ -351,6 +351,8 @@ private class AgentTaskComposerFormState(
     var workingTreeStatus by mutableStateOf<WorkingTreeStatus?>(null)
     var baseWorktreeTaskId by mutableStateOf<String?>(null)
     var availableBases by mutableStateOf<List<WorktreeBaseOption>>(emptyList())
+    /** Branch a new worktree forks from; null follows the project checkout's current HEAD. */
+    var worktreeBaseRef by mutableStateOf<String?>(null)
     /** Last agent whose provider defaults were seeded into this draft; avoids clobbering restored drafts. */
     var defaultsSeededForAgent: AgentKind? = null
 
@@ -532,6 +534,7 @@ private fun rememberAgentTaskComposerForm(
             state.workingTreeStatus = null
             state.availableBases = emptyList()
             state.baseWorktreeTaskId = null
+            state.worktreeBaseRef = null
             return@LaunchedEffect
         }
         refreshComposerGitState(services, directory, state)
@@ -542,6 +545,10 @@ private fun rememberAgentTaskComposerForm(
         }
         if (state.baseWorktreeTaskId != null && state.availableBases.none { it.taskId == state.baseWorktreeTaskId }) {
             state.baseWorktreeTaskId = null
+        }
+        // A base branch only means something for a new worktree, and only while it still exists.
+        if (!state.useWorktree || state.localBranches.none { it.name == state.worktreeBaseRef }) {
+            state.worktreeBaseRef = null
         }
     }
     LaunchedEffect(state.agent, state.modelId, selectedModel) {
@@ -620,6 +627,7 @@ private class AgentTaskComposerForm(
             directory = directory?.trim()?.takeIf { it.isNotBlank() },
             useWorktree = state.useWorktree,
             baseWorktreeTaskId = state.baseWorktreeTaskId,
+            baseRef = state.worktreeBaseRef?.takeIf { state.useWorktree },
             attachAndyMcp = state.attachMcp,
             autonomy = state.autonomy,
             sandboxMode = state.sandboxMode,
@@ -824,6 +832,8 @@ private fun AgentChatComposer(
                     branch = state.currentBranch,
                     workingTreeStatus = state.workingTreeStatus,
                     branches = state.localBranches,
+                    worktreeBaseRef = state.worktreeBaseRef,
+                    onWorktreeBaseRefChange = { state.worktreeBaseRef = it },
                     onRefreshGit = {
                         form.scope.launch {
                             refreshComposerGitState(form.services, form.directory, state)
@@ -844,6 +854,9 @@ private fun AgentChatComposer(
                         val result = form.services.agentRuns.createAndCheckoutBranch(dir, name)
                         if (result.isSuccess) {
                             refreshComposerGitState(form.services, dir, state)
+                            // In worktree mode the checkout isn't what the agent works in, so make
+                            // the branch the user just made the fork point instead of a dead end.
+                            if (state.useWorktree) state.worktreeBaseRef = name.trim()
                             null
                         } else {
                             result.stderr.ifBlank { result.stdout }.ifBlank { "Create branch failed" }

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -25,10 +25,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.DisableSelection
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import app.andy.ui.components.bottomBorder
@@ -50,6 +48,8 @@ import androidx.compose.runtime.withFrameMillis
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
@@ -69,6 +69,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.zIndex
 import app.andy.HostCodeEditor
 import app.andy.rememberCopyText
 import app.andy.currentTimeMillis
@@ -141,7 +142,6 @@ import app.andy.ui.components.onChatImagePaste
 import app.andy.ui.components.fieldColors
 import app.andy.ui.components.primaryButtonColors
 import app.andy.ui.theme.AndyColors
-import app.andy.ui.theme.AndyOverlay
 import app.andy.ui.theme.AndyRadius
 import app.andy.ui.theme.AndySpace
 import app.andy.ui.theme.Border
@@ -671,6 +671,8 @@ fun AgentTaskDetail(
                 )
             }
         }
+        var chatPaneWidth by remember(task.id) { mutableStateOf(0.dp) }
+        val density = LocalDensity.current
         Box(
             Modifier
                 .weight(1f)
@@ -681,7 +683,10 @@ fun AgentTaskDetail(
                         else -> 280.dp
                     },
                 )
-                .clipToBounds(),
+                .clipToBounds()
+                .onSizeChanged { size ->
+                    chatPaneWidth = with(density) { size.width.toDp() }
+                },
         ) {
             val terminalModifier = remember { Modifier.fillMaxSize() }
             val imagesStagedLatest = rememberUpdatedState(
@@ -774,6 +779,22 @@ fun AgentTaskDetail(
                     onImagesStaged = onImagesStaged,
                     maskBottomChrome = showCompletedTurnChrome && !terminalSessionActive,
                     modifier = terminalModifier,
+                )
+            }
+            // Cursor-style Environment chip: floats top-right over the chat/terminal pane.
+            if (task.worktreePath != null && !terminalSessionActive) {
+                WorktreeEnvironmentPanel(
+                    services = services,
+                    task = task,
+                    diffSummary = diffSummary,
+                    onDiffSummaryChange = { diffSummary = it },
+                    onCopyText = copyText,
+                    paneWidth = chatPaneWidth,
+                    contentFullBleed = !acpTask,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = AndySpace.Space2, end = AndySpace.Space2)
+                        .zIndex(2f),
                 )
             }
         }
@@ -1260,50 +1281,6 @@ fun AgentTaskDetail(
                     }
                 },
             )
-        }
-
-        // Same rule as change-summary: never steal height from a live terminal.
-        if (task.worktreePath != null && !terminalSessionActive) {
-            PanelCard(
-                modifier = Modifier.fillMaxWidth().heightIn(min = 72.dp, max = 160.dp),
-                background = AndyColors.Neutral900.copy(alpha = AndyOverlay.Medium),
-                contentPadding = PaddingValues(AndySpace.Space3),
-                verticalArrangement = Arrangement.spacedBy(AndySpace.Space2),
-            ) {
-                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text("worktree ${task.branchName.orEmpty()}", color = TextSecondary, fontFamily = MonoFont, fontWeight = FontWeight.SemiBold, fontSize = 11.sp, modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    OutlinedButton(
-                        onClick = { copyText(task.worktreePath.orEmpty()) },
-                        modifier = Modifier.height(28.dp),
-                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
-                    ) { Text("copy path", fontSize = 10.sp) }
-                    OutlinedButton(
-                        onClick = {
-                            val branch = task.branchName ?: return@OutlinedButton
-                            val parentPath = task.parentWorktreeTaskId?.let { parentId ->
-                                services.agentRuns.tasks.value.firstOrNull { it.id == parentId }?.worktreePath
-                            }
-                            val targetDir = parentPath ?: task.originDir ?: return@OutlinedButton
-                            copyText(services.agentRuns.mergeCommand(targetDir, branch))
-                        },
-                        modifier = Modifier.height(28.dp),
-                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
-                    ) { Text("copy merge cmd", fontSize = 10.sp) }
-                    OutlinedButton(
-                        onClick = { scope.launch { diffSummary = services.agentRuns.worktreeDiffSummary(task.id) } },
-                        modifier = Modifier.height(28.dp),
-                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
-                    ) { Text("refresh diff", fontSize = 10.sp) }
-                }
-                Text(
-                    diffSummary ?: "loading diff…",
-                    color = TextSecondary,
-                    fontFamily = MonoFont,
-                    fontSize = 11.sp,
-                    lineHeight = 14.sp,
-                    modifier = Modifier.verticalScroll(rememberScrollState()),
-                )
-            }
         }
     }
     }

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ComposerContextBar.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ComposerContextBar.kt
@@ -92,6 +92,8 @@ internal fun ComposerContextBar(
     branch: String?,
     workingTreeStatus: WorkingTreeStatus?,
     branches: List<GitBranchInfo>,
+    worktreeBaseRef: String?,
+    onWorktreeBaseRefChange: (String?) -> Unit,
     onRefreshGit: () -> Unit,
     onCheckoutBranch: suspend (String) -> String?,
     onCreateAndCheckoutBranch: suspend (String) -> String?,
@@ -122,6 +124,10 @@ internal fun ComposerContextBar(
                     branch = branch,
                     workingTreeStatus = workingTreeStatus,
                     branches = branches,
+                    // In worktree mode the chip picks the fork point; the checkout stays put.
+                    worktreeMode = useWorktree,
+                    worktreeBaseRef = worktreeBaseRef,
+                    onWorktreeBaseRefChange = onWorktreeBaseRefChange,
                     onRefreshGit = onRefreshGit,
                     onCheckoutBranch = onCheckoutBranch,
                     onCreateAndCheckoutBranch = onCreateAndCheckoutBranch,
@@ -356,6 +362,9 @@ private fun ComposerBranchChip(
     branch: String?,
     workingTreeStatus: WorkingTreeStatus?,
     branches: List<GitBranchInfo>,
+    worktreeMode: Boolean,
+    worktreeBaseRef: String?,
+    onWorktreeBaseRefChange: (String?) -> Unit,
     onRefreshGit: () -> Unit,
     onCheckoutBranch: suspend (String) -> String?,
     onCreateAndCheckoutBranch: suspend (String) -> String?,
@@ -383,9 +392,14 @@ private fun ComposerBranchChip(
         }
     }
 
+    // Worktree chats fork a fresh andy/… branch, so the chip names the fork point, not a checkout.
+    val effectiveBase = worktreeBaseRef ?: branch
     Box {
         ComposerContextMenuChip(
-            text = branch ?: "detached",
+            text = when {
+                worktreeMode -> "from ${effectiveBase ?: "HEAD"}"
+                else -> branch ?: "detached"
+            },
             expanded = expanded,
             onClick = { expanded = true },
             leading = {
@@ -398,6 +412,19 @@ private fun ComposerBranchChip(
             modifier = Modifier.widthIn(min = 280.dp, max = 360.dp),
         ) {
             Column(Modifier.padding(AndySpace.Space1)) {
+                if (worktreeMode) {
+                    AndyDropdownMenuSectionLabel("Fork the new worktree from")
+                    if (workingTreeStatus?.isDirty == true) {
+                        // Easy to miss otherwise: a worktree forks from the branch tip, not the desk.
+                        Text(
+                            "Uncommitted changes stay in your checkout — the worktree starts from the branch tip.",
+                            color = Yellow,
+                            fontFamily = DisplayFont,
+                            fontSize = 11.sp,
+                            modifier = Modifier.padding(horizontal = AndySpace.Space2, vertical = AndySpace.Space1),
+                        )
+                    }
+                }
                 TextField(
                     value = query,
                     onValueChange = {
@@ -460,10 +487,17 @@ private fun ComposerBranchChip(
                                         if (hovered) AndyColors.SurfaceHover else Color.Transparent,
                                     )
                                     .clickable(
-                                        enabled = !busy && !info.isCurrent,
+                                        enabled = !busy && (worktreeMode || !info.isCurrent),
                                         interactionSource = interaction,
                                         indication = null,
                                     ) {
+                                        if (worktreeMode) {
+                                            // Picking a fork point never moves the user's checkout.
+                                            onWorktreeBaseRefChange(info.name.takeIf { !info.isCurrent })
+                                            error = null
+                                            expanded = false
+                                            return@clickable
+                                        }
                                         busy = true
                                         error = null
                                         scope.launch {
@@ -491,9 +525,14 @@ private fun ComposerBranchChip(
                                         overflow = TextOverflow.Ellipsis,
                                         modifier = Modifier.weight(1f),
                                     )
-                                    if (info.isCurrent) {
+                                    val tag = when {
+                                        worktreeMode && info.name == effectiveBase -> "base"
+                                        info.isCurrent -> "current"
+                                        else -> null
+                                    }
+                                    tag?.let {
                                         Text(
-                                            "current",
+                                            it,
                                             color = TextSecondary,
                                             fontFamily = DisplayFont,
                                             fontSize = 11.sp,

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/WorktreeEnvironmentPanel.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/WorktreeEnvironmentPanel.kt
@@ -149,7 +149,9 @@ internal fun WorktreeEnvironmentPanel(
     val worktreePath = task.worktreePath ?: return
     val scope = rememberCoroutineScope()
     val launcher = LocalProjectDirLauncher.current
-    val worktreeActions = remember(launcher, task.projectId) { launcher.actionsFor(task.projectId) }
+    // Read reactively (not remember-cached) so runbook edits, disk refresh, or a remote-host
+    // switch while this chat is open refresh the actions; actionsFor reads a mutableStateOf.
+    val worktreeActions = launcher.actionsFor(task.projectId)
 
     var treeStatus by remember(task.id) { mutableStateOf<WorkingTreeStatus?>(null) }
     var changesExpanded by remember(task.id) { mutableStateOf(false) }
@@ -201,6 +203,15 @@ internal fun WorktreeEnvironmentPanel(
         }
     }
 
+    fun copyMergeCommand() {
+        val branch = task.branchName ?: return
+        val parentPath = task.parentWorktreeTaskId?.let { parentId ->
+            services.agentRuns.tasks.value.firstOrNull { it.id == parentId }?.worktreePath
+        }
+        val targetDir = parentPath ?: task.originDir ?: return
+        onCopyText(services.agentRuns.mergeCommand(targetDir, branch))
+    }
+
     val selectedLabel = when (val action = selectedAction) {
         SelectedEnvironmentAction.Terminal -> "Terminal"
         is SelectedEnvironmentAction.Run -> action.action.name
@@ -246,6 +257,7 @@ internal fun WorktreeEnvironmentPanel(
                 onRunSelected = ::runSelected,
                 onOpenTerminal = ::openTerminal,
                 onCopyText = onCopyText,
+                onCopyMergeCommand = ::copyMergeCommand,
                 showTuckControl = shouldAutoTuck,
                 onTuck = { pinnedOpen = false },
             )
@@ -341,6 +353,7 @@ private fun EnvironmentExpandedCard(
     onRunSelected: () -> Unit,
     onOpenTerminal: () -> Unit,
     onCopyText: (String) -> Unit,
+    onCopyMergeCommand: () -> Unit,
     showTuckControl: Boolean,
     onTuck: () -> Unit,
 ) {
@@ -445,6 +458,16 @@ private fun EnvironmentExpandedCard(
                         },
                         leading = {
                             LucideIcon(Lucide.Copy, TextSecondary, Modifier.size(14.dp))
+                        },
+                    )
+                    AndyDropdownMenuItem(
+                        label = "Copy merge cmd",
+                        onClick = {
+                            onOverflowOpenChange(false)
+                            onCopyMergeCommand()
+                        },
+                        leading = {
+                            LucideIcon(Lucide.GitBranch, TextSecondary, Modifier.size(14.dp))
                         },
                     )
                     AndyDropdownMenuItem(

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/WorktreeEnvironmentPanel.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/WorktreeEnvironmentPanel.kt
@@ -1,0 +1,719 @@
+package app.andy.ui.agents
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.andy.model.AgentTask
+import app.andy.model.ProjectAction
+import app.andy.model.WorkingTreeStatus
+import app.andy.service.AndyServices
+import app.andy.ui.components.AndyDropdownMenuItem
+import app.andy.ui.components.Card
+import app.andy.ui.components.CardElevation
+import app.andy.ui.components.HoverTooltip
+import app.andy.ui.components.LocalProjectDirLauncher
+import app.andy.ui.components.Lucide
+import app.andy.ui.components.LucideIcon
+import app.andy.ui.theme.AndyColors
+import app.andy.ui.theme.AndyLayout
+import app.andy.ui.theme.AndyShape
+import app.andy.ui.theme.AndySpace
+import app.andy.ui.theme.DisplayFont
+import app.andy.ui.theme.Green
+import app.andy.ui.theme.MonoFont
+import app.andy.ui.theme.Red
+import app.andy.ui.theme.TextPrimary
+import app.andy.ui.theme.TextSecondary
+import kotlinx.coroutines.launch
+
+private sealed interface SelectedEnvironmentAction {
+    data object Terminal : SelectedEnvironmentAction
+    data class Run(val action: ProjectAction) : SelectedEnvironmentAction
+}
+
+/** Session memory so switching away from a worktree chat doesn't reset the play target. */
+private object EnvironmentSelectedActionMemory {
+    private const val TerminalKey = "terminal"
+    private val selectedKeys = mutableMapOf<String, String>()
+
+    fun keyFor(task: AgentTask): String = task.id
+
+    fun read(task: AgentTask, actions: List<ProjectAction>): SelectedEnvironmentAction {
+        val stored = selectedKeys[keyFor(task)] ?: return SelectedEnvironmentAction.Terminal
+        if (stored == TerminalKey) return SelectedEnvironmentAction.Terminal
+        val action = actions.firstOrNull { it.id == stored } ?: return SelectedEnvironmentAction.Terminal
+        return SelectedEnvironmentAction.Run(action)
+    }
+
+    fun write(task: AgentTask, selected: SelectedEnvironmentAction) {
+        selectedKeys[keyFor(task)] = when (selected) {
+            SelectedEnvironmentAction.Terminal -> TerminalKey
+            is SelectedEnvironmentAction.Run -> selected.action.id
+        }
+    }
+}
+
+private val EnvironmentCardWidth = 248.dp
+
+/**
+ * True when the floating Environment card would cover chat/terminal text.
+ *
+ * Centered transcript content ([AndyLayout.ChatContentMaxWidth]) leaves side gutters only when
+ * the pane is wider than that column plus the card. Full-bleed panes (live terminal surface)
+ * always collide, so they tuck.
+ */
+internal fun environmentCardWouldEclipseContent(
+    paneWidth: Dp,
+    contentFullBleed: Boolean,
+    cardWidth: Dp = EnvironmentCardWidth,
+    endPadding: Dp = AndySpace.Space2,
+    contentMaxWidth: Dp = AndyLayout.ChatContentMaxWidth,
+    /** Extra clear gap between the content column's right edge and the card's left edge. */
+    minClearance: Dp = 16.dp,
+    /** Transcript LazyColumn end paddings that shrink the usable text edge. */
+    contentEndInset: Dp = 26.dp, // 18 contentPadding + 8 list padding
+): Boolean {
+    if (paneWidth <= 0.dp) return false
+    if (contentFullBleed) return true
+    val contentWidth = minOf(paneWidth, contentMaxWidth)
+    val contentRight = (paneWidth + contentWidth) / 2 - contentEndInset
+    val panelLeft = paneWidth - endPadding - cardWidth
+    return panelLeft < contentRight + minClearance
+}
+
+/**
+ * Floating Environment chip for worktree chats — top-right over the transcript/terminal pane.
+ * Tucks into an edge tag whenever the expanded card would cover chat text.
+ */
+@Composable
+internal fun WorktreeEnvironmentPanel(
+    services: AndyServices,
+    task: AgentTask,
+    diffSummary: String?,
+    onDiffSummaryChange: (String?) -> Unit,
+    onCopyText: (String) -> Unit,
+    paneWidth: Dp,
+    /** Terminal surface uses the full pane width; ACP transcript is a centered max-width column. */
+    contentFullBleed: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val worktreePath = task.worktreePath ?: return
+    val scope = rememberCoroutineScope()
+    val launcher = LocalProjectDirLauncher.current
+    val worktreeActions = remember(launcher, task.projectId) { launcher.actionsFor(task.projectId) }
+
+    var treeStatus by remember(task.id) { mutableStateOf<WorkingTreeStatus?>(null) }
+    var changesExpanded by remember(task.id) { mutableStateOf(false) }
+    var overflowOpen by remember(task.id) { mutableStateOf(false) }
+    var worktreeMenuOpen by remember(task.id) { mutableStateOf(false) }
+    var pinnedOpen by remember(task.id) { mutableStateOf(false) }
+    var selectedAction by remember(task.id, worktreeActions) {
+        mutableStateOf(EnvironmentSelectedActionMemory.read(task, worktreeActions))
+    }
+
+    // Drop a stale Run selection if the action list changes.
+    LaunchedEffect(worktreeActions) {
+        val current = selectedAction
+        if (current is SelectedEnvironmentAction.Run &&
+            worktreeActions.none { it.id == current.action.id }
+        ) {
+            selectedAction = SelectedEnvironmentAction.Terminal
+            EnvironmentSelectedActionMemory.write(task, SelectedEnvironmentAction.Terminal)
+        }
+    }
+
+    val shouldAutoTuck = environmentCardWouldEclipseContent(
+        paneWidth = paneWidth,
+        contentFullBleed = contentFullBleed,
+    )
+    LaunchedEffect(shouldAutoTuck) {
+        if (!shouldAutoTuck) pinnedOpen = false
+    }
+    val showExpanded = !shouldAutoTuck || pinnedOpen
+
+    suspend fun refreshStatusAndDiff() {
+        treeStatus = services.agentRuns.workingTreeStatus(worktreePath)
+        onDiffSummaryChange(services.agentRuns.worktreeDiffSummary(task.id))
+    }
+
+    LaunchedEffect(task.id, worktreePath) {
+        treeStatus = services.agentRuns.workingTreeStatus(worktreePath)
+    }
+
+    fun openTerminal() {
+        launcher.openTerminal(task.projectId, worktreePath)
+    }
+
+    fun runSelected() {
+        when (val action = selectedAction) {
+            SelectedEnvironmentAction.Terminal -> openTerminal()
+            is SelectedEnvironmentAction.Run ->
+                launcher.runAction(task.projectId, action.action, worktreePath)
+        }
+    }
+
+    val selectedLabel = when (val action = selectedAction) {
+        SelectedEnvironmentAction.Terminal -> "Terminal"
+        is SelectedEnvironmentAction.Run -> action.action.name
+    }
+
+    AnimatedContent(
+        targetState = showExpanded,
+        transitionSpec = {
+            if (targetState) {
+                (slideInHorizontally { it / 3 } + fadeIn()) togetherWith
+                    (slideOutHorizontally { it / 4 } + fadeOut())
+            } else {
+                (slideInHorizontally { it / 4 } + fadeIn()) togetherWith
+                    (slideOutHorizontally { it / 3 } + fadeOut())
+            }.using(SizeTransform(clip = false))
+        },
+        label = "environment-dock",
+        modifier = modifier,
+    ) { expanded ->
+        if (expanded) {
+            EnvironmentExpandedCard(
+                selectedLabel = selectedLabel,
+                selectedAction = selectedAction,
+                treeStatus = treeStatus,
+                changesExpanded = changesExpanded,
+                onChangesExpandedChange = { opening ->
+                    changesExpanded = opening
+                    if (opening) scope.launch { refreshStatusAndDiff() }
+                },
+                onRefreshDiff = { scope.launch { refreshStatusAndDiff() } },
+                diffSummary = diffSummary,
+                worktreePath = worktreePath,
+                branchName = task.branchName,
+                worktreeActions = worktreeActions,
+                overflowOpen = overflowOpen,
+                onOverflowOpenChange = { overflowOpen = it },
+                worktreeMenuOpen = worktreeMenuOpen,
+                onWorktreeMenuOpenChange = { worktreeMenuOpen = it },
+                onSelectAction = {
+                    selectedAction = it
+                    EnvironmentSelectedActionMemory.write(task, it)
+                },
+                onRunSelected = ::runSelected,
+                onOpenTerminal = ::openTerminal,
+                onCopyText = onCopyText,
+                showTuckControl = shouldAutoTuck,
+                onTuck = { pinnedOpen = false },
+            )
+        } else {
+            EnvironmentEdgeTag(
+                status = treeStatus,
+                onClick = { pinnedOpen = true },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EnvironmentEdgeTag(
+    status: WorkingTreeStatus?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    HoverTooltip(text = "Show Environment") {
+        Card(
+            modifier = modifier
+                .pointerHoverIcon(PointerIcon.Hand)
+                .semantics {
+                    contentDescription = "Show Environment"
+                    role = Role.Button
+                }
+                .clickable(
+                    interactionSource = interaction,
+                    indication = null,
+                    onClick = onClick,
+                )
+                .testTag("chat-worktree-environment-tag"),
+            elevation = CardElevation.Med,
+            shape = AndyShape.Menu,
+            backgroundColor = AndyColors.SurfaceRaised,
+            contentPadding = PaddingValues(horizontal = AndySpace.Space2, vertical = AndySpace.Space2),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                LucideIcon(Lucide.GitBranch, TextSecondary, Modifier.size(14.dp))
+                Text(
+                    "Env",
+                    color = if (hovered) TextPrimary else TextSecondary,
+                    fontFamily = DisplayFont,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 12.sp,
+                )
+                val dirty = status?.takeIf { it.additions > 0 || it.deletions > 0 }
+                if (dirty != null) {
+                    if (dirty.additions > 0) {
+                        Text(
+                            "+${dirty.additions}",
+                            color = Green,
+                            fontFamily = MonoFont,
+                            fontSize = 11.sp,
+                        )
+                    }
+                    if (dirty.deletions > 0) {
+                        Text(
+                            "-${dirty.deletions}",
+                            color = Red,
+                            fontFamily = MonoFont,
+                            fontSize = 11.sp,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EnvironmentExpandedCard(
+    selectedLabel: String,
+    selectedAction: SelectedEnvironmentAction,
+    treeStatus: WorkingTreeStatus?,
+    changesExpanded: Boolean,
+    onChangesExpandedChange: (Boolean) -> Unit,
+    onRefreshDiff: () -> Unit,
+    diffSummary: String?,
+    worktreePath: String,
+    branchName: String?,
+    worktreeActions: List<ProjectAction>,
+    overflowOpen: Boolean,
+    onOverflowOpenChange: (Boolean) -> Unit,
+    worktreeMenuOpen: Boolean,
+    onWorktreeMenuOpenChange: (Boolean) -> Unit,
+    onSelectAction: (SelectedEnvironmentAction) -> Unit,
+    onRunSelected: () -> Unit,
+    onOpenTerminal: () -> Unit,
+    onCopyText: (String) -> Unit,
+    showTuckControl: Boolean,
+    onTuck: () -> Unit,
+) {
+    val shortPath = remember(worktreePath) { worktreePath.trimEnd('/').substringAfterLast('/') }
+
+    Card(
+        modifier = Modifier
+            .width(EnvironmentCardWidth)
+            .heightIn(max = 280.dp)
+            .testTag("chat-worktree-environment"),
+        elevation = CardElevation.Med,
+        shape = AndyShape.Menu,
+        backgroundColor = AndyColors.SurfaceRaised,
+        contentPadding = PaddingValues(horizontal = AndySpace.Space2, vertical = AndySpace.Space2),
+        verticalArrangement = Arrangement.spacedBy(1.dp),
+    ) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .height(EnvironmentHeaderHeight)
+                .padding(horizontal = AndySpace.Space1),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                "Environment",
+                color = TextSecondary,
+                fontFamily = DisplayFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+            )
+            Spacer(Modifier.weight(1f))
+            Text(
+                selectedLabel,
+                color = TextPrimary,
+                fontFamily = DisplayFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.widthIn(max = 96.dp),
+            )
+            Box(contentAlignment = Alignment.Center) {
+                EnvironmentIconButton(
+                    path = Lucide.Ellipsis,
+                    contentDescription = "Worktree actions",
+                    onClick = { onOverflowOpenChange(true) },
+                    modifier = Modifier.testTag("chat-worktree-overflow"),
+                )
+                DropdownMenu(
+                    expanded = overflowOpen,
+                    onDismissRequest = { onOverflowOpenChange(false) },
+                    modifier = Modifier.widthIn(min = 200.dp),
+                ) {
+                    AndyDropdownMenuItem(
+                        label = "Terminal",
+                        onClick = {
+                            onSelectAction(SelectedEnvironmentAction.Terminal)
+                            onOverflowOpenChange(false)
+                        },
+                        leading = {
+                            LucideIcon(Lucide.SquareTerminal, TextSecondary, Modifier.size(14.dp))
+                        },
+                        trailing = {
+                            if (selectedAction is SelectedEnvironmentAction.Terminal) {
+                                LucideIcon(Lucide.Check, TextSecondary, Modifier.size(12.dp))
+                            }
+                        },
+                        modifier = Modifier.testTag("chat-worktree-terminal"),
+                    )
+                    worktreeActions.forEachIndexed { index, action ->
+                        AndyDropdownMenuItem(
+                            label = action.name,
+                            onClick = {
+                                onSelectAction(SelectedEnvironmentAction.Run(action))
+                                onOverflowOpenChange(false)
+                            },
+                            leading = {
+                                LucideIcon(Lucide.Play, TextSecondary, Modifier.size(14.dp))
+                            },
+                            trailing = {
+                                val selected = (selectedAction as? SelectedEnvironmentAction.Run)
+                                    ?.action?.id == action.id
+                                if (selected) {
+                                    LucideIcon(Lucide.Check, TextSecondary, Modifier.size(12.dp))
+                                }
+                            },
+                            modifier = if (index == 0) {
+                                Modifier.testTag("chat-worktree-run")
+                            } else {
+                                Modifier
+                            },
+                        )
+                    }
+                    AndyDropdownMenuItem(
+                        label = "Copy path",
+                        onClick = {
+                            onOverflowOpenChange(false)
+                            onCopyText(worktreePath)
+                        },
+                        leading = {
+                            LucideIcon(Lucide.Copy, TextSecondary, Modifier.size(14.dp))
+                        },
+                    )
+                    AndyDropdownMenuItem(
+                        label = "Refresh diff",
+                        onClick = {
+                            onOverflowOpenChange(false)
+                            onRefreshDiff()
+                            onChangesExpandedChange(true)
+                        },
+                        leading = {
+                            LucideIcon(Lucide.RefreshCw, TextSecondary, Modifier.size(14.dp))
+                        },
+                    )
+                }
+            }
+            EnvironmentIconButton(
+                path = Lucide.Play,
+                contentDescription = "Run $selectedLabel",
+                onClick = onRunSelected,
+                modifier = Modifier.testTag("chat-worktree-play"),
+            )
+            if (showTuckControl) {
+                EnvironmentIconButton(
+                    path = Lucide.ChevronRight,
+                    contentDescription = "Hide Environment",
+                    onClick = onTuck,
+                    modifier = Modifier.testTag("chat-worktree-tuck"),
+                )
+            }
+        }
+
+        EnvironmentRow(
+            label = "Changes",
+            leading = { LucideIcon(Lucide.FileCode, TextSecondary, Modifier.size(RowIconSize)) },
+            onClick = { onChangesExpandedChange(!changesExpanded) },
+            trailing = {
+                EnvironmentDiffStats(status = treeStatus)
+            },
+        )
+
+        AnimatedVisibility(
+            visible = changesExpanded,
+            enter = fadeIn() + expandVertically(),
+            exit = fadeOut() + shrinkVertically(),
+        ) {
+            Text(
+                diffSummary ?: "loading diff…",
+                color = TextSecondary,
+                fontFamily = MonoFont,
+                fontSize = 11.sp,
+                lineHeight = 14.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 88.dp)
+                    .padding(start = 28.dp, end = AndySpace.Space1, bottom = AndySpace.Space1)
+                    .verticalScroll(rememberScrollState()),
+            )
+        }
+
+        EnvironmentRow(
+            label = "Worktree",
+            leading = { LucideIcon(Lucide.Monitor, TextSecondary, Modifier.size(RowIconSize)) },
+            onClick = { onWorktreeMenuOpenChange(true) },
+            description = shortPath,
+            tooltip = worktreePath,
+            trailing = {
+                Box {
+                    LucideIcon(Lucide.ChevronDown, TextSecondary.copy(alpha = 0.55f), Modifier.size(12.dp))
+                    DropdownMenu(
+                        expanded = worktreeMenuOpen,
+                        onDismissRequest = { onWorktreeMenuOpenChange(false) },
+                        modifier = Modifier.widthIn(min = 220.dp, max = 360.dp),
+                    ) {
+                        Text(
+                            worktreePath,
+                            color = TextSecondary,
+                            fontFamily = MonoFont,
+                            fontSize = 11.sp,
+                            modifier = Modifier.padding(
+                                horizontal = AndySpace.Space2,
+                                vertical = AndySpace.Space1,
+                            ),
+                        )
+                        AndyDropdownMenuItem(
+                            label = "Copy path",
+                            onClick = {
+                                onWorktreeMenuOpenChange(false)
+                                onCopyText(worktreePath)
+                            },
+                            leading = { LucideIcon(Lucide.Copy, TextSecondary, Modifier.size(14.dp)) },
+                        )
+                        AndyDropdownMenuItem(
+                            label = "Open terminal",
+                            onClick = {
+                                onWorktreeMenuOpenChange(false)
+                                onOpenTerminal()
+                            },
+                            leading = {
+                                LucideIcon(Lucide.SquareTerminal, TextSecondary, Modifier.size(14.dp))
+                            },
+                        )
+                    }
+                }
+            },
+        )
+
+        EnvironmentRow(
+            label = branchName ?: "detached",
+            leading = { LucideIcon(Lucide.GitBranch, TextSecondary, Modifier.size(RowIconSize)) },
+            onClick = { branchName?.let(onCopyText) },
+            marqueeLabel = branchName != null,
+            trailing = {
+                LucideIcon(Lucide.Copy, TextSecondary.copy(alpha = 0.45f), Modifier.size(12.dp))
+            },
+        )
+    }
+}
+
+@Composable
+private fun EnvironmentDiffStats(status: WorkingTreeStatus?) {
+    if (status != null && (status.additions > 0 || status.deletions > 0 || status.isDirty)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            if (status.additions > 0) {
+                Text(
+                    "+${status.additions}",
+                    color = Green,
+                    fontFamily = MonoFont,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+            if (status.deletions > 0) {
+                Text(
+                    "-${status.deletions}",
+                    color = Red,
+                    fontFamily = MonoFont,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+            if (status.additions == 0 && status.deletions == 0 && status.isDirty) {
+                Text(
+                    "${status.dirtyFileCount}",
+                    color = TextSecondary,
+                    fontFamily = MonoFont,
+                    fontSize = 12.sp,
+                )
+            }
+        }
+    } else {
+        Text(
+            "clean",
+            color = TextSecondary.copy(alpha = 0.7f),
+            fontFamily = DisplayFont,
+            fontSize = 12.sp,
+        )
+    }
+}
+
+@Composable
+private fun EnvironmentRow(
+    label: String,
+    leading: @Composable () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    tooltip: String? = description,
+    marqueeLabel: Boolean = false,
+    trailing: @Composable (() -> Unit)? = null,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+
+    @Composable
+    fun RowBody() {
+        Row(
+            modifier
+                .fillMaxWidth()
+                .height(EnvironmentRowHeight)
+                .clip(AndyShape.Interactive)
+                .pointerHoverIcon(PointerIcon.Hand)
+                .clickable(
+                    interactionSource = interaction,
+                    indication = null,
+                    onClick = onClick,
+                )
+                .padding(horizontal = AndySpace.Space1),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+        ) {
+            leading()
+            Text(
+                label,
+                color = if (hovered) TextPrimary else TextPrimary.copy(alpha = 0.92f),
+                fontFamily = DisplayFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 13.sp,
+                maxLines = 1,
+                softWrap = !marqueeLabel,
+                overflow = if (marqueeLabel) TextOverflow.Visible else TextOverflow.Ellipsis,
+                modifier = when {
+                    marqueeLabel ->
+                        Modifier
+                            .weight(1f)
+                            .basicMarquee(
+                                iterations = Int.MAX_VALUE,
+                                initialDelayMillis = 800,
+                                velocity = 28.dp,
+                            )
+                    description == null -> Modifier.weight(1f)
+                    else -> Modifier
+                },
+            )
+            if (description != null) {
+                Text(
+                    description,
+                    color = TextSecondary,
+                    fontFamily = MonoFont,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            } else if (!marqueeLabel) {
+                Spacer(Modifier.weight(1f))
+            }
+            if (trailing != null) {
+                Box(contentAlignment = Alignment.CenterEnd) {
+                    trailing()
+                }
+            }
+        }
+    }
+
+    if (tooltip != null) {
+        HoverTooltip(text = tooltip, modifier = Modifier.fillMaxWidth()) { RowBody() }
+    } else {
+        RowBody()
+    }
+}
+
+@Composable
+private fun EnvironmentIconButton(
+    path: String,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    Box(
+        modifier
+            .size(28.dp)
+            .clip(AndyShape.Interactive)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .semantics {
+                this.contentDescription = contentDescription
+                role = Role.Button
+            }
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        LucideIcon(path, TextSecondary, Modifier.size(14.dp))
+    }
+}
+
+private val RowIconSize = 15.dp
+private val EnvironmentRowHeight = 32.dp
+private val EnvironmentHeaderHeight = 28.dp

--- a/feature/agents/src/commonTest/kotlin/app/andy/ui/agents/WorktreeEnvironmentPanelTest.kt
+++ b/feature/agents/src/commonTest/kotlin/app/andy/ui/agents/WorktreeEnvironmentPanelTest.kt
@@ -1,0 +1,80 @@
+package app.andy.ui.agents
+
+import androidx.compose.ui.unit.dp
+import app.andy.ui.theme.AndyLayout
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WorktreeEnvironmentPanelTest {
+
+    @Test
+    fun unmeasuredPaneDoesNotTuck() {
+        assertFalse(
+            environmentCardWouldEclipseContent(
+                paneWidth = 0.dp,
+                contentFullBleed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun fullBleedPaneAlwaysTucks() {
+        assertTrue(
+            environmentCardWouldEclipseContent(
+                paneWidth = 2_000.dp,
+                contentFullBleed = true,
+            ),
+        )
+    }
+
+    @Test
+    fun halfMonitorCenteredChatTucks() {
+        // Typical half-monitor chat pane: content fills to ChatContentMaxWidth and the
+        // floating card sits on top of the message column's right edge.
+        assertTrue(
+            environmentCardWouldEclipseContent(
+                paneWidth = 900.dp,
+                contentFullBleed = false,
+            ),
+        )
+        assertTrue(
+            environmentCardWouldEclipseContent(
+                paneWidth = AndyLayout.ChatContentMaxWidth,
+                contentFullBleed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun widePaneWithSideGuttersKeepsCardExpanded() {
+        // Need room for the 800dp column, card, end padding, clearance, and end inset.
+        assertFalse(
+            environmentCardWouldEclipseContent(
+                paneWidth = 1_400.dp,
+                contentFullBleed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun justWideEnoughKeepsCardExpanded() {
+        // contentRight = (pane + 800) / 2 - 26
+        // panelLeft = pane - 8 - 248
+        // clear when panelLeft >= contentRight + 16
+        // ⇒ pane - 256 >= (pane + 800) / 2 - 10
+        // ⇒ pane >= ~1,292dp
+        assertFalse(
+            environmentCardWouldEclipseContent(
+                paneWidth = 1_300.dp,
+                contentFullBleed = false,
+            ),
+        )
+        assertTrue(
+            environmentCardWouldEclipseContent(
+                paneWidth = 1_200.dp,
+                contentFullBleed = false,
+            ),
+        )
+    }
+}

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/ShellNavigation.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/ShellNavigation.kt
@@ -1,6 +1,7 @@
 package app.andy.ui.components
 
 import androidx.compose.runtime.staticCompositionLocalOf
+import app.andy.model.ProjectAction
 import app.andy.service.OpenAgentTaskRequest
 import app.andy.service.OpenInvestigationRequest
 
@@ -9,3 +10,16 @@ val LocalOpenAgentTask = staticCompositionLocalOf<(OpenAgentTaskRequest) -> Unit
 
 /** Returns from an agent chat to the investigation behind it. */
 val LocalOpenInvestigation = staticCompositionLocalOf<(OpenInvestigationRequest) -> Unit> { {} }
+
+/**
+ * Runs a project's shell or runbook actions in an arbitrary directory — the shell owns the
+ * terminal docks, so surfaces deep in the tree (a chat's worktree card) reach them through here
+ * instead of threading callbacks down. [dir] is normally a worktree path.
+ */
+class ProjectDirLauncher(
+    val actionsFor: (projectId: String?) -> List<ProjectAction> = { emptyList() },
+    val openTerminal: (projectId: String?, dir: String) -> Unit = { _, _ -> },
+    val runAction: (projectId: String?, action: ProjectAction, dir: String) -> Unit = { _, _, _ -> },
+)
+
+val LocalProjectDirLauncher = staticCompositionLocalOf { ProjectDirLauncher() }

--- a/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
+++ b/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/AndyShell.kt
@@ -45,6 +45,8 @@ import app.andy.ui.components.HorizontalPaneDivider
 import app.andy.LocalSuppressHeavyweightSurfaces
 import app.andy.ui.components.LocalOpenAgentTask
 import app.andy.ui.components.LocalOpenInvestigation
+import app.andy.ui.components.LocalProjectDirLauncher
+import app.andy.ui.components.ProjectDirLauncher
 import app.andy.ui.components.PaneDivider
 import app.andy.ui.components.ModalDialogRegistry
 import app.andy.ui.components.PendingConfirmation
@@ -276,6 +278,13 @@ internal fun AndyShell(
         LocalSuppressHeavyweightSurfaces provides ModalDialogRegistry.anyOpen,
         LocalOpenAgentTask provides state::openAgentTask,
         LocalOpenInvestigation provides state::openInvestigation,
+        LocalProjectDirLauncher provides remember(state) {
+            ProjectDirLauncher(
+                actionsFor = state::projectActions,
+                openTerminal = state::openTerminalIn,
+                runAction = state::runActionIn,
+            )
+        },
         LocalChatComposerInbox provides remember { ChatComposerInbox() },
     ) {
     Box(

--- a/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
+++ b/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
@@ -1427,6 +1427,26 @@ internal class ShellState(
         destination = AndyDestination.Live
     }
 
+    /** Project whose env/runbook applies to a directory launch, preferring the chat's own project. */
+    private fun launchProject(projectId: String?): ActionProject? =
+        actionsConfig.projects.firstOrNull { it.id == projectId }
+            ?: actionsConfig.projects.firstOrNull { it.id == workspaceState.lastActionProjectId }
+            ?: actionsConfig.projects.firstOrNull()
+
+    fun projectActions(projectId: String?): List<ProjectAction> = launchProject(projectId)?.actions.orEmpty()
+
+    /** Opens and reveals a shell rooted at [dir] (a worktree path) with [projectId]'s environment. */
+    fun openTerminalIn(projectId: String?, dir: String) {
+        val project = launchProject(projectId) ?: return
+        focusTerminalRun(services.actionRuns.openShell(project, dir))
+    }
+
+    /** Runs a runbook [action] against [dir] instead of the project checkout, and reveals it. */
+    fun runActionIn(projectId: String?, action: ProjectAction, dir: String) {
+        val project = launchProject(projectId) ?: return
+        focusTerminalRun(services.actionRuns.run(project, action, dir))
+    }
+
     fun runAction(project: ActionProject, action: ProjectAction) {
         updateWorkspace {
             it.copy(

--- a/ui/shell/src/commonTest/kotlin/app/andy/ui/shell/ShellStateLayoutTest.kt
+++ b/ui/shell/src/commonTest/kotlin/app/andy/ui/shell/ShellStateLayoutTest.kt
@@ -92,7 +92,7 @@ class ShellStateLayoutTest {
         val services = baseServices.copy(
             capabilities = PlatformCapabilities.Desktop,
             actionRuns = object : ActionRunService by UnavailableActionRunService {
-                override fun openShell(project: ActionProject): String = "run-restored"
+                override fun openShell(project: ActionProject, cwdOverride: String?): String = "run-restored"
             },
         )
         val scope = CoroutineScope(EmptyCoroutineContext)


### PR DESCRIPTION
## Summary
Makes worktrees fully usable without leaving Andy, so a run can be isolated *and* tested in place.

### What changed
- **Floating Environment panel** on worktree chats — replaces the old inline worktree card. Shows change stats, expandable diff, worktree path, and branch; supports copy path, copy merge cmd, refresh diff, plus a play picker for **Terminal** or any runbook action rooted in the worktree. Auto-tucks into an edge tag when it would cover chat text (with a pin control).
- **Worktrees tab** rows gain `terminal` and `run…` actions that open a shell or run a runbook action against that worktree's path (plus `open chat`).
- **`cwdOverride` on shells/runbook runs** — a run can target a directory (worktree) instead of the checkout. Runs are deduplicated *per directory*, so the same action can be live in several worktrees without evicting the checkout's run. Relative action `cwd` rebases on top of the override.
- **Fork-from-a-base-branch** (`baseRef`): a new worktree can fork from a branch the user picks in the composer chip (or that an agent passes to the MCP tool), without moving the user's checkout. `baseWorktreeTaskId` still wins over `baseRef`.
- **`ProjectDirLauncher`** composition-local routes these directory launches from deep surfaces to the shell's terminal docks.
- README documents the worktree branch + test-in-place flow.

### Tests
- `DesktopActionRunServiceTest`: worktree run dedup without evicting the checkout run; relative `cwd` rebase onto a worktree override.
- `NestedWorktreeServiceTest`: `baseRef` forks from that branch without moving the checkout; `baseWorktreeTaskId` precedence.
- `WorktreeEnvironmentPanelTest`: tuck/eclipse geometry.
- `ShellStateLayoutTest` updated for the new `openShell` signature.

### Known risks
- New visual surface (Environment panel) — screenshot baselines will be verified by CI.