### PR TITLE
Add managed chat attachments, transcript find, and merged remote projects

### DIFF
--- a/agent-store/src/main/kotlin/app/andy/store/AndyAgentDb.kt
+++ b/agent-store/src/main/kotlin/app/andy/store/AndyAgentDb.kt
@@ -6,19 +6,66 @@ import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import java.io.File
 import java.util.Properties
 
-fun openAndyAgentDatabase(dbFile: File): AndyAgentDatabase {
+/**
+ * The database plus the driver that backs it. The driver is exposed so callers can run the
+ * JSON1-based statements in [AgentJsonSql], which SQLDelight cannot generate.
+ */
+class AndyAgentDb(
+    val database: AndyAgentDatabase,
+    val driver: SqlDriver,
+)
+
+fun openAndyAgentDatabase(dbFile: File): AndyAgentDb {
     dbFile.parentFile?.mkdirs()
     val fresh = !dbFile.exists()
     val driver = JdbcSqliteDriver("jdbc:sqlite:${dbFile.absolutePath}", Properties())
     if (fresh) {
         AndyAgentDatabase.Schema.create(driver)
-    } else {
-        // Schema.create aborts on the first already-existing table, so additive tables
-        // (e.g. kanban_board) never land on older agents.db files. Apply IF NOT EXISTS
-        // migrations for schema additions instead.
-        ensureAdditiveSchema(driver)
     }
-    return AndyAgentDatabase(driver)
+    // Schema.create aborts on the first already-existing table, so additive tables
+    // (e.g. kanban_board, transcript FTS) never land on older agents.db files. Always
+    // apply IF NOT EXISTS migrations — including on fresh DBs for FTS (not in .sq).
+    ensureAdditiveSchema(driver)
+    return AndyAgentDb(AndyAgentDatabase(driver), driver)
+}
+
+/**
+ * Statements that need SQLite's JSON1 functions, which none of SQLDelight's dialects model, so
+ * they cannot live in AgentStore.sq. All of them exist to keep `completedChanges.diffs` — tens of
+ * MB of stored diff text — out of the JVM heap.
+ */
+object AgentJsonSql {
+    /**
+     * Startup projection of [AgentStore.sq]'s `selectAllTasks` with `completedChanges.diffs`
+     * stripped. Read-only: stored rows keep their diffs untouched.
+     */
+    const val SELECT_ALL_TASKS_LITE: String =
+        "SELECT id, json_remove(payload, '\$.completedChanges.diffs') AS payload " +
+            "FROM agent_task ORDER BY created_at_millis DESC"
+
+    /** One task's stored diffs, fetched when a diff view actually opens. */
+    const val SELECT_TASK_DIFFS: String =
+        "SELECT json_extract(payload, '\$.completedChanges.diffs') FROM agent_task WHERE id = ?"
+
+    /**
+     * Writes a task whose in-memory snapshot never hydrated its diffs, splicing the already-stored
+     * diffs back inside SQLite so the save cannot blank them. The `ELSE` covers both a task that
+     * genuinely has no stored diffs and one whose `completedChanges` was cleared (e.g. by undo),
+     * which must be allowed to write through.
+     */
+    const val UPDATE_TASK_PRESERVING_DIFFS: String =
+        """
+        UPDATE agent_task SET
+          status = ?, agent = ?, created_at_millis = ?, updated_at_millis = ?,
+          payload = CASE
+            WHEN json_extract(payload, '$.completedChanges.diffs') IS NOT NULL
+             AND json_extract(?, '$.completedChanges') IS NOT NULL
+            THEN json_set(?, '$.completedChanges.diffs',
+                          json_extract(payload, '$.completedChanges.diffs'))
+            ELSE ?
+          END
+        WHERE id = ?
+        """
 }
 
 /**
@@ -27,20 +74,20 @@ fun openAndyAgentDatabase(dbFile: File): AndyAgentDatabase {
  */
 internal fun ensureAdditiveSchema(driver: SqlDriver) {
     migrateLegacyKanbanTable(driver)
-        driver.execute(
-            identifier = null,
-            sql = """
+    driver.execute(
+        identifier = null,
+        sql = """
             CREATE TABLE IF NOT EXISTS kanban_board (
               project_id TEXT NOT NULL PRIMARY KEY,
               updated_at_millis INTEGER NOT NULL,
               payload TEXT NOT NULL
             )
         """.trimIndent(),
-            parameters = 0,
-        )
-        driver.execute(
-            identifier = null,
-            sql = """
+        parameters = 0,
+    )
+    driver.execute(
+        identifier = null,
+        sql = """
             CREATE TABLE IF NOT EXISTS automation (
               id TEXT NOT NULL PRIMARY KEY,
               project_id TEXT NOT NULL,
@@ -48,9 +95,80 @@ internal fun ensureAdditiveSchema(driver: SqlDriver) {
               payload TEXT NOT NULL
             )
         """.trimIndent(),
-            parameters = 0,
-        )
-    }
+        parameters = 0,
+    )
+    ensureTranscriptSearchSchema(driver)
+}
+
+/**
+ * Cmd+K transcript body search. Kept as raw SQL because SQLDelight does not model FTS5
+ * virtual tables cleanly, and older agents.db files need IF NOT EXISTS migrations.
+ */
+internal fun ensureTranscriptSearchSchema(driver: SqlDriver) {
+    driver.execute(
+        identifier = null,
+        sql = """
+            CREATE TABLE IF NOT EXISTS transcript_search_doc (
+              task_id TEXT NOT NULL PRIMARY KEY,
+              body TEXT NOT NULL,
+              source_mtime INTEGER NOT NULL,
+              source_len INTEGER NOT NULL,
+              complete INTEGER NOT NULL DEFAULT 0
+            )
+        """.trimIndent(),
+        parameters = 0,
+    )
+    driver.execute(
+        identifier = null,
+        sql = """
+            CREATE VIRTUAL TABLE IF NOT EXISTS transcript_fts USING fts5(
+              task_id UNINDEXED,
+              body,
+              tokenize = 'unicode61'
+            )
+        """.trimIndent(),
+        parameters = 0,
+    )
+}
+
+/** Raw SQL for the transcript FTS sidecar (see [ensureTranscriptSearchSchema]). */
+object TranscriptSearchSql {
+    val UPSERT_DOC: String =
+        """
+        INSERT INTO transcript_search_doc(task_id, body, source_mtime, source_len, complete)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(task_id) DO UPDATE SET
+          body = excluded.body,
+          source_mtime = excluded.source_mtime,
+          source_len = excluded.source_len,
+          complete = excluded.complete
+        """.trimIndent()
+
+    const val DELETE_FTS_FOR_TASK: String =
+        "DELETE FROM transcript_fts WHERE task_id = ?"
+
+    const val INSERT_FTS: String =
+        "INSERT INTO transcript_fts(task_id, body) VALUES (?, ?)"
+
+    const val DELETE_DOC: String =
+        "DELETE FROM transcript_search_doc WHERE task_id = ?"
+
+    const val SELECT_DOC: String =
+        "SELECT body, source_mtime, source_len, complete FROM transcript_search_doc WHERE task_id = ?"
+
+    const val SELECT_INCOMPLETE_TASK_IDS: String =
+        "SELECT task_id FROM transcript_search_doc WHERE complete = 0"
+
+    val SEARCH_FTS: String =
+        """
+        SELECT transcript_fts.task_id, d.body
+        FROM transcript_fts
+        JOIN transcript_search_doc AS d ON d.task_id = transcript_fts.task_id
+        WHERE transcript_fts MATCH ?
+        ORDER BY d.source_mtime DESC
+        LIMIT ?
+        """.trimIndent()
+}
 
 /**
  * The board used to be a singleton. There is no reliable project to attribute that data to,

--- a/agent-store/src/main/sqldelight/app/andy/store/AgentStore.sq
+++ b/agent-store/src/main/sqldelight/app/andy/store/AgentStore.sq
@@ -64,11 +64,21 @@ upsertTask:
 INSERT OR REPLACE INTO agent_task(id, status, agent, created_at_millis, updated_at_millis, payload)
 VALUES (?, ?, ?, ?, ?, ?);
 
+-- Paired with AgentJsonSql.updateTaskPreservingDiffs: insert-if-absent, then splice stored diffs
+-- back. The splice itself lives in raw SQL because SQLDelight's dialects do not model the JSON1
+-- functions it needs.
+insertTaskIfAbsent:
+INSERT OR IGNORE INTO agent_task(id, status, agent, created_at_millis, updated_at_millis, payload)
+VALUES (?, ?, ?, ?, ?, ?);
+
 deleteTask:
 DELETE FROM agent_task WHERE id = ?;
 
 deleteAllTasks:
 DELETE FROM agent_task;
+
+deleteTasksNotIn:
+DELETE FROM agent_task WHERE id NOT IN ?;
 
 selectAllWorkflows:
 SELECT project_id, updated_at_millis, payload FROM project_workflow;

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -83,11 +83,11 @@ dependencies {
     // Kept for one-shot migration from EncryptedSharedPreferences.
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
-    implementation(compose.runtime)
-    implementation(compose.foundation)
-    implementation(compose.material3)
-    implementation(compose.ui)
-    implementation(compose.components.resources)
+    implementation(libs.compose.runtime)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.components.resources)
 
     implementation(libs.coroutines.core)
     implementation(libs.serialization.json)
@@ -96,7 +96,7 @@ dependencies {
     implementation(libs.ktor.serialization.json)
     implementation(libs.ktor.client.websockets)
 
-    debugImplementation(compose.uiTooling)
+    debugImplementation(libs.compose.ui.tooling)
 
     testImplementation("junit:junit:4.13.2")
     testImplementation(libs.coroutines.test)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -28,10 +28,8 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="com.joetr.andy.action.VOICE_NEW_THREAD" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
+            <!-- Voice widget/shortcut use an explicit component; no exported action filter
+                 so third-party apps cannot inject EXTRA_TEXT into a new thread. -->
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/androidApp/src/main/kotlin/com/joetr/andy/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.joetr.andy
 
 import android.Manifest
+import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Color
@@ -34,11 +35,12 @@ class MainActivity : ComponentActivity() {
 
     private val speechRecognizer =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode != Activity.RESULT_OK) return@registerForActivityResult
             val spoken = result.data
                 ?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
                 ?.firstOrNull()
                 ?.takeIf { it.isNotBlank() }
-            // Always land on confirm even if recognition failed — user can type.
+            // OK with empty results still opens confirm so the user can type.
             pendingVoiceNewThread = PendingVoiceNewThread(prompt = spoken.orEmpty())
         }
 
@@ -75,21 +77,31 @@ class MainActivity : ComponentActivity() {
 
     private fun handleVoiceIntent(intent: Intent?) {
         if (intent?.action != ACTION_VOICE_NEW_THREAD) return
-        val supplied = intent.voicePromptExtra()
-        if (supplied != null) {
-            // Assistant / third-party supplied text — skip recognition, still require Start tap.
-            pendingVoiceNewThread = PendingVoiceNewThread(prompt = supplied)
-        } else {
-            // Marker that AndyMobileApp should request recognition (or we launch it here).
-            pendingVoiceNewThread = PendingVoiceNewThread(prompt = null)
-        }
+        // Never accept third-party prompt extras — widget/shortcut only trigger recognition.
+        pendingVoiceNewThread = PendingVoiceNewThread(prompt = null)
+        scrubVoiceIntent()
+    }
+
+    /** Drop the voice action so process death / recreate does not re-fire recognition. */
+    private fun scrubVoiceIntent() {
+        setIntent(
+            Intent(this, MainActivity::class.java).apply {
+                action = Intent.ACTION_MAIN
+                addCategory(Intent.CATEGORY_LAUNCHER)
+                // Preserve open-chat deep links if they were combined somehow.
+                pendingOpenChatId?.let { putExtra(EXTRA_OPEN_CHAT_ID, it) }
+            },
+        )
     }
 
     private fun launchSpeechRecognition() {
         val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
             putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
-            putExtra(RecognizerIntent.EXTRA_PROMPT, "New Andy thread")
+            putExtra(
+                RecognizerIntent.EXTRA_PROMPT,
+                getString(com.joetr.andy.R.string.voice_recognizer_prompt),
+            )
             // Best-effort: give thinking pauses more room. OEM recognizers (esp. Google /
             // Samsung) may ignore these — full control needs an in-app SpeechRecognizer.
             putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS, VOICE_MIN_LENGTH_MS)
@@ -139,15 +151,3 @@ data class PendingVoiceNewThread(val prompt: String?)
 
 private fun Intent.chatIdExtra(): String? =
     getStringExtra(MainActivity.EXTRA_OPEN_CHAT_ID)?.takeIf { it.isNotBlank() }
-
-/**
- * Accepts assistant-supplied text from any caller ([RecognizerIntent.EXTRA_RESULTS] or
- * [Intent.EXTRA_TEXT]). The mandatory Start tap on NewChat is the security gate.
- */
-private fun Intent.voicePromptExtra(): String? {
-    getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
-        ?.firstOrNull()
-        ?.takeIf { it.isNotBlank() }
-        ?.let { return it }
-    return getStringExtra(Intent.EXTRA_TEXT)?.takeIf { it.isNotBlank() }
-}

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/AndyMobileApp.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/AndyMobileApp.kt
@@ -98,6 +98,9 @@ fun AndyMobileApp(
     val initialTab = repository.selectedTab.value
     val backStack = rememberNavBackStack(MobileNavKey.Tabs(initialTab))
 
+    /** Prompt parked while the user picks a host from the voice no-host screen. */
+    var parkedVoicePrompt by remember { mutableStateOf<String?>(null) }
+
     var screenFullScreen by remember { mutableStateOf(true) }
     var screenKeyboardOpen by remember { mutableStateOf(false) }
 
@@ -177,6 +180,7 @@ fun AndyMobileApp(
             sessionManager.restoreFromStoredSession()
             // Still open NewChat even without a host — screen redirects to Hosts/Projects.
         }
+        parkedVoicePrompt = null
         navigateReplaceSession(
             MobileNavKey.NewChat(
                 initialPrompt = pending.prompt,
@@ -212,10 +216,24 @@ fun AndyMobileApp(
         val hosts by repository.hosts.collectAsStateWithLifecycle()
         val selectedId by repository.selectedHostId.collectAsStateWithLifecycle()
         val selectedHost = hosts.firstOrNull { it.id == selectedId } ?: hosts.firstOrNull()
-        val sessionClient = sessionManager.client
+        val sessionGraph by sessionManager.session.collectAsStateWithLifecycle()
+        val sessionClient = sessionGraph?.networkAccessClient
         // Activity-scoped so project list / expand state survives Chat pushes that
         // temporarily remove the Tabs entry from composition.
         val projectsVm: ProjectsViewModel = viewModel(factory = graph.factory<ProjectsViewModel>())
+
+        // After "Choose host", restore the voice NewChat once a session is available.
+        LaunchedEffect(sessionGraph, selectedHost?.id, parkedVoicePrompt) {
+            val prompt = parkedVoicePrompt ?: return@LaunchedEffect
+            if (sessionGraph == null || selectedHost == null) return@LaunchedEffect
+            parkedVoicePrompt = null
+            navigateReplaceSession(
+                MobileNavKey.NewChat(
+                    initialPrompt = prompt,
+                    fromVoice = true,
+                ),
+            )
+        }
 
         NavDisplay(
             backStack = backStack,
@@ -342,7 +360,10 @@ fun AndyMobileApp(
                                         viewModel = projectsVm,
                                         onClientReady = { client ->
                                             sessionManager.adoptClient(client)
-                                            val token = client.sessionToken
+                                        },
+                                        onConnectionReady = {
+                                            val client = sessionManager.client
+                                            val token = client?.sessionToken
                                             val host = selectedHost
                                             if (host != null && !token.isNullOrBlank()) {
                                                 AttentionPushService.start(
@@ -445,6 +466,7 @@ fun AndyMobileApp(
                                     )
                                     androidx.compose.material3.TextButton(
                                         onClick = {
+                                            parkedVoicePrompt = route.initialPrompt
                                             backStack.removeLastOrNull()
                                             ensureTabs(MobileTab.Hosts)
                                         },

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/VoiceDefaultsStore.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/VoiceDefaultsStore.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import dev.zacsweers.metro.Inject
@@ -42,9 +41,9 @@ class VoiceDefaultsStore(context: Context) {
     }
 
     suspend fun update(transform: (VoiceDefaults) -> VoiceDefaults) = withContext(Dispatchers.IO) {
-        _defaults.update { current ->
-            transform(current).also { persist(it) }
-        }
+        val next = transform(_defaults.value)
+        persist(next)
+        _defaults.value = next
     }
 
     private suspend fun load(): VoiceDefaults {

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/AttentionPushService.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/attention/AttentionPushService.kt
@@ -87,10 +87,13 @@ class AttentionPushService : Service() {
                     stopSelf()
                     return START_NOT_STICKY
                 }
-                persistSession(this, baseUrl, token, hostName)
                 hostLabel = hostName
-                startAsForeground(combinedStatus())
-                connect(baseUrl, token)
+                startAttentionSession(
+                    scope = scope,
+                    persist = { persistSession(this, baseUrl, token, hostName) },
+                    startForeground = { startAsForeground(combinedStatus()) },
+                    connect = { connect(baseUrl, token) },
+                )
                 return START_STICKY
             }
             else -> {
@@ -521,4 +524,17 @@ class AttentionPushService : Service() {
 
         private data class Session(val baseUrl: String, val token: String, val hostName: String)
     }
+}
+
+internal fun startAttentionSession(
+    scope: CoroutineScope,
+    persist: suspend () -> Unit,
+    startForeground: () -> Unit,
+    connect: () -> Unit,
+): Job {
+    // Android dispatches Service.onStartCommand on Main. Start the required foreground state and
+    // network listener immediately; encrypted persistence can safely finish on the service's IO scope.
+    startForeground()
+    connect()
+    return scope.launch { persist() }
 }

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessApi.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessApi.kt
@@ -273,7 +273,7 @@ class NetworkAccessClient(
     fun observeChat(chatId: String): Flow<ChatWsBatch> = flow {
         val token = sessionToken?.takeIf { it.isNotBlank() }
             ?: throw NetworkAccessException("Not signed in")
-        val url = "$root/ws/chats/${chatId.encodeURL()}?token=${token.encodeURL()}"
+        val url = networkAccessWebSocketUrl(root, "/ws/chats/${chatId.encodeURL()}?token=${token.encodeURL()}")
         client.webSocket(urlString = url) {
             for (frame in incoming) {
                 if (frame !is Frame.Text) continue
@@ -287,14 +287,15 @@ class NetworkAccessClient(
 
     /**
      * Host-pushed attention stream (Blocked / Done / Error). Same auth + URL style as [observeChat]
-     * (`https://…/ws/…` — Ktor upgrades; do not force `wss://` or Tailscale Serve TLS breaks).
+     * Uses an explicit WebSocket scheme so OkHttp performs an upgrade instead of accepting the
+     * web app's HTML fallback as a normal HTTP response.
      */
     fun observeAttention(
         onReady: suspend () -> Unit = {},
     ): Flow<ChatAttentionEvent> = flow {
         val token = sessionToken?.takeIf { it.isNotBlank() }
             ?: throw NetworkAccessException("Not signed in")
-        val url = "$root/ws/attention?token=${token.encodeURL()}"
+        val url = networkAccessWebSocketUrl(root, "/ws/attention?token=${token.encodeURL()}")
         try {
             client.webSocket(urlString = url) {
                 var ready = false
@@ -447,6 +448,15 @@ class NetworkAccessClient(
     override fun close() {
         client.close()
     }
+}
+
+internal fun networkAccessWebSocketUrl(root: String, path: String): String {
+    val webSocketRoot = when {
+        root.startsWith("https://", ignoreCase = true) -> "wss://${root.substringAfter("://")}"
+        root.startsWith("http://", ignoreCase = true) -> "ws://${root.substringAfter("://")}"
+        else -> root
+    }
+    return webSocketRoot.trimEnd('/') + "/" + path.trimStart('/')
 }
 
 data class ChatWsBatch(

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessLoading.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessLoading.kt
@@ -1,0 +1,27 @@
+package com.joetr.andy.mobile.data.networkaccess
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+internal suspend fun loadProjectGroupsConcurrently(
+    loadProjects: suspend () -> List<ProjectDto>,
+    loadChats: suspend () -> List<ChatDto>,
+): List<ProjectGroup> = coroutineScope {
+    val projects = async { loadProjects() }
+    val chats = async { loadChats() }
+    groupChatsByProject(projects.await(), chats.await())
+}
+
+internal data class ChatInitialData(
+    val detail: ChatDetailDto,
+    val settings: TranscriptSettingsDto?,
+)
+
+internal suspend fun loadChatInitialDataConcurrently(
+    loadDetail: suspend () -> ChatDetailDto,
+    loadSettings: suspend () -> TranscriptSettingsDto?,
+): ChatInitialData = coroutineScope {
+    val detail = async { loadDetail() }
+    val settings = async { loadSettings() }
+    ChatInitialData(detail = detail.await(), settings = settings.await())
+}

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ChatScreen.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ChatScreen.kt
@@ -74,6 +74,7 @@ import com.joetr.andy.mobile.data.networkaccess.latestPlanHasPendingEntries
 import androidx.compose.foundation.clickable
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
+import com.joetr.andy.mobile.data.networkaccess.loadChatInitialDataConcurrently
 import com.joetr.andy.mobile.data.networkaccess.showImplementPlan
 import app.andy.ui.theme.Yellow
 import kotlinx.coroutines.delay
@@ -112,7 +113,6 @@ fun ChatScreen(
     val statusLabel = chat?.displayStatusLabel(hasPendingPlanEntries).orEmpty()
 
     suspend fun loadOnce() {
-        runCatching { client.getTranscriptSettings() }.onSuccess { transcriptPrefs = it }
         val detail = client.chatDetail(chatId)
         chat = detail.chat
         events = detail.events.coalesceStreams()
@@ -123,18 +123,28 @@ fun ChatScreen(
     LaunchedEffect(chatId) {
         expandedOverrides = emptySet()
         try {
-            loadOnce()
+            val initial = loadChatInitialDataConcurrently(
+                loadDetail = { client.chatDetail(chatId) },
+                loadSettings = { runCatching { client.getTranscriptSettings() }.getOrNull() },
+            )
+            chat = initial.detail.chat
+            events = initial.detail.events.coalesceStreams()
+            pendingInput = initial.detail.chat.userInputRequest
+            loading = false
+            initial.settings?.let { transcriptPrefs = it }
         } catch (e: Exception) {
             error = e.message
             loading = false
         }
-        // Prefer websocket; fall back to quiet polling if WS fails.
+        // The compressed REST snapshot paints the chat first. WebSocket then supplies live deltas
+        // without making the server serialize and send the full transcript twice at once.
         try {
             client.observeChat(chatId).collect { batch ->
-                batch.chat?.let { chat = it }
+                batch.chat?.let {
+                    chat = it
+                    error = null
+                }
                 if (batch.events.isNotEmpty()) {
-                    // The server sends replaceFrom to avoid duplicating history the client
-                    // already loaded over REST, and to coalesce rewritten/edited events.
                     val base = if (batch.replaceFrom != null) {
                         events.take(batch.replaceFrom)
                     } else {

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/MobileViewModels.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/MobileViewModels.kt
@@ -8,7 +8,7 @@ import com.joetr.andy.mobile.data.VoiceDefaultsStore
 import com.joetr.andy.mobile.data.networkaccess.NetworkAccessClient
 import com.joetr.andy.mobile.data.networkaccess.NetworkAccessException
 import com.joetr.andy.mobile.data.networkaccess.ProjectGroup
-import com.joetr.andy.mobile.data.networkaccess.groupChatsByProject
+import com.joetr.andy.mobile.data.networkaccess.loadProjectGroupsConcurrently
 import com.joetr.andy.mobile.data.updates.AndroidAppUpdateService
 import com.joetr.andy.mobile.data.vnc.RfbClient
 import com.joetr.andy.mobile.di.SessionManager
@@ -93,9 +93,10 @@ class ProjectsViewModel(
         if (showLoading) _loading.value = true
         _error.value = null
         try {
-            val projects = client.listProjects()
-            val chats = client.listChats()
-            _groups.value = groupChatsByProject(projects, chats)
+            _groups.value = loadProjectGroupsConcurrently(
+                loadProjects = client::listProjects,
+                loadChats = client::listChats,
+            )
             _signedIn.value = true
             _loadedHostId.value = hostId
         } catch (e: NetworkAccessException) {

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ProjectsScreen.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/ui/ProjectsScreen.kt
@@ -64,7 +64,11 @@ import com.joetr.andy.mobile.data.networkaccess.NetworkAccessException
 import com.joetr.andy.mobile.data.networkaccess.ProjectGroup
 import com.joetr.andy.mobile.data.networkaccess.awaitingPlanConfirmation
 import com.joetr.andy.mobile.data.networkaccess.displayStatusLabel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun ProjectsScreen(
@@ -74,6 +78,7 @@ fun ProjectsScreen(
     okHttpClient: okhttp3.OkHttpClient,
     viewModel: ProjectsViewModel,
     onClientReady: (NetworkAccessClient) -> Unit,
+    onConnectionReady: () -> Unit = {},
     onSignedOut: () -> Unit = {},
     onOpenChat: (String) -> Unit,
     onNewChat: () -> Unit,
@@ -139,20 +144,30 @@ fun ProjectsScreen(
         }
     }
 
-    suspend fun refresh(client: NetworkAccessClient, showLoading: Boolean) {
+    suspend fun refresh(client: NetworkAccessClient, showLoading: Boolean): Boolean {
         try {
             viewModel.refresh(client, host.id, showLoading = showLoading)
         } catch (e: NetworkAccessException) {
             handleAuthFailure(e)
         }
+        return viewModel.signedIn.value
     }
 
     suspend fun completeLogin(client: NetworkAccessClient) {
         val session = client.sessionToken
         if (session.isNullOrBlank()) throw NetworkAccessException("Login failed")
-        repository.saveNetworkAccessSession(host.id, session)
-        onClientReady(client)
-        refresh(client, showLoading = true)
+        coroutineScope {
+            val persistSession = async(Dispatchers.IO) {
+                repository.saveNetworkAccessSession(host.id, session)
+            }
+            try {
+                onClientReady(client)
+                if (refresh(client, showLoading = true)) onConnectionReady()
+            } finally {
+                // A valid login must remain saved even if the first project refresh fails.
+                persistSession.await()
+            }
+        }
     }
 
     LaunchedEffect(host.id) {
@@ -166,8 +181,16 @@ fun ProjectsScreen(
                 return@LaunchedEffect
             }
         }
-        val storedSession = repository.networkAccessSession(host.id)
-        val legacyToken = repository.legacyNetworkAccessToken(host.id)
+        val storedSession = withContext(Dispatchers.IO) {
+            repository.networkAccessSession(host.id)
+        }
+        // Legacy tokens are only a migration fallback. Avoid another encrypted DataStore read
+        // on every normal connection after a session has already been established.
+        val legacyToken = if (storedSession.isNullOrBlank()) {
+            withContext(Dispatchers.IO) { repository.legacyNetworkAccessToken(host.id) }
+        } else {
+            null
+        }
         when {
             !storedSession.isNullOrBlank() -> {
                 val existing = networkClient
@@ -181,7 +204,9 @@ fun ProjectsScreen(
                 }
                 try {
                     onClientReady(client)
-                    refresh(client, showLoading = !viewModel.hasCachedProjects(host.id))
+                    if (refresh(client, showLoading = !viewModel.hasCachedProjects(host.id))) {
+                        onConnectionReady()
+                    }
                 } catch (e: Exception) {
                     viewModel.markSignedOut()
                     if (e !is NetworkAccessException) {

--- a/androidApp/src/main/kotlin/com/joetr/andy/mobile/widget/VoiceThreadWidgetProvider.kt
+++ b/androidApp/src/main/kotlin/com/joetr/andy/mobile/widget/VoiceThreadWidgetProvider.kt
@@ -11,7 +11,7 @@ import com.joetr.andy.R
 
 /**
  * Home-screen widget that starts the same voice-new-thread path as the launcher shortcut:
- * [MainActivity.ACTION_VOICE_NEW_THREAD] → system speech UI (or supplied text) → confirm Start.
+ * [MainActivity.ACTION_VOICE_NEW_THREAD] → system speech UI → confirm Start.
  */
 class VoiceThreadWidgetProvider : AppWidgetProvider() {
     override fun onUpdate(

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="shortcut_voice_new_thread_long">New thread from voice</string>
     <string name="widget_voice_new_thread_label">Voice thread</string>
     <string name="widget_voice_new_thread_description">Dictate a new Andy agent thread</string>
+    <string name="voice_recognizer_prompt">New Andy thread</string>
 </resources>

--- a/androidApp/src/main/res/xml/shortcuts.xml
+++ b/androidApp/src/main/res/xml/shortcuts.xml
@@ -10,6 +10,5 @@
             android:action="com.joetr.andy.action.VOICE_NEW_THREAD"
             android:targetPackage="com.joetr.andy"
             android:targetClass="com.joetr.andy.MainActivity" />
-        <categories android:name="android.shortcut.conversation" />
     </shortcut>
 </shortcuts>

--- a/androidApp/src/test/kotlin/com/joetr/andy/mobile/data/attention/AttentionSessionStartupTest.kt
+++ b/androidApp/src/test/kotlin/com/joetr/andy/mobile/data/attention/AttentionSessionStartupTest.kt
@@ -1,0 +1,33 @@
+package com.joetr.andy.mobile.data.attention
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttentionSessionStartupTest {
+    @Test
+    fun foregroundAndConnectionDoNotWaitForEncryptedPersistence() = runTest {
+        val persistenceStarted = CompletableDeferred<Unit>()
+        val releasePersistence = CompletableDeferred<Unit>()
+        var foregroundStarted = false
+        var connected = false
+
+        val persistence = startAttentionSession(
+            scope = backgroundScope,
+            persist = {
+                persistenceStarted.complete(Unit)
+                releasePersistence.await()
+            },
+            startForeground = { foregroundStarted = true },
+            connect = { connected = true },
+        )
+
+        assertTrue(foregroundStarted)
+        assertTrue(connected)
+        assertFalse(persistence.isCompleted)
+        persistenceStarted.await()
+        releasePersistence.complete(Unit)
+    }
+}

--- a/androidApp/src/test/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessLoadingTest.kt
+++ b/androidApp/src/test/kotlin/com/joetr/andy/mobile/data/networkaccess/NetworkAccessLoadingTest.kt
@@ -1,0 +1,85 @@
+package com.joetr.andy.mobile.data.networkaccess
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NetworkAccessLoadingTest {
+    @Test
+    fun webSocketUrlsUseUpgradeSchemes() {
+        assertEquals(
+            "ws://100.72.168.32:8565/ws/attention?token=session",
+            networkAccessWebSocketUrl(
+                "http://100.72.168.32:8565",
+                "/ws/attention?token=session",
+            ),
+        )
+        assertEquals(
+            "wss://andy.example.com/ws/chats/chat-id",
+            networkAccessWebSocketUrl(
+                "https://andy.example.com/",
+                "ws/chats/chat-id",
+            ),
+        )
+    }
+
+    @Test
+    fun projectAndChatListsStartTogether() = runTest {
+        val projectsStarted = CompletableDeferred<Unit>()
+        val chatsStarted = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        val loading = async {
+            loadProjectGroupsConcurrently(
+                loadProjects = {
+                    projectsStarted.complete(Unit)
+                    release.await()
+                    listOf(ProjectDto("project", "Project"))
+                },
+                loadChats = {
+                    chatsStarted.complete(Unit)
+                    release.await()
+                    listOf(ChatDto(id = "chat", projectId = "project"))
+                },
+            )
+        }
+
+        projectsStarted.await()
+        chatsStarted.await()
+        release.complete(Unit)
+
+        assertEquals(listOf("chat"), loading.await().single().chats.map { it.id })
+    }
+
+    @Test
+    fun chatDetailAndTranscriptSettingsStartTogether() = runTest {
+        val detailStarted = CompletableDeferred<Unit>()
+        val settingsStarted = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        val loading = async {
+            loadChatInitialDataConcurrently(
+                loadDetail = {
+                    detailStarted.complete(Unit)
+                    release.await()
+                    ChatDetailDto(chat = ChatDto(id = "chat"))
+                },
+                loadSettings = {
+                    settingsStarted.complete(Unit)
+                    release.await()
+                    TranscriptSettingsDto(showThinkingOnTimeline = true)
+                },
+            )
+        }
+
+        detailStarted.await()
+        settingsStarted.await()
+        release.complete(Unit)
+
+        val result = loading.await()
+        assertEquals("chat", result.detail.chat.id)
+        assertEquals(true, result.settings?.showThinkingOnTimeline)
+    }
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -119,7 +119,7 @@ kotlin {
                 implementation(project(":data:workspace"))
                 implementation(project(":data:platform-tools"))
                 implementation(compose.desktop.currentOs)
-                implementation(compose.material3)
+                implementation(libs.compose.material3)
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2")
                 implementation("io.github.kdroidfilter:composenativetray:1.3.3")
             }
@@ -127,8 +127,8 @@ kotlin {
         val wasmJsMain by getting {
             dependencies {
                 implementation(project(":core:di"))
-                implementation(compose.runtime)
-                implementation(compose.ui)
+                implementation(libs.compose.runtime)
+                implementation(libs.compose.ui)
                 implementation("org.jetbrains.kotlinx:kotlinx-browser:0.3")
                 implementation(npm("@yume-chan/adb", "2.6.0"))
                 implementation(npm("@yume-chan/adb-daemon-webusb", "2.3.2"))
@@ -532,6 +532,33 @@ compose.desktop {
         jvmArgs += "--add-exports=java.base/java.lang=ALL-UNNAMED"
         jvmArgs += "--add-exports=java.desktop/sun.awt=ALL-UNNAMED"
         jvmArgs += "--add-exports=java.desktop/sun.java2d=ALL-UNNAMED"
+
+        // --- Footprint ---
+        // Without an explicit -Xmx the JVM picks 25% of physical RAM (12g on a 48g Mac). G1 then
+        // sizes regions at 8m, never feels pressure, and parks ~470m of committed heap for a
+        // ~110m live set. Capping the ceiling is what makes every other knob here effective.
+        jvmArgs += "-Xms128m"
+        jvmArgs += "-Xmx768m"
+        // Let G1 hand pages back instead of hoarding them. Without the periodic GC the heap only
+        // shrinks on a full collection, which an idle desktop app never triggers.
+        jvmArgs += "-XX:MinHeapFreeRatio=10"
+        jvmArgs += "-XX:MaxHeapFreeRatio=25"
+        jvmArgs += "-XX:G1PeriodicGCInterval=15000"
+        jvmArgs += "-XX:G1PeriodicGCSystemLoadThreshold=0"
+        // 14 GC threads on a desktop UI app is all overhead: stacks plus per-thread GC structures.
+        jvmArgs += "-XX:ParallelGCThreads=4"
+        jvmArgs += "-XX:ConcGCThreads=2"
+        // Measured peak is ~23m across the segmented heaps; the 240m default just reserves address
+        // space and commits more than we ever JIT.
+        jvmArgs += "-XX:ReservedCodeCacheSize=96m"
+        // Class space actually uses ~8m. The 1g default reservation bloats the address space.
+        jvmArgs += "-XX:CompressedClassSpaceSize=256m"
+        // Diff text repeats heavily across stored agent runs.
+        jvmArgs += "-XX:+UseStringDeduplication"
+        // Netty defaults to 2*cores arenas of 16m chunks — server sizing for a loopback server.
+        jvmArgs += "-Dio.netty.allocator.numDirectArenas=2"
+        jvmArgs += "-Dio.netty.allocator.numHeapArenas=2"
+        jvmArgs += "-Dio.netty.allocator.maxOrder=6"
         buildTypes.release.proguard {
             isEnabled.set(false)
         }

--- a/composeApp/src/desktopMain/kotlin/app/andy/desktop/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/andy/desktop/Main.kt
@@ -148,11 +148,17 @@ fun main() {
             consumePendingOpen()
         }
         fun openMicPrivacySettings() {
-            runCatching {
-                ProcessBuilder(
-                    "open",
-                    "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
-                ).start()
+            // Prefer the modern Settings pane; fall back to the legacy Security URL.
+            val urls = listOf(
+                "x-apple.systempreferences:com.apple.Settings.PrivacySecurity.extension?Privacy_Microphone",
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+            )
+            for (url in urls) {
+                val started = runCatching {
+                    ProcessBuilder("open", url).start()
+                    true
+                }.getOrDefault(false)
+                if (started) break
             }
         }
         var voiceOverlayStopRequest by remember { mutableStateOf(0) }
@@ -162,11 +168,16 @@ fun main() {
             voiceOverlayBlocker = blocker
             voiceOverlayRecording = blocker == null
             voiceOverlayOpen = true
+            // Overlay is an Andy window — keep Carbon unregistered while it is up.
+            andyWindowFocused = true
         }
         fun closeVoiceOverlay() {
             voiceOverlayOpen = false
             voiceOverlayRecording = false
             voiceOverlayBlocker = null
+            // Overlay was an Andy window; keep Carbon off until the main WindowAdapter
+            // reports deactivation (avoids briefly re-arming while Andy is still key).
+            andyWindowFocused = true
         }
         fun handleVoiceNewThreadHotKey() {
             // Never open/close windows synchronously inside a key or Carbon callback —
@@ -615,6 +626,24 @@ fun main() {
                     }
                 },
             ) {
+                DisposableEffect(window) {
+                    val listener = object : java.awt.event.WindowAdapter() {
+                        override fun windowActivated(event: java.awt.event.WindowEvent) {
+                            andyWindowFocused = true
+                        }
+
+                        override fun windowDeactivated(event: java.awt.event.WindowEvent) {
+                            // Only clear when the overlay is still the open Andy surface;
+                            // closing sets andyWindowFocused=true in closeVoiceOverlay.
+                            if (voiceOverlayOpen) {
+                                andyWindowFocused = false
+                            }
+                        }
+                    }
+                    window.addWindowListener(listener)
+                    andyWindowFocused = true
+                    onDispose { window.removeWindowListener(listener) }
+                }
                 AndyTheme {
                     VoiceNewThreadOverlayContent(
                         services = services,

--- a/composeApp/src/desktopMain/kotlin/app/andy/desktop/voice/VoiceNewThreadOverlay.kt
+++ b/composeApp/src/desktopMain/kotlin/app/andy/desktop/voice/VoiceNewThreadOverlay.kt
@@ -64,6 +64,7 @@ import app.andy.ui.theme.MonoFont
 import app.andy.ui.theme.Rust
 import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /** Why the overlay opened without starting capture. */
@@ -128,6 +129,7 @@ fun VoiceNewThreadOverlayContent(
     var projectId by remember { mutableStateOf(workspaceState.voiceDefaultProjectId) }
     var starting by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
+    var finishJob by remember { mutableStateOf<Job?>(null) }
 
     val cliStatuses by services.agentRuns.cliStatuses.collectAsState()
     val providerModels by services.agentRuns.providerModels.collectAsState()
@@ -139,28 +141,58 @@ fun VoiceNewThreadOverlayContent(
     }
     val projects = actionsConfig.projects
 
+    fun recordingStartFailureBlocker(): VoiceNewThreadBlocker {
+        val err = voice.lastError.value
+        return when {
+            err?.contains("Already recording", ignoreCase = true) == true ->
+                VoiceNewThreadBlocker.ComposerRecording
+            err?.contains("Microphone", ignoreCase = true) == true ->
+                VoiceNewThreadBlocker.MicDenied
+            else -> VoiceNewThreadBlocker.Other(err ?: "Could not start recording")
+        }
+    }
+
+    /** Starts capture and keeps [onRecordingChanged] in sync so the hotkey can stop. */
+    fun beginListening() {
+        blocker = null
+        phase = VoiceNewThreadPhase.Recording
+        scope.launch {
+            onRecordingChanged(true)
+            val started = voice.startRecording()
+            if (!started) {
+                blocker = recordingStartFailureBlocker()
+                onRecordingChanged(false)
+                phase = VoiceNewThreadPhase.Blocked
+            }
+        }
+    }
+
     fun stopAndConfirm() {
         if (phase != VoiceNewThreadPhase.Recording) return
         phase = VoiceNewThreadPhase.Transcribing
         onRecordingChanged(false)
-        scope.launch {
-            val text = voice.finishRecording()
-            if (!text.isNullOrBlank()) {
-                transcript = text
-                val matched = matchProject(
-                    text,
-                    projects.map { it.id to it.name },
-                )
-                if (matched != null) projectId = matched
-                phase = VoiceNewThreadPhase.Confirm
-            } else {
-                val err = voice.lastError.value
-                blocker = when {
-                    err?.contains("Microphone", ignoreCase = true) == true ->
-                        VoiceNewThreadBlocker.MicDenied
-                    else -> VoiceNewThreadBlocker.Other(err ?: "No speech detected")
+        finishJob = scope.launch {
+            try {
+                val text = voice.finishRecording()
+                if (!text.isNullOrBlank()) {
+                    transcript = text
+                    val matched = matchProject(
+                        text,
+                        projects.map { it.id to it.name },
+                    )
+                    if (matched != null) projectId = matched
+                    phase = VoiceNewThreadPhase.Confirm
+                } else {
+                    val err = voice.lastError.value
+                    blocker = when {
+                        err?.contains("Microphone", ignoreCase = true) == true ->
+                            VoiceNewThreadBlocker.MicDenied
+                        else -> VoiceNewThreadBlocker.Other(err ?: "No speech detected")
+                    }
+                    phase = VoiceNewThreadPhase.Blocked
                 }
-                phase = VoiceNewThreadPhase.Blocked
+            } finally {
+                finishJob = null
             }
         }
     }
@@ -170,18 +202,11 @@ fun VoiceNewThreadOverlayContent(
         // Let the overlay window finish its first layout pass before touching audio —
         // starting capture in the same frame as window creation has frozen the EDT.
         kotlinx.coroutines.delay(64)
-        if (phase == VoiceNewThreadPhase.Recording) {
+        if (phase == VoiceNewThreadPhase.Recording && blocker == null) {
             onRecordingChanged(true)
             val started = voice.startRecording()
             if (!started) {
-                val err = voice.lastError.value
-                blocker = when {
-                    err?.contains("Already recording", ignoreCase = true) == true ->
-                        VoiceNewThreadBlocker.ComposerRecording
-                    err?.contains("Microphone", ignoreCase = true) == true ->
-                        VoiceNewThreadBlocker.MicDenied
-                    else -> VoiceNewThreadBlocker.Other(err ?: "Could not start recording")
-                }
+                blocker = recordingStartFailureBlocker()
                 onRecordingChanged(false)
                 phase = VoiceNewThreadPhase.Blocked
             }
@@ -195,11 +220,21 @@ fun VoiceNewThreadOverlayContent(
     }
 
     fun cancel() {
-        if (phase == VoiceNewThreadPhase.Recording) voice.cancelRecording()
+        when (phase) {
+            VoiceNewThreadPhase.Recording -> voice.cancelRecording()
+            VoiceNewThreadPhase.Transcribing -> {
+                finishJob?.cancel()
+                // Clears isBusy if recording already stopped mid-transcribe.
+                voice.cancelRecording()
+            }
+            else -> Unit
+        }
+        onRecordingChanged(false)
         onClose()
     }
 
     fun startThread() {
+        if (starting) return
         val prompt = transcript.trim()
         if (prompt.isBlank()) {
             error = "Transcript is empty"
@@ -271,19 +306,7 @@ fun VoiceNewThreadOverlayContent(
                     onOpenSettings = onOpenSettings,
                     onOpenMicPrivacySettings = onOpenMicPrivacySettings,
                     onDismiss = onClose,
-                    onTryAgain = {
-                        blocker = null
-                        phase = VoiceNewThreadPhase.Recording
-                        scope.launch {
-                            val started = voice.startRecording()
-                            if (!started) {
-                                blocker = VoiceNewThreadBlocker.Other(
-                                    voice.lastError.value ?: "Could not start recording",
-                                )
-                                phase = VoiceNewThreadPhase.Blocked
-                            }
-                        }
-                    },
+                    onTryAgain = { beginListening() },
                 )
                 VoiceNewThreadPhase.Recording -> {
                     Text(
@@ -399,6 +422,7 @@ private fun BlockedBody(
         blocker != null -> blocker
         else -> VoiceNewThreadBlocker.Other("Voice is not ready")
     }
+    var awaitingReady by remember { mutableStateOf(false) }
     val message: String
     val actionLabel: String
     val action: () -> Unit
@@ -429,15 +453,21 @@ private fun BlockedBody(
             action = onTryAgain
         }
     }
+    LaunchedEffect(setupState, awaitingReady) {
+        if (awaitingReady && setupState is VoiceSetupState.Ready) {
+            awaitingReady = false
+            onTryAgain()
+        }
+    }
     Text(message, color = TextSecondary, fontSize = 13.sp)
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         OutlinedButton(onClick = {
-            action()
             if (effective is VoiceNewThreadBlocker.NotEnabled ||
                 effective is VoiceNewThreadBlocker.Failed
             ) {
-                // After Enable/Retry, attempt capture once setup reports Ready.
+                awaitingReady = true
             }
+            action()
         }) { Text(actionLabel) }
         TextButton(onClick = onOpenSettings) { Text("Open Settings", color = TextSecondary) }
         TextButton(onClick = onDismiss) { Text("Close", color = TextSecondary) }

--- a/composeApp/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
+++ b/composeApp/src/desktopTest/kotlin/app/andy/ScreenshotServices.kt
@@ -121,6 +121,7 @@ internal object ScreenshotServices {
         override suspend fun reconnect(rememberPassword: Boolean) = Result.success(Unit)
         override suspend fun addSavedTarget(target: String) = Unit
         override suspend fun removeSavedTarget(target: String) = Unit
+        override suspend fun renameSavedTargetAlias(target: String, alias: String) = Unit
         override suspend fun saveRemoteActionsConfig(config: ActionsConfig) = Result.success(Unit)
         override suspend fun forwardPort(remotePort: Int) = Result.success(remotePort)
         override suspend fun openRemoteScreen() = Result.success("Opened Screen Sharing")
@@ -770,6 +771,7 @@ internal object ScreenshotServices {
             skills: List<AgentSkill>,
             contextBundleIds: List<String>,
             provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
         ) = Unit
         override fun reattachSession(taskId: String) = Unit
         override fun canReattachSession(taskId: String): Boolean = false
@@ -783,6 +785,7 @@ internal object ScreenshotServices {
             skills: List<AgentSkill>,
             contextBundleIds: List<String>,
             provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
         ) = Unit
         override fun removeQueuedFollowUp(taskId: String, queueIndex: Int) = Unit
         override fun sendQueuedFollowUp(taskId: String, queueIndex: Int) = Unit

--- a/core/di/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
+++ b/core/di/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
@@ -892,6 +892,7 @@ private fun createEmbeddedDesktopRuntime(): DesktopRuntime {
         localLocalServers = localLocalServers,
         agentRunsForLocalServers = swappableAgents,
         actionRunsForLocalServers = actionRuns,
+        localAttachments = chatAttachmentService,
     )
     remoteShellRef.set { remoteSession.shellEndpoint() }
     val agentRetention = DesktopAgentRetentionService(

--- a/core/di/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
+++ b/core/di/src/desktopMain/kotlin/app/andy/desktop/service/DesktopServices.kt
@@ -16,6 +16,7 @@ import app.andy.desktop.service.agents.CursorAdapter
 import app.andy.desktop.service.agents.DesktopAgentRunService
 import app.andy.desktop.service.agents.DesktopAgentRetentionService
 import app.andy.desktop.service.agents.DesktopAgentTaskStore
+import app.andy.desktop.service.agents.DesktopChatAttachmentService
 import app.andy.desktop.service.agents.DesktopOrchestrationPreferencesService
 import app.andy.desktop.service.agents.defaultAndyAgentArtifactsDir
 import app.andy.desktop.service.agents.registerArchiveViewShutdownHook
@@ -213,6 +214,7 @@ fun createDaemonRuntime(
     )
 
     val agentTaskStore = DesktopAgentTaskStore()
+    val chatAttachmentService = DesktopChatAttachmentService()
     val agentRuns = DesktopAgentRunService(
         scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
         store = agentTaskStore,
@@ -233,6 +235,7 @@ fun createDaemonRuntime(
         workspaceStore = store,
         actionConfig = actionConfig,
         terminalMode = AgentTerminalMode.TmuxHeadless,
+        chatAttachments = chatAttachmentService,
     )
     val automations = DesktopAutomationService(
         store = agentTaskStore,
@@ -245,7 +248,7 @@ fun createDaemonRuntime(
         actionRuns = actionRuns,
         andyVersion = { AndyBuildInfo.versionName },
     ).also { it.attachAgentEvents(agentRuns) }
-    mcp.bindAgentServices(agentRuns, agentRuns, automations, plugins)
+    mcp.bindAgentServices(agentRuns, agentRuns, automations, plugins, chatAttachmentService)
     val agentRetention = DesktopAgentRetentionService(
         runService = agentRuns,
         store = agentTaskStore,
@@ -294,6 +297,7 @@ fun createDaemonRuntime(
         crashInspector = crashInspector,
         heapDump = heapDump,
         evidence = evidenceService,
+        chatAttachments = chatAttachmentService,
         workspaceStore = store,
         updates = DesktopAppUpdateService(CoroutineScope(SupervisorJob() + Dispatchers.Default)),
         runtimeBundle = DesktopRuntimeBundleService(),
@@ -499,9 +503,11 @@ private fun createDesktopClientRuntime(): DesktopRuntime {
 
     val socket = File(System.getProperty("user.home"), ".andy/andyd.sock")
     val agentScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    val chatAttachmentService = DesktopChatAttachmentService()
     val remoteAgents = McpAgentRunClient(
         scope = agentScope,
         socketPath = socket,
+        localAttachments = chatAttachmentService,
     )
     // Attach-only terminal host: must not open ~/.andy/agents.db. andyd owns that
     // store; a second writer silently reverts chats / unread badges on GUI quit.
@@ -581,6 +587,7 @@ private fun createDesktopClientRuntime(): DesktopRuntime {
         localLocalServers = localLocalServers,
         agentRunsForLocalServers = swappableAgents,
         actionRunsForLocalServers = actionRuns,
+        localAttachments = chatAttachmentService,
     )
     remoteShellRef.set { remoteSession.shellEndpoint() }
 
@@ -644,6 +651,7 @@ private fun createDesktopClientRuntime(): DesktopRuntime {
         crashInspector = crashInspector,
         heapDump = heapDump,
         evidence = evidenceService,
+        chatAttachments = chatAttachmentService,
         workspaceStore = store,
         updates = updates,
         runtimeBundle = runtimeBundle,
@@ -775,6 +783,7 @@ private fun createEmbeddedDesktopRuntime(): DesktopRuntime {
     )
 
     val agentTaskStore = DesktopAgentTaskStore()
+    val chatAttachmentService = DesktopChatAttachmentService()
     val agentScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     val agentRuns = DesktopAgentRunService(
         scope = agentScope,
@@ -795,6 +804,7 @@ private fun createEmbeddedDesktopRuntime(): DesktopRuntime {
         mcp = mcp,
         workspaceStore = store,
         actionConfig = actionConfig,
+        chatAttachments = chatAttachmentService,
     )
     val automations = DesktopAutomationService(
         store = agentTaskStore,
@@ -807,7 +817,7 @@ private fun createEmbeddedDesktopRuntime(): DesktopRuntime {
         actionRuns = actionRuns,
         andyVersion = { AndyBuildInfo.versionName },
     ).also { it.attachAgentEvents(agentRuns) }
-    mcp.bindAgentServices(agentRuns, agentRuns, automations, plugins)
+    mcp.bindAgentServices(agentRuns, agentRuns, automations, plugins, chatAttachmentService)
     plugins.runStartupHooks()
     val attachStoreDir = File(System.getProperty("java.io.tmpdir"), "andy-gui-attach").also { it.mkdirs() }
     val localAttach = DesktopAgentRunService(
@@ -953,6 +963,7 @@ private fun createEmbeddedDesktopRuntime(): DesktopRuntime {
         crashInspector = crashInspector,
         heapDump = heapDump,
         evidence = evidenceService,
+        chatAttachments = chatAttachmentService,
         workspaceStore = store,
         updates = updates,
         runtimeBundle = runtimeBundle,

--- a/data/agents/build.gradle.kts
+++ b/data/agents/build.gradle.kts
@@ -129,6 +129,7 @@ kotlin {
             implementation(libs.ktor.server.sse)
             implementation(libs.ktor.server.double.receive)
             implementation(libs.ktor.server.websockets)
+            implementation(libs.ktor.server.compression)
             implementation(libs.web.push)
             implementation(libs.bouncycastle)
             implementation(libs.httpclient)
@@ -136,7 +137,7 @@ kotlin {
             implementation(libs.tomlkt)
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
-            implementation(compose.ui)
+            implementation(libs.compose.ui)
         }
         desktopTest.dependencies {
             implementation(project(":agent-store"))

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/ChatSubscribeSupport.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/ChatSubscribeSupport.kt
@@ -1,6 +1,8 @@
 package app.andy.desktop.service
 
 import app.andy.domain.excludingTemporary
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentAttachmentKind
 import app.andy.model.AgentEvent
 import app.andy.model.AgentStatus
 import app.andy.service.AgentRunService
@@ -28,6 +30,12 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
@@ -99,6 +107,58 @@ internal fun parseImagePathsArg(args: Map<String, JsonElement>): List<String> {
         primitive.content
     }
     return validateImagePaths(paths)
+}
+
+/** Parses managed attachment descriptors (never bodies) from MCP chat tool args. */
+internal fun parseAttachmentsArg(args: Map<String, JsonElement>): List<AgentAttachment> {
+    val element = args["attachments"] ?: return emptyList()
+    val array = element as? JsonArray
+        ?: error("attachments must be an array of objects")
+    return array.mapIndexed { index, item ->
+        val obj = item as? JsonObject
+            ?: error("attachments[$index] must be an object")
+        val id = obj["id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            ?: error("attachments[$index].id required")
+        if (!id.matches(Regex("^[A-Za-z0-9._-]{1,128}$"))) {
+            error("attachments[$index].id is invalid")
+        }
+        val displayName = obj["displayName"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            ?: error("attachments[$index].displayName required")
+        val byteCount = obj["byteCount"]?.jsonPrimitive?.longOrNull
+            ?: error("attachments[$index].byteCount required")
+        val sha256 = obj["sha256"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            ?: error("attachments[$index].sha256 required")
+        if (!sha256.matches(Regex("^[a-fA-F0-9]{64}$"))) {
+            error("attachments[$index].sha256 is invalid")
+        }
+        AgentAttachment(
+            id = id,
+            displayName = displayName,
+            kind = AgentAttachmentKind.entries.firstOrNull {
+                it.name.equals(obj["kind"]?.jsonPrimitive?.contentOrNull, ignoreCase = true)
+            } ?: AgentAttachmentKind.Text,
+            mediaType = obj["mediaType"]?.jsonPrimitive?.contentOrNull
+                ?: "text/plain; charset=utf-8",
+            byteCount = byteCount,
+            lineCount = obj["lineCount"]?.jsonPrimitive?.longOrNull?.takeIf { it > 0 },
+            sha256 = sha256.lowercase(),
+            // Inbound MCP/Web mutations must not select an arbitrary path — materialize from
+            // the managed staging id only. Persisted relativePath is set by the host after
+            // materialization.
+            relativePath = null,
+        )
+    }
+}
+
+internal fun attachmentDescriptorJson(attachment: AgentAttachment): JsonObject = buildJsonObject {
+    put("id", attachment.id)
+    put("displayName", attachment.displayName)
+    put("kind", attachment.kind.name)
+    put("mediaType", attachment.mediaType)
+    put("byteCount", attachment.byteCount)
+    attachment.lineCount?.let { put("lineCount", it) }
+    put("sha256", attachment.sha256)
+    attachment.relativePath?.let { put("relativePath", it) }
 }
 
 /**

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/DesktopMcpServerService.kt
@@ -12,6 +12,7 @@ import io.ktor.server.routing.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.plugins.doublereceive.*
+import io.ktor.server.plugins.compression.*
 import io.ktor.server.websocket.WebSockets
 import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.server.*
@@ -85,6 +86,7 @@ class DesktopMcpServerService(
     private var projectWorkflows: ProjectWorkflowService? = null
     private var automations: AutomationService? = null
     private var plugins: PluginService? = null
+    private var chatAttachments: ChatAttachmentService? = null
     private val hub = McpHubService()
 
     /**
@@ -99,11 +101,13 @@ class DesktopMcpServerService(
         projects: ProjectWorkflowService,
         automations: AutomationService = UnavailableAutomationService,
         plugins: PluginService = UnavailablePluginService,
+        chatAttachments: ChatAttachmentService = UnavailableChatAttachmentService,
     ) {
         agentRuns = agents
         projectWorkflows = projects
         this.automations = automations
         this.plugins = plugins
+        this.chatAttachments = chatAttachments
         attentionHub.startWatching(agents)
         webPush.startWatching(attentionHub)
     }
@@ -226,6 +230,7 @@ class DesktopMcpServerService(
             val engine = embeddedServer(Netty, host = host, port = port) {
                 install(DoubleReceive)
                 install(WebSockets)
+                install(Compression)
                 installNetworkAccessSecurityHeaders()
                 install(NetworkAccessAuthPlugin) {
                     sessionStore = networkAccessSessions
@@ -270,6 +275,7 @@ class DesktopMcpServerService(
                     projectWorkflows = { projectWorkflows },
                     actionConfig = { actionConfig },
                     workspaceStore = { workspaceStore },
+                    chatAttachments = { chatAttachments },
                     push = webPush,
                     attention = attentionHub,
                     networkAccess = webConfig,
@@ -485,6 +491,7 @@ class DesktopMcpServerService(
                 projects,
                 callerTaskId = callerTaskId?.takeIf { it.isNotBlank() },
                 automations = automations ?: UnavailableAutomationService,
+                chatAttachments = chatAttachments ?: UnavailableChatAttachmentService,
             )
         }
         mcpServer.registerPluginTools(plugins ?: UnavailablePluginService)

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
@@ -19,6 +19,8 @@ import app.andy.model.permissionSandbox
 import app.andy.model.AgentModelCatalog
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskDraft
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentAttachmentKind
 import app.andy.model.importedThreadTitle
 import app.andy.model.withImportedVendorSession
 import app.andy.model.LocalAgentRuntime
@@ -33,8 +35,10 @@ import app.andy.model.ContextualActionKind
 import app.andy.model.ProjectSpecDraft
 import app.andy.service.AgentRunService
 import app.andy.service.AutomationService
+import app.andy.service.ChatAttachmentService
 import app.andy.service.ProjectWorkflowService
 import app.andy.service.UnavailableAutomationService
+import app.andy.service.UnavailableChatAttachmentService
 import app.andy.terminal.TmuxAndy
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
@@ -63,6 +67,40 @@ private val ImagePathsSchema = buildJsonObject {
     )
 }
 
+private val AttachmentsSchema = buildJsonObject {
+    put("type", "array")
+    put(
+        "description",
+        "Managed text attachment descriptors previously staged via chat.attachment_* upload tools " +
+            "(id, displayName, byteCount, sha256, optional lineCount/relativePath). Never include bodies.",
+    )
+    put(
+        "items",
+        buildJsonObject {
+            put("type", "object")
+            put(
+                "properties",
+                buildJsonObject {
+                    put("id", buildJsonObject { put("type", "string") })
+                    put("displayName", buildJsonObject { put("type", "string") })
+                    put("kind", buildJsonObject { put("type", "string") })
+                    put("mediaType", buildJsonObject { put("type", "string") })
+                    put("byteCount", buildJsonObject { put("type", "number") })
+                    put("lineCount", buildJsonObject { put("type", "number") })
+                    put("sha256", buildJsonObject { put("type", "string") })
+                    put("relativePath", buildJsonObject { put("type", "string") })
+                },
+            )
+            put("required", buildJsonArray {
+                add(JsonPrimitive("id"))
+                add(JsonPrimitive("displayName"))
+                add(JsonPrimitive("byteCount"))
+                add(JsonPrimitive("sha256"))
+            })
+        },
+    )
+}
+
 /** MCP argument keys that would smuggle a raw filesystem path in place of a managed evidence bundle id. */
 private val DisallowedRawPathKeys = listOf("evidencePath", "evidencePaths", "filePath", "filePaths", "localPath")
 
@@ -84,6 +122,7 @@ fun Server.registerAgentProjectTools(
     projectWorkflows: ProjectWorkflowService,
     callerTaskId: String? = null,
     automations: AutomationService = UnavailableAutomationService,
+    chatAttachments: ChatAttachmentService = UnavailableChatAttachmentService,
 ) {
     fun register(
         name: String,
@@ -578,6 +617,7 @@ fun Server.registerAgentProjectTools(
                 put("description", "Managed evidence bundle ids (§4) to attach; never raw filesystem paths")
             },
             "imagePaths" to ImagePathsSchema,
+            "attachments" to AttachmentsSchema,
             "provenance" to buildJsonObject {
                 put("type", "object")
                 put(
@@ -592,7 +632,8 @@ fun Server.registerAgentProjectTools(
         rejectRawEvidencePaths(args)
         val vendorSessionId = str(args, "vendorSessionId")?.trim()?.takeIf { it.isNotBlank() }
         val prompt = str(args, "prompt").orEmpty()
-        if (prompt.isBlank() && vendorSessionId == null) error("prompt required")
+        val attachments = parseAttachmentsArg(args)
+        if (prompt.isBlank() && vendorSessionId == null && attachments.isEmpty()) error("prompt required")
         val agentName = str(args, "agent") ?: error("agent required")
         val agent = AgentKind.entries.firstOrNull {
             it.name.equals(agentName, ignoreCase = true) ||
@@ -663,6 +704,7 @@ fun Server.registerAgentProjectTools(
                         ?: error("unknown lane; expected ACP or Terminal")
                 },
                 imagePaths = imagePaths,
+                attachments = attachments,
                 contextBundleIds = strList(args, "contextBundleIds"),
                 provenance = parseProvenance(args),
                 vendorSessionId = vendorSessionId,
@@ -876,6 +918,7 @@ fun Server.registerAgentProjectTools(
                 put("description", "Managed evidence bundle ids (§4) to attach; never raw filesystem paths")
             },
             "imagePaths" to ImagePathsSchema,
+            "attachments" to AttachmentsSchema,
         ),
         required = listOf("taskId", "followUp"),
     ) { args ->
@@ -883,11 +926,13 @@ fun Server.registerAgentProjectTools(
         val id = str(args, "taskId") ?: error("taskId required")
         val followUp = str(args, "followUp") ?: error("followUp required")
         val imagePaths = parseImagePathsArg(args)
+        val attachments = parseAttachmentsArg(args)
         agentRuns.resume(
             id,
             followUp,
             imagePaths = imagePaths,
             contextBundleIds = strList(args, "contextBundleIds"),
+            attachments = attachments,
         )
         textResult("""{"ok":true,"id":"$id"}""")
     }
@@ -904,6 +949,7 @@ fun Server.registerAgentProjectTools(
                 put("description", "Managed evidence bundle ids (§4) to attach; never raw filesystem paths")
             },
             "imagePaths" to ImagePathsSchema,
+            "attachments" to AttachmentsSchema,
         ),
         required = listOf("taskId", "followUp"),
     ) { args ->
@@ -911,6 +957,7 @@ fun Server.registerAgentProjectTools(
         val id = str(args, "taskId") ?: error("taskId required")
         val followUp = str(args, "followUp") ?: error("followUp required")
         val imagePaths = parseImagePathsArg(args)
+        val attachments = parseAttachmentsArg(args)
         val queuedBefore = agentRuns.tasks.value.excludingTemporary()
             .firstOrNull { it.id == id }
             ?.queuedFollowUps
@@ -921,6 +968,7 @@ fun Server.registerAgentProjectTools(
             followUp,
             imagePaths = imagePaths,
             contextBundleIds = strList(args, "contextBundleIds"),
+            attachments = attachments,
         )
         val queuedAfter = agentRuns.tasks.value.excludingTemporary()
             .firstOrNull { it.id == id }
@@ -1380,6 +1428,86 @@ fun Server.registerAgentProjectTools(
     }
 
     registerAutomationTools(automations, agentRuns, callerTaskId)
+
+    register(
+        name = "chat.attachment_begin",
+        description = "Begin a chunked managed text-attachment upload. Pass the returned uploadId to append/commit.",
+        properties = mapOf(
+            "displayName" to buildJsonObject { put("type", "string") },
+            "byteCount" to buildJsonObject { put("type", "number") },
+            "sha256" to buildJsonObject { put("type", "string") },
+            "mediaType" to buildJsonObject { put("type", "string") },
+            "draftKey" to buildJsonObject { put("type", "string") },
+        ),
+        required = listOf("displayName", "byteCount", "sha256"),
+    ) { args ->
+        val displayName = str(args, "displayName") ?: error("displayName required")
+        val byteCount = args["byteCount"]?.jsonPrimitive?.longOrNull
+            ?: error("byteCount required")
+        val sha256 = str(args, "sha256") ?: error("sha256 required")
+        val session = chatAttachments.beginUpload(
+            displayName = displayName,
+            byteCount = byteCount,
+            sha256 = sha256,
+            mediaType = str(args, "mediaType") ?: "text/plain; charset=utf-8",
+            draftKey = str(args, "draftKey"),
+        ).getOrElse { error(it.message ?: "begin upload failed") }
+        textResult(
+            buildJsonObject {
+                put("uploadId", session.uploadId)
+                put("displayName", session.displayName)
+                put("expectedBytes", session.expectedBytes)
+                put("expectedSha256", session.expectedSha256)
+            }.toString(),
+        )
+    }
+
+    register(
+        name = "chat.attachment_append",
+        description = "Append a Base64 chunk to an in-progress managed text-attachment upload.",
+        properties = mapOf(
+            "uploadId" to buildJsonObject { put("type", "string") },
+            "sequence" to buildJsonObject { put("type", "number") },
+            "base64Chunk" to buildJsonObject { put("type", "string") },
+        ),
+        required = listOf("uploadId", "sequence", "base64Chunk"),
+    ) { args ->
+        val uploadId = str(args, "uploadId") ?: error("uploadId required")
+        val sequence = args["sequence"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+            ?: args["sequence"]?.jsonPrimitive?.longOrNull?.toInt()
+            ?: error("sequence required")
+        val chunk = str(args, "base64Chunk") ?: error("base64Chunk required")
+        chatAttachments.appendUploadChunk(uploadId, sequence, chunk)
+            .getOrElse { error(it.message ?: "append failed") }
+        textResult("""{"ok":true,"uploadId":"$uploadId","sequence":$sequence}""")
+    }
+
+    register(
+        name = "chat.attachment_commit",
+        description = "Finalize a managed text-attachment upload and return its descriptor.",
+        properties = mapOf(
+            "uploadId" to buildJsonObject { put("type", "string") },
+        ),
+        required = listOf("uploadId"),
+    ) { args ->
+        val uploadId = str(args, "uploadId") ?: error("uploadId required")
+        val attachment = chatAttachments.commitUpload(uploadId)
+            .getOrElse { error(it.message ?: "commit failed") }
+        textResult(attachmentDescriptorJson(attachment).toString())
+    }
+
+    register(
+        name = "chat.attachment_cancel",
+        description = "Cancel an in-progress managed text-attachment upload, or discard a committed-but-unsent staged attachment, deleting its bytes.",
+        properties = mapOf(
+            "uploadId" to buildJsonObject { put("type", "string") },
+        ),
+        required = listOf("uploadId"),
+    ) { args ->
+        val uploadId = str(args, "uploadId") ?: error("uploadId required")
+        val cancelled = chatAttachments.cancelUpload(uploadId)
+        textResult("""{"ok":$cancelled,"uploadId":"$uploadId"}""")
+    }
 }
 
 /**
@@ -1464,6 +1592,10 @@ fun agentProjectToolNames(): List<String> = listOf(
     "chat.delete",
     "chat.resume",
     "chat.queue_follow_up",
+    "chat.attachment_begin",
+    "chat.attachment_append",
+    "chat.attachment_commit",
+    "chat.attachment_cancel",
     "chat.remove_queued_follow_up",
     "chat.send_queued_follow_up",
     "chat.send_next_queued_follow_up",

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentTools.kt
@@ -44,6 +44,7 @@ import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -436,6 +437,34 @@ fun Server.registerAgentProjectTools(
         val id = str(args, "taskId") ?: error("taskId required")
         val events = agentRuns.events(id).value
         textResult(buildJsonArray { events.forEach { add(it.toWire()) } }.toString())
+    }
+
+    register(
+        name = "chat.search",
+        description = "Search transcript body text across chats (user/assistant text and tool titles)",
+        properties = mapOf(
+            "query" to buildJsonObject { put("type", "string") },
+        ),
+        required = listOf("query"),
+    ) { args ->
+        val query = str(args, "query") ?: error("query required")
+        val hits = agentRuns.searchTranscripts(query).toList()
+        textResult(
+            buildJsonArray {
+                hits.forEach { hit ->
+                    add(
+                        buildJsonObject {
+                            put("taskId", hit.taskId)
+                            hit.projectId?.let { put("projectId", it) }
+                            put("title", hit.title)
+                            hit.projectName?.let { put("projectName", it) }
+                            put("snippet", hit.snippet)
+                            put("atMillis", hit.atMillis)
+                        },
+                    )
+                }
+            }.toString(),
+        )
     }
 
     register(

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpClientConfig.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/McpClientConfig.kt
@@ -6,6 +6,8 @@ import java.io.File
 import kotlinx.serialization.json.*
 
 object McpClientConfig {
+    private val prettyJson = Json { prettyPrint = true }
+
     enum class ClientType(val label: String) {
         ClaudeCode("Claude Code"),
         Cursor("Cursor"),
@@ -283,7 +285,7 @@ object McpClientConfig {
         }
         if (!changed) return content
         val updated = json.toMutableMap().apply { this[rootKey] = JsonObject(block) }
-        return Json { prettyPrint = true }.encodeToString(JsonObject.serializer(), JsonObject(updated))
+        return prettyJson.encodeToString(JsonObject.serializer(), JsonObject(updated))
     }
 
     internal fun stripTomlMcpServers(content: String, ids: Set<String>): String {
@@ -340,7 +342,6 @@ object McpClientConfig {
         val updated = json.toMutableMap().apply {
             this["mcpServers"] = JsonObject(mcpServers)
         }
-        val prettyJson = Json { prettyPrint = true }
         return prettyJson.encodeToString(JsonObject.serializer(), JsonObject(updated))
     }
 
@@ -362,7 +363,6 @@ object McpClientConfig {
                 this["${'$'}schema"] = JsonPrimitive("https://opencode.ai/config.json")
             }
         }
-        val prettyJson = Json { prettyPrint = true }
         return prettyJson.encodeToString(JsonObject.serializer(), JsonObject(updated))
     }
 
@@ -399,7 +399,6 @@ object McpClientConfig {
         val updated = json.toMutableMap().apply {
             this["mcpServers"] = JsonObject(servers)
         }
-        val prettyJson = Json { prettyPrint = true }
         return prettyJson.encodeToString(JsonObject.serializer(), JsonObject(updated))
     }
 
@@ -411,8 +410,7 @@ object McpClientConfig {
             put("url", "http://127.0.0.1:$port/mcp-http")
             putMcpAuthHeaders(bearerToken)
         }
-        val pretty = Json { prettyPrint = true }
-        return pretty.encodeToString(JsonObject.serializer(), JsonObject(json.toMutableMap().apply { this["mcp"] = JsonObject(mcp) }))
+        return prettyJson.encodeToString(JsonObject.serializer(), JsonObject(json.toMutableMap().apply { this["mcp"] = JsonObject(mcp) }))
     }
 
     internal fun mergeHermesYaml(content: String, port: Int, bearerToken: String? = null): String {

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentRunService.kt
@@ -18,6 +18,7 @@ import app.andy.model.AgentModelOption
 import app.andy.model.AgentProviderDefaults
 import app.andy.model.AgentMessageDeliveryMode
 import app.andy.model.AgentQueuedFollowUp
+import app.andy.model.AgentAttachment
 import app.andy.model.AgentProviderQuota
 import app.andy.model.AgentQuotaSource
 import app.andy.model.AgentQuotaAccess
@@ -26,6 +27,7 @@ import app.andy.model.AgentSkill
 import app.andy.model.AgentSlashCommand
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskDraft
+import app.andy.model.TranscriptSearchHit
 import app.andy.model.AgentToolKind
 import app.andy.model.AgentToolState
 import app.andy.model.AcpToolCallPresentation
@@ -98,6 +100,7 @@ import app.andy.model.TerminalAppearanceSnapshot
 import app.andy.model.toTerminalAppearance
 import app.andy.terminal.TmuxAndy
 import app.andy.service.ActionConfigStore
+import app.andy.service.ChatAttachmentService
 import app.andy.service.CommandResult
 import app.andy.service.AgentRunService
 import app.andy.service.McpServerService
@@ -112,10 +115,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -169,6 +175,7 @@ class DesktopAgentRunService(
     private val ownsAgentSessions: Boolean = true,
     /** Managed evidence bundle root (§4), mirroring [app.andy.desktop.service.DesktopInvestigationEvidenceService]. */
     private val evidenceRootDir: File = File(System.getProperty("user.home"), ".andy/evidence"),
+    private val chatAttachments: ChatAttachmentService = DesktopChatAttachmentService(),
 ) : AgentRunService, ProjectWorkflowService {
     private class TaskHandle(
         @Volatile var job: Job? = null,
@@ -282,6 +289,9 @@ class DesktopAgentRunService(
     private val eventFlows = ConcurrentHashMap<String, MutableStateFlow<List<AgentEvent>>>()
     private val emptyEvents = MutableStateFlow<List<AgentEvent>>(emptyList())
     private val acpTranscriptStore = AcpTranscriptStore(::resolvedTranscriptFile)
+    private val transcriptSearch by lazy {
+        store.transcriptSearchIndex(::resolvedTranscriptFile)
+    }
     private val acpManager = AgentAcpManager(
         scope = scope,
         binaryFor = ::binaryFor,
@@ -336,9 +346,20 @@ class DesktopAgentRunService(
             // A crash skips the shutdown hook, so a previous session's disposable directory can
             // survive. Only stale roots are swept, so a second running instance is untouched.
             withContext(Dispatchers.IO) { runCatching { TemporaryChatArtifacts.sweepOrphans() } }
+            // Drop abandoned composer staging so ~/.andy/attachments-staging cannot grow forever.
+            withContext(Dispatchers.IO) { runCatching { chatAttachments.expireAbandonedStaging() } }
             refreshCliStatuses()
             refreshSlashCommandsForReadyProviders()
             watchLocalModelSettings()
+            scope.launch(Dispatchers.IO) {
+                runCatching {
+                    transcriptSearch.backfill(
+                        _tasks.value
+                            .sortedByDescending { it.finishedAtMillis ?: it.createdAtMillis }
+                            .map { it.id },
+                    )
+                }
+            }
             if (enableProbes) {
                 refreshProviderQuotas()
                 while (isActive) {
@@ -1360,6 +1381,7 @@ class DesktopAgentRunService(
             fastMode = draft.fastMode,
             openClawNewSession = if (importedVendorSession != null) false else draft.openClawNewSession,
             imagePaths = draft.imagePaths,
+            attachments = draft.attachments,
             skills = draft.skills.filter { it.path in discoveredSkillPaths },
             goal = draft.goal,
             maxBudgetUsd = draft.maxBudgetUsd,
@@ -1470,10 +1492,26 @@ class DesktopAgentRunService(
                 task = task.copy(evidenceLocalPathsHint = evidenceSuffix)
             }
         }
+        if (task.attachments.isNotEmpty()) {
+            val materialized = try {
+                withContext(Dispatchers.IO) {
+                    chatAttachments.materializeForTask(task.id, task.cwd, task.attachments)
+                }
+            } catch (error: Exception) {
+                throw IllegalStateException(
+                    error.message?.takeIf { it.isNotBlank() } ?: "Failed to prepare text attachment",
+                    error,
+                )
+            }
+            task = task.copy(attachments = materialized)
+        }
         upsertTask(task)
         rememberTemporaryWorkflowDir(task)
         persist()
-        val initialPrompt = task.promptForCli().takeIf { it.isNotBlank() && importedVendorSession == null }
+        val rawInitialPrompt = task.promptForCli().takeIf { it.isNotBlank() && importedVendorSession == null }
+        val initialPrompt = rawInitialPrompt?.let { prompt ->
+            withContext(Dispatchers.IO) { chatAttachments.spilloverPromptIfNeeded(task.id, task.cwd, prompt) }
+        }
         // Prefer argv/flag delivery when the CLI supports it (agy --prompt-interactive,
         // claude/codex/cursor positional). PTY typing is a fragile fallback.
         val writeAfterStart = initialPrompt.takeUnless { adapter.embedsInitialPrompt }
@@ -1486,11 +1524,22 @@ class DesktopAgentRunService(
             quietResume = importedVendorSession != null,
         ) { nextAdapter, resolvedBinary, mcpUrl ->
             val current = currentTask(task.id) ?: task
-            if (importedVendorSession != null) {
-                nextAdapter.buildInteractiveResumeCommand(resolvedBinary, current, mcpUrl)
-                    ?: nextAdapter.buildInteractiveCommand(resolvedBinary, current, mcpUrl)
+            // When the prompt spilled to a file, adapters that embed argv still need the short hint.
+            val forArgv = if (
+                adapter.embedsInitialPrompt &&
+                initialPrompt != null &&
+                rawInitialPrompt != null &&
+                initialPrompt != rawInitialPrompt
+            ) {
+                current.copy(continuationPrompt = initialPrompt)
             } else {
-                nextAdapter.buildInteractiveCommand(resolvedBinary, current, mcpUrl)
+                current
+            }
+            if (importedVendorSession != null) {
+                nextAdapter.buildInteractiveResumeCommand(resolvedBinary, forArgv, mcpUrl)
+                    ?: nextAdapter.buildInteractiveCommand(resolvedBinary, forArgv, mcpUrl)
+            } else {
+                nextAdapter.buildInteractiveCommand(resolvedBinary, forArgv, mcpUrl)
             }
         }
         return task
@@ -1518,17 +1567,43 @@ class DesktopAgentRunService(
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
     ) {
+        scope.launch(Dispatchers.IO) {
+            resumePrepared(
+                taskId = taskId,
+                followUp = followUp,
+                imagePaths = imagePaths,
+                skills = skills,
+                contextBundleIds = contextBundleIds,
+                provenance = provenance,
+                attachments = attachments,
+            )
+        }
+    }
+
+    override suspend fun resumePrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         failedReattachTaskIds.remove(taskId)
-        var existing = currentTask(taskId) ?: return
-        if (existing.userInputRequest != null) return
+        var existing = currentTask(taskId) ?: return@withContext Result.failure(IllegalStateException("Unknown task"))
+        if (existing.userInputRequest != null) {
+            return@withContext Result.failure(IllegalStateException("Chat is waiting for user input"))
+        }
         val scheduledRecovery = taskId in scheduledConnectionRecoveryResumes
         if (!scheduledRecovery && existing.connectionRecovery != null) {
             // Any explicit user continuation takes precedence over a delayed automatic one.
             connectionRecoveryJobs.remove(taskId)?.cancel()
             updateTask(taskId) { current -> current.copy(connectionRecovery = null) }
-            existing = currentTask(taskId) ?: return
-            scope.launch { persist() }
+            existing = currentTask(taskId)
+                ?: return@withContext Result.failure(IllegalStateException("Unknown task"))
+            persist()
         }
         // Keep the chat's original provenance; a contextual follow-up only fills an empty one.
         val task = if (provenance != null && existing.provenance == null) {
@@ -1536,16 +1611,59 @@ class DesktopAgentRunService(
         } else {
             existing
         }
-
         _lastUsedAgent.value = task.agent
-
         val skillDirectory = task.worktreePath ?: task.cwd
         val selectedSkills = skills.filter { skill ->
-            this.skills(task.runtimeKind(), skillDirectory).value.any { it.path == skill.path }
+            this@DesktopAgentRunService.skills(task.runtimeKind(), skillDirectory).value.any { it.path == skill.path }
         }
+        val materialized = try {
+            if (attachments.isNotEmpty()) {
+                chatAttachments.materializeForTask(taskId, task.cwd, attachments)
+            } else {
+                emptyList()
+            }
+        } catch (error: Exception) {
+            reportAttachmentFailure(taskId, error)
+            return@withContext Result.failure(error)
+        }
+        // Provider turn continues asynchronously; attachment readiness is what callers await.
+        scope.launch(Dispatchers.IO) {
+            resumeWithAttachments(
+                taskId = taskId,
+                followUp = followUp,
+                imagePaths = imagePaths,
+                selectedSkills = selectedSkills,
+                contextBundleIds = contextBundleIds,
+                attachments = materialized,
+            )
+        }
+        Result.success(Unit)
+    }
+
+    private suspend fun resumeWithAttachments(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        selectedSkills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        attachments: List<AgentAttachment>,
+    ) {
+        val task = currentTask(taskId) ?: return
         if (task.lane == AgentLaneKind.Acp) {
-            val acpFollowUp = task.followUpCliPayload(followUp, imagePaths, selectedSkills).prompt
-            appendEvents(taskId, listOf(AgentEvent.UserMessage(System.currentTimeMillis(), followUp, selectedSkills, imagePaths)))
+            val raw = task.followUpCliPayload(followUp, imagePaths, selectedSkills, attachments).prompt
+            val acpFollowUp = chatAttachments.spilloverPromptIfNeeded(taskId, task.cwd, raw)
+            appendEvents(
+                taskId,
+                listOf(
+                    AgentEvent.UserMessage(
+                        System.currentTimeMillis(),
+                        followUp,
+                        selectedSkills,
+                        imagePaths,
+                        attachments,
+                    ),
+                ),
+            )
             updateTask(taskId) {
                 it.copy(
                     status = AgentStatus.Working,
@@ -1556,36 +1674,53 @@ class DesktopAgentRunService(
                     latestPrompt = followUp.trim().ifBlank { it.latestPrompt },
                 )
             }
-            scope.launch(Dispatchers.IO) {
-                // PlanReady "Implement" flips plan mode then resumes; wait for setMode first.
-                acpPlanModeSyncJobs.remove(taskId)?.join()
-                val success = runAcpFollowUp(taskId, acpFollowUp, imagePaths)
-                // ACP-capable providers stay on ACP. A failed resume must not demote to terminal.
-                if (!success) {
-                    val current = currentTask(taskId) ?: return@launch
-                    if (current.status == AgentStatus.Working || current.status == null) {
-                        finishTask(
-                            taskId = taskId,
-                            status = AgentStatus.Error,
-                            exitCode = null,
-                            error = current.errorMessage ?: "ACP session failed to resume",
-                            statusConfident = true,
-                        )
-                    }
+            // PlanReady "Implement" flips plan mode then resumes; wait for setMode first.
+            acpPlanModeSyncJobs.remove(taskId)?.join()
+            val success = runAcpFollowUp(taskId, acpFollowUp, imagePaths)
+            // ACP-capable providers stay on ACP. A failed resume must not demote to terminal.
+            if (!success) {
+                val current = currentTask(taskId) ?: return
+                if (current.status == AgentStatus.Working || current.status == null) {
+                    finishTask(
+                        taskId = taskId,
+                        status = AgentStatus.Error,
+                        exitCode = null,
+                        error = current.errorMessage ?: "ACP session failed to resume",
+                        statusConfident = true,
+                    )
                 }
             }
             return
         }
 
-        val adapter = adapters[existing.runtimeKind()] ?: return
+        resumeTerminalFollowUp(
+            taskId = taskId,
+            followUp = followUp,
+            imagePaths = imagePaths,
+            selectedSkills = selectedSkills,
+            contextBundleIds = contextBundleIds,
+            attachments = attachments,
+        )
+    }
 
-        val followUpCli = task.followUpCliPayload(followUp, imagePaths, selectedSkills)
-        val followUpForCli = followUpCli.prompt
+    private suspend fun resumeTerminalFollowUp(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        selectedSkills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        attachments: List<AgentAttachment>,
+    ) {
+        val task = currentTask(taskId) ?: return
+        val adapter = adapters[task.runtimeKind()] ?: return
+
+        val followUpCli = task.followUpCliPayload(followUp, imagePaths, selectedSkills, attachments)
+        val followUpForCli = chatAttachments.spilloverPromptIfNeeded(taskId, task.cwd, followUpCli.prompt)
         val followUpImagePathsForCli = followUpCli.imagePaths
 
         if (terminals.isAlive(taskId)) {
             val now = System.currentTimeMillis()
-            appendEvents(taskId, listOf(AgentEvent.UserMessage(now, followUp, selectedSkills, imagePaths)))
+            appendEvents(taskId, listOf(AgentEvent.UserMessage(now, followUp, selectedSkills, imagePaths, attachments)))
             updateTask(taskId) {
                 it.copy(
                     status = AgentStatus.Working,
@@ -1595,15 +1730,14 @@ class DesktopAgentRunService(
                     unread = false,
                 )
             }
-            val liveText = task.followUpPromptForLiveTerminal(followUp, imagePaths, selectedSkills)
-            scope.launch {
-                // A tmux session can outlive the app that spawned it. Mount a viewer before
-                // typing so a chat resumed from read-only replay comes back interactive.
-                attachTerminalIfNeeded(taskId)
-                val evidenceSuffix = withContext(Dispatchers.IO) { materializeTaskEvidence(taskId, contextBundleIds) }
-                terminals.write(taskId, liveText + evidenceSuffix)
-                persist()
-            }
+            val liveText = task.followUpPromptForLiveTerminal(followUp, imagePaths, selectedSkills, attachments)
+            // A tmux session can outlive the app that spawned it. Mount a viewer before
+            // typing so a chat resumed from read-only replay comes back interactive.
+            attachTerminalIfNeeded(taskId)
+            val evidenceSuffix = materializeTaskEvidence(taskId, contextBundleIds)
+            val spilledLive = chatAttachments.spilloverPromptIfNeeded(taskId, task.cwd, liveText + evidenceSuffix)
+            terminals.write(taskId, spilledLive)
+            persist()
             return
         }
 
@@ -1635,7 +1769,7 @@ class DesktopAgentRunService(
         }.getOrNull()
 
         val now = System.currentTimeMillis()
-        appendEvents(taskId, listOf(AgentEvent.UserMessage(now, followUp, selectedSkills, imagePaths)))
+        appendEvents(taskId, listOf(AgentEvent.UserMessage(now, followUp, selectedSkills, imagePaths, attachments)))
         val resolvedCwd = AgentScratchWorkspace.resolveCwd(taskForResume.cwd)
         val queued = taskForResume.copy(
             cwd = resolvedCwd,
@@ -1647,48 +1781,46 @@ class DesktopAgentRunService(
             unread = false,
         )
         upsertTask(queued)
-        scope.launch {
-            persist()
-            val evidenceSuffix = withContext(Dispatchers.IO) { materializeTaskEvidence(taskId, contextBundleIds) }
-            val enrichedFollowUp = followUpForCli + evidenceSuffix
-            if (resumeArgv == null) {
-                // Provider cannot resume (missing vendor session). Start a fresh
-                // interactive session that still includes the original Andy prompt.
-                val seeded = composeResumePrompt(
-                    originalPrompt = queued.promptForCli(),
-                    followUp = enrichedFollowUp,
-                    boundToConversation = false,
-                ) ?: enrichedFollowUp
-                val writeAfterStart = seeded.takeUnless { adapter.embedsInitialPrompt }
-                launchRunAwaitingTerminal(queued, writeAfterStart = writeAfterStart) { nextAdapter, binary, mcpUrl ->
-                    val current = currentTask(taskId) ?: queued
-                    nextAdapter.buildInteractiveCommand(
-                        binary,
-                        current.copy(
-                            prompt = seeded,
-                            imagePaths = if (current.agent == AgentKind.Codex) {
-                                (current.imagePaths + followUpImagePathsForCli).distinct()
-                            } else {
-                                current.imagePaths
-                            },
-                        ),
-                        mcpUrl,
-                    )
-                }
-                return@launch
-            }
-            // Await the PTY so the detail pane remounts the live terminal instead of
-            // staying on the "session ended" placeholder until a manual refresh.
-            val writeAfterStart = enrichedFollowUp.takeUnless { adapter.embedsResumePrompt }
-            launchRunAwaitingTerminal(queued, writeAfterStart = writeAfterStart) { resumeAdapter, binary, mcpUrl ->
-                resumeAdapter.buildInteractiveResumeCommand(
+        persist()
+        val evidenceSuffix = materializeTaskEvidence(taskId, contextBundleIds)
+        val enrichedFollowUp = followUpForCli + evidenceSuffix
+        if (resumeArgv == null) {
+            // Provider cannot resume (missing vendor session). Start a fresh
+            // interactive session that still includes the original Andy prompt.
+            val seeded = composeResumePrompt(
+                originalPrompt = queued.promptForCli(),
+                followUp = enrichedFollowUp,
+                boundToConversation = false,
+            ) ?: enrichedFollowUp
+            val writeAfterStart = seeded.takeUnless { adapter.embedsInitialPrompt }
+            launchRunAwaitingTerminal(queued, writeAfterStart = writeAfterStart) { nextAdapter, binary, mcpUrl ->
+                val current = currentTask(taskId) ?: queued
+                nextAdapter.buildInteractiveCommand(
                     binary,
-                    currentTask(taskId) ?: queued,
+                    current.copy(
+                        prompt = seeded,
+                        imagePaths = if (current.agent == AgentKind.Codex) {
+                            (current.imagePaths + followUpImagePathsForCli).distinct()
+                        } else {
+                            current.imagePaths
+                        },
+                    ),
                     mcpUrl,
-                    enrichedFollowUp,
-                    followUpImagePathsForCli,
-                ) ?: error("interactive resume not supported")
+                )
             }
+            return
+        }
+        // Await the PTY so the detail pane remounts the live terminal instead of
+        // staying on the "session ended" placeholder until a manual refresh.
+        val writeAfterStart = enrichedFollowUp.takeUnless { adapter.embedsResumePrompt }
+        launchRunAwaitingTerminal(queued, writeAfterStart = writeAfterStart) { resumeAdapter, binary, mcpUrl ->
+            resumeAdapter.buildInteractiveResumeCommand(
+                binary,
+                currentTask(taskId) ?: queued,
+                mcpUrl,
+                enrichedFollowUp,
+                followUpImagePathsForCli,
+            ) ?: error("interactive resume not supported")
         }
     }
 
@@ -1937,26 +2069,65 @@ class DesktopAgentRunService(
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
     ) {
-        val task = currentTask(taskId) ?: return
+        scope.launch(Dispatchers.IO) {
+            queueFollowUpPrepared(
+                taskId = taskId,
+                followUp = followUp,
+                imagePaths = imagePaths,
+                skills = skills,
+                contextBundleIds = contextBundleIds,
+                provenance = provenance,
+                attachments = attachments,
+            )
+        }
+    }
+
+    override suspend fun queueFollowUpPrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        val task = currentTask(taskId)
+            ?: return@withContext Result.failure(IllegalStateException("Unknown task"))
         val preferQueue = agentMessageDeliveryMode() == AgentMessageDeliveryMode.Queue
         // Leftover queue rows (e.g. after stop) must stay FIFO even if the workspace
         // was later switched to Immediate — never drop or jump the line.
         val hasQueued = task.queuedFollowUps.isNotEmpty()
-        if (!task.isActive && !isLaneLive(taskId) && !preferQueue && !hasQueued) return
+        if (!task.isActive && !isLaneLive(taskId) && !preferQueue && !hasQueued) {
+            return@withContext Result.failure(IllegalStateException("Chat is not ready for a follow-up"))
+        }
 
         val text = followUp.trim()
-        if (text.isBlank() && imagePaths.isEmpty()) return
+        if (text.isBlank() && imagePaths.isEmpty() && attachments.isEmpty()) {
+            return@withContext Result.failure(IllegalStateException("Follow-up is empty"))
+        }
         val skillDirectory = task.worktreePath ?: task.cwd
         val selectedSkills = skills.filter { skill ->
-            this.skills(task.runtimeKind(), skillDirectory).value.any { it.path == skill.path }
+            this@DesktopAgentRunService.skills(task.runtimeKind(), skillDirectory).value.any { it.path == skill.path }
         }
 
         if (!preferQueue && !hasQueued) {
             if (task.lane == AgentLaneKind.Acp && acpManager.isAlive(taskId)) {
+                val materialized = try {
+                    if (attachments.isNotEmpty()) {
+                        chatAttachments.materializeForTask(taskId, task.cwd, attachments)
+                    } else {
+                        emptyList()
+                    }
+                } catch (error: Exception) {
+                    reportAttachmentFailure(taskId, error)
+                    return@withContext Result.failure(error)
+                }
                 val now = System.currentTimeMillis()
-                val acpPrompt = task.followUpCliPayload(text, imagePaths, selectedSkills).prompt
-                appendEvents(taskId, listOf(AgentEvent.UserMessage(now, text, selectedSkills, imagePaths)))
+                val raw = task.followUpCliPayload(text, imagePaths, selectedSkills, materialized).prompt
+                val acpPrompt = chatAttachments.spilloverPromptIfNeeded(taskId, task.cwd, raw)
+                appendEvents(taskId, listOf(AgentEvent.UserMessage(now, text, selectedSkills, imagePaths, materialized)))
                 updateTask(taskId) { current ->
                     current.copy(
                         status = AgentStatus.Working,
@@ -1966,37 +2137,49 @@ class DesktopAgentRunService(
                     )
                 }
                 scope.launch(Dispatchers.IO) { runAcpFollowUp(taskId, acpPrompt, imagePaths) }
-                return
+                return@withContext Result.success(Unit)
             }
 
             if (terminals.isAlive(taskId)) {
-                val now = System.currentTimeMillis()
-                appendEvents(taskId, listOf(AgentEvent.UserMessage(now, text, selectedSkills, imagePaths)))
-                updateTask(taskId) { current -> current.copy(latestPrompt = text.ifBlank { current.latestPrompt }) }
-                val liveText = task.followUpPromptForLiveTerminal(text, imagePaths, selectedSkills)
-                scope.launch {
-                    val evidenceSuffix = withContext(Dispatchers.IO) { materializeTaskEvidence(taskId, contextBundleIds) }
-                    terminals.write(taskId, liveText + evidenceSuffix)
+                val materialized = try {
+                    if (attachments.isNotEmpty()) {
+                        chatAttachments.materializeForTask(taskId, task.cwd, attachments)
+                    } else {
+                        emptyList()
+                    }
+                } catch (error: Exception) {
+                    reportAttachmentFailure(taskId, error)
+                    return@withContext Result.failure(error)
                 }
-                return
+                val now = System.currentTimeMillis()
+                appendEvents(taskId, listOf(AgentEvent.UserMessage(now, text, selectedSkills, imagePaths, materialized)))
+                updateTask(taskId) { current -> current.copy(latestPrompt = text.ifBlank { current.latestPrompt }) }
+                val liveText = task.followUpPromptForLiveTerminal(text, imagePaths, selectedSkills, materialized)
+                val evidenceSuffix = materializeTaskEvidence(taskId, contextBundleIds)
+                val spilled = chatAttachments.spilloverPromptIfNeeded(taskId, task.cwd, liveText + evidenceSuffix)
+                terminals.write(taskId, spilled)
+                return@withContext Result.success(Unit)
             }
 
             if (task.isActive && !isLaunchInProgress(taskId)) {
-                resume(taskId, text, imagePaths, selectedSkills, contextBundleIds, provenance)
-                return
+                return@withContext resumePrepared(
+                    taskId, text, imagePaths, selectedSkills, contextBundleIds, provenance, attachments,
+                )
             }
         } else if (!task.isActive && !isLaunchInProgress(taskId) && !hasQueued) {
-            resume(taskId, text, imagePaths, selectedSkills, contextBundleIds, provenance)
-            return
+            return@withContext resumePrepared(
+                taskId, text, imagePaths, selectedSkills, contextBundleIds, provenance, attachments,
+            )
         }
 
-        enqueueFollowUp(
+        enqueueFollowUpPrepared(
             taskId = taskId,
             text = text,
             imagePaths = imagePaths,
             selectedSkills = selectedSkills,
             contextBundleIds = contextBundleIds,
             provenance = provenance,
+            attachments = attachments,
         )
     }
 
@@ -2015,6 +2198,7 @@ class DesktopAgentRunService(
             next.skills,
             next.contextBundleIds,
             next.provenance,
+            next.attachments,
         )
     }
 
@@ -2038,7 +2222,45 @@ class DesktopAgentRunService(
         selectedSkills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment> = emptyList(),
     ) {
+        scope.launch(Dispatchers.IO) {
+            enqueueFollowUpPrepared(
+                taskId = taskId,
+                text = text,
+                imagePaths = imagePaths,
+                selectedSkills = selectedSkills,
+                contextBundleIds = contextBundleIds,
+                provenance = provenance,
+                attachments = attachments,
+            )
+        }
+    }
+
+    private suspend fun enqueueFollowUpPrepared(
+        taskId: String,
+        text: String,
+        imagePaths: List<String>,
+        selectedSkills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
+    ): Result<Unit> {
+        val task = currentTask(taskId)
+            ?: return Result.failure(IllegalStateException("Unknown task"))
+        val materialized = try {
+            if (attachments.isNotEmpty()) {
+                chatAttachments.materializeForTask(taskId, task.cwd, attachments)
+            } else {
+                emptyList()
+            }
+        } catch (error: Exception) {
+            reportAttachmentFailure(taskId, error)
+            return Result.failure(error)
+        }
+        if (contextBundleIds.isNotEmpty()) {
+            materializeTaskEvidence(taskId, contextBundleIds)
+        }
         updateTask(taskId) { current ->
             current.copy(
                 latestPrompt = text.ifBlank { current.latestPrompt },
@@ -2048,18 +2270,24 @@ class DesktopAgentRunService(
                     imagePaths = imagePaths,
                     skills = selectedSkills,
                     contextBundleIds = contextBundleIds,
+                    attachments = materialized,
                     provenance = provenance,
                 ),
             )
         }
-        // Copy evidence into task-local storage at queue time (not just at run time) so it
-        // survives even if the shared managed bundle is deleted before this follow-up runs.
-        scope.launch {
-            if (contextBundleIds.isNotEmpty()) {
-                withContext(Dispatchers.IO) { materializeTaskEvidence(taskId, contextBundleIds) }
-            }
-            persist()
-        }
+        persist()
+        return Result.success(Unit)
+    }
+
+    private suspend fun reportAttachmentFailure(taskId: String, error: Throwable) {
+        val message = error.message?.takeIf { it.isNotBlank() }
+            ?: "Failed to prepare text attachment"
+        appendEvents(
+            taskId,
+            listOf(AgentEvent.TaskError(System.currentTimeMillis(), message)),
+        )
+        updateTask(taskId) { current -> current.copy(errorMessage = message) }
+        persist()
     }
 
     fun agentMessageDeliveryMode(): AgentMessageDeliveryMode =
@@ -2091,6 +2319,7 @@ class DesktopAgentRunService(
             connectionRecovery = null,
         )
         store.deleteTaskArtifacts(taskId)
+        runCatching { transcriptSearch.removeTask(taskId) }
         connectionRecoveryJobs.remove(taskId)?.cancel()
         eventFlows[taskId]?.value = emptyList()
         upsertTask(retried)
@@ -2745,7 +2974,8 @@ class DesktopAgentRunService(
         }
         onTerminalStarted()
         ensureAcpArtifactMonitor(taskId, started.artifacts)
-        val acpPrompt = writeAfterStart?.takeIf { it.isNotBlank() } ?: launchTask.promptForCli()
+        val acpPromptRaw = writeAfterStart?.takeIf { it.isNotBlank() } ?: launchTask.promptForCli()
+        val acpPrompt = chatAttachments.spilloverPromptIfNeeded(taskId, launchTask.cwd, acpPromptRaw)
         if (launchTask.continuationPrompt != null) {
             updateTask(taskId) { current ->
                 if (current.continuationPrompt == launchTask.continuationPrompt) {
@@ -2756,10 +2986,18 @@ class DesktopAgentRunService(
             }
             persist()
         }
-        val userFacingPrompt = launchTask.continuationPrompt?.takeIf { it.isNotBlank() } ?: launchTask.prompt
+        val userFacingPrompt = launchTask.prompt
         appendEvents(
             taskId,
-            listOf(AgentEvent.UserMessage(System.currentTimeMillis(), userFacingPrompt, launchTask.skills, launchTask.imagePaths)),
+            listOf(
+                AgentEvent.UserMessage(
+                    System.currentTimeMillis(),
+                    userFacingPrompt,
+                    launchTask.skills,
+                    launchTask.imagePaths,
+                    launchTask.attachments,
+                ),
+            ),
         )
         val success = acpManager.prompt(taskId, acpPrompt, launchTask.imagePaths)
         if (!success) {
@@ -3433,7 +3671,18 @@ class DesktopAgentRunService(
             }
         }
         store.deleteTaskArtifacts(taskId)
-        if (task.temporary) discardTemporaryArtifacts(task)
+        scope.launch(Dispatchers.IO) { runCatching { transcriptSearch.removeTask(taskId) } }
+        // Managed attachments / workflow files live under <cwd>/.andy/<taskId>/ — remove only
+        // this task's directory so sibling chats keep their artifacts.
+        if (task.temporary) {
+            discardTemporaryArtifacts(task)
+        } else {
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    AgentWorkflowArtifacts.dirFor(task.cwd?.let(::File), task.id).deleteRecursively()
+                }
+            }
+        }
         task.workflowTaskId?.let { projectTaskId -> detachDeletedWorkflowRun(projectTaskId, taskId) }
         if (removeWorktree && task.ownsWorktree && worktreePath != null) {
             task.originDir?.let { originDir ->
@@ -3553,6 +3802,22 @@ class DesktopAgentRunService(
             }
         }
     }
+
+    override fun searchTranscripts(query: String): Flow<TranscriptSearchHit> = flow {
+        val projectNames = runCatching {
+            actionConfig.load().projects.associate { it.id to it.name }
+        }.getOrDefault(emptyMap())
+        val refs = _tasks.value.map { task ->
+            DesktopTranscriptSearchIndex.TaskRef(
+                taskId = task.id,
+                projectId = task.projectId,
+                title = task.title,
+                projectName = task.projectId?.let(projectNames::get),
+                updatedAtMillis = task.finishedAtMillis ?: task.createdAtMillis,
+            )
+        }
+        transcriptSearch.search(query, refs).collect { emit(it) }
+    }.flowOn(Dispatchers.IO)
 
     override fun interactiveResumeCommand(taskId: String): String? {
         val task = currentTask(taskId) ?: return null
@@ -3702,7 +3967,9 @@ class DesktopAgentRunService(
         val changeEvent = fileChangesEventsForUndo(taskId, task)
             .lastOrNull { it.batchId == batchId && !it.undone }
             ?: return CommandResult.failure("edit batch not found")
-        val snapshot = enrichedUndoSnapshot(cwd, changeEvent.baselineTree, changeEvent.snapshot)
+        // Batch snapshots come from the ACP transcript already hydrated, so the diffsHydrated
+        // guard inside keeps this from consulting the task-level stored diffs.
+        val snapshot = enrichedUndoSnapshot(taskId, cwd, changeEvent.baselineTree, changeEvent.snapshot)
         worktrees.restorePaths(cwd, changeEvent.baselineTree, snapshot)
             .getOrElse { return CommandResult.failure(it.message ?: "undo failed") }
         if (task.lane == AgentLaneKind.Acp) {
@@ -3731,7 +3998,7 @@ class DesktopAgentRunService(
         if (snapshot.summary.files.isEmpty()) {
             return@withContext CommandResult.failure("nothing to undo")
         }
-        val enriched = enrichedUndoSnapshot(cwd, baseline, snapshot)
+        val enriched = enrichedUndoSnapshot(taskId, cwd, baseline, snapshot)
         worktrees.restorePaths(cwd, baseline, enriched)
             .getOrElse { return@withContext CommandResult.failure(it.message ?: "undo failed") }
         updateTask(taskId) { t ->
@@ -3757,12 +4024,29 @@ class DesktopAgentRunService(
             .distinctBy { it.batchId }
     }
 
-    private fun enrichedUndoSnapshot(
+    /**
+     * Diffs for a task whose snapshot may have come off disk summary-only. Returns the in-memory
+     * diffs when they are already hydrated, otherwise reads them from the store.
+     */
+    private suspend fun hydratedDiffs(task: AgentTask): Map<String, AgentFileDiff> {
+        val changes = task.completedChanges ?: return emptyMap()
+        if (changes.diffsHydrated) return changes.diffs
+        return store.loadCompletedDiffs(task.id)
+    }
+
+    private suspend fun enrichedUndoSnapshot(
+        taskId: String,
         cwd: String,
         baselineTree: String,
         snapshot: AgentThreadChangeSnapshot,
     ): AgentThreadChangeSnapshot {
         if (snapshot.diffs.isNotEmpty()) return snapshot
+        // Prefer the diffs captured when the chat finished: recomputing against the current tree
+        // can fold in later repository edits, which is exactly what completedChanges guards against.
+        if (!snapshot.diffsHydrated) {
+            val stored = store.loadCompletedDiffs(taskId)
+            if (stored.isNotEmpty()) return snapshot.copy(diffs = stored, diffsHydrated = true)
+        }
         val paths = snapshot.summary.files.map { it.path }
         return worktrees.changeSnapshot(cwd, baselineTree, paths) ?: snapshot
     }
@@ -4485,6 +4769,8 @@ class DesktopAgentRunService(
         scratchpad: String?,
         previousFeedback: List<String>,
         previousReviewRun: AgentTask?,
+        /** Hydrated by the caller: stored snapshots arrive summary-only. */
+        previousReviewDiffs: Map<String, AgentFileDiff>,
     ): String = buildString {
         append("Implement the frozen plan below in the current project workspace. The linked verifier decides when this build is complete.\n\n")
         append("Implementation plan (source: ").append(build.planSnapshot?.sourceLabel ?: "unknown").append("):\n")
@@ -4495,9 +4781,9 @@ class DesktopAgentRunService(
             append("\n\nThe previous quality gate requested changes. Fix every finding:\n")
             previousFeedback.forEach { append("- ").append(it).append('\n') }
         }
-        previousReviewRun?.completedChanges?.let { changes ->
+        previousReviewRun?.completedChanges?.let {
             append("\n\nWorkspace diff produced by the previous Review:\n")
-            changes.diffs.values.forEach { diff ->
+            previousReviewDiffs.values.forEach { diff ->
                 append("--- ").append(diff.path).append('\n')
                 if (diff.isBinary) {
                     append("(binary file changed)\n")
@@ -4658,7 +4944,11 @@ class DesktopAgentRunService(
         }
         val previousReviewRun = lastReviewFailure?.runId?.let(::currentTask)
             ?.takeIf { (lastReviewFailure.createdAtMillis) > (lastVerificationFailure?.createdAtMillis ?: Long.MIN_VALUE) }
-        val prompt = buildPrompt(build, scratchpad, feedback, previousReviewRun)
+        val previousReviewDiffs = previousReviewRun
+            ?.takeIf { it.completedChanges != null }
+            ?.let { hydratedDiffs(it) }
+            .orEmpty()
+        val prompt = buildPrompt(build, scratchpad, feedback, previousReviewRun, previousReviewDiffs)
         updateProjectTask(build.id) { it.copy(state = ProjectTaskState.Queued, lastError = null, updatedAtMillis = System.currentTimeMillis()) }
         linkedReview?.let { item ->
             updateProjectTask(item.id) {
@@ -5856,9 +6146,22 @@ class DesktopAgentRunService(
             previousProviderTitle = event.title.trim()
         }
         if (isAcp) {
+            var shouldReindex = false
             accepted.forEach { event ->
-                if (event is AgentEvent.ToolCall) acpTranscriptStore.upsert(taskId, event)
-                else acpTranscriptStore.append(taskId, event)
+                if (event is AgentEvent.ToolCall) {
+                    acpTranscriptStore.upsert(taskId, event)
+                    shouldReindex = true
+                } else {
+                    acpTranscriptStore.append(taskId, event)
+                    if (DesktopTranscriptSearchIndex.searchableText(event) != null) {
+                        shouldReindex = true
+                    }
+                }
+            }
+            if (shouldReindex) {
+                scope.launch(Dispatchers.IO) {
+                    runCatching { transcriptSearch.reindexTask(taskId) }
+                }
             }
         }
         flow.update { existing ->

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStore.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStore.kt
@@ -1,6 +1,8 @@
 package app.andy.desktop.service.agents
 
 import app.andy.model.AgentAutonomy
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentAttachmentKind
 import app.andy.model.AgentContextualProvenance
 import app.andy.model.AgentConnectionRecovery
 import app.andy.model.AgentConnectionRecoveryReason
@@ -86,6 +88,10 @@ class DesktopAgentTaskStore(
     private val legacyTomlFile: File get() = File(databaseFile.parentFile, "agents.toml")
     private val sqlite by lazy { SqliteAgentStore(dbFile = databaseFile) }
 
+    /** Cmd+K transcript FTS index; [transcriptFileFor] should resolve compressed archives. */
+    fun transcriptSearchIndex(transcriptFileFor: (String) -> File): DesktopTranscriptSearchIndex =
+        sqlite.transcriptSearchIndex(transcriptFileFor)
+
     fun taskDir(taskId: String): File = File(transcriptsDir, taskId)
 
     fun archiveFile(taskId: String): File = File(taskDir(taskId), "archive.zip")
@@ -151,6 +157,13 @@ class DesktopAgentTaskStore(
         databaseFile.parentFile?.mkdirs()
         sqlite.save(state, allowEmptyTaskList)
     }
+
+    /**
+     * Stored diffs for one task. [load] returns snapshots summary-only to keep ~80MB of diff text
+     * off the heap, so the diff UI fetches them here when a chat's changes are actually opened.
+     */
+    suspend fun loadCompletedDiffs(taskId: String): Map<String, AgentFileDiff> =
+        withContext(Dispatchers.IO) { sqlite.loadTaskDiffs(taskId) }
 
     fun loadAllKanbanBoards(): Map<String, KanbanBoard> = sqlite.loadAllKanbanBoards()
 
@@ -278,6 +291,7 @@ internal data class AgentTaskDto(
     val fastMode: Boolean = false,
     val openClawNewSession: Boolean = true,
     val imagePaths: List<String> = emptyList(),
+    val attachments: List<AgentAttachmentDto> = emptyList(),
     val skillNames: List<String> = emptyList(),
     val skillPaths: List<String> = emptyList(),
     val goal: String = "",
@@ -537,7 +551,42 @@ internal data class AgentQueuedFollowUpDto(
     val skillNames: List<String> = emptyList(),
     val skillPaths: List<String> = emptyList(),
     val contextBundleIds: List<String> = emptyList(),
+    val attachments: List<AgentAttachmentDto> = emptyList(),
     val provenance: AgentContextualProvenanceDto? = null,
+)
+
+@Serializable
+internal data class AgentAttachmentDto(
+    val id: String,
+    val displayName: String,
+    val kind: String = "Text",
+    val mediaType: String = "text/plain; charset=utf-8",
+    val byteCount: Long = 0,
+    val lineCount: Long = 0,
+    val sha256: String = "",
+    val relativePath: String = "",
+)
+
+internal fun AgentAttachmentDto.toModel(): AgentAttachment = AgentAttachment(
+    id = id,
+    displayName = displayName,
+    kind = AgentAttachmentKind.entries.firstOrNull { it.name == kind } ?: AgentAttachmentKind.Text,
+    mediaType = mediaType,
+    byteCount = byteCount,
+    lineCount = lineCount.takeIf { it > 0 },
+    sha256 = sha256,
+    relativePath = relativePath.takeIf { it.isNotBlank() },
+)
+
+internal fun AgentAttachment.toDto(): AgentAttachmentDto = AgentAttachmentDto(
+    id = id,
+    displayName = displayName,
+    kind = kind.name,
+    mediaType = mediaType,
+    byteCount = byteCount,
+    lineCount = lineCount ?: 0,
+    sha256 = sha256,
+    relativePath = relativePath.orEmpty(),
 )
 
 @Serializable
@@ -665,12 +714,15 @@ internal fun AgentTaskDto.toModel(scrollbackFile: (String) -> File): AgentTask? 
         fastMode = fastMode,
         openClawNewSession = openClawNewSession,
         imagePaths = imagePaths,
+        attachments = attachments.map { it.toModel() },
         skills = skillNames.zip(skillPaths).filter { (_, path) -> path.isNotBlank() }.map { (name, path) ->
             AgentSkill(name = name, description = "", path = path)
         },
         goal = goal.takeIf { it.isNotBlank() },
         queuedFollowUps = queuedFollowUps.mapNotNull { queued ->
-            queued.text.takeIf { it.isNotBlank() || queued.imagePaths.isNotEmpty() }?.let { text ->
+            queued.text.takeIf {
+                it.isNotBlank() || queued.imagePaths.isNotEmpty() || queued.attachments.isNotEmpty()
+            }?.let { text ->
                 AgentQueuedFollowUp(
                     text = text,
                     imagePaths = queued.imagePaths,
@@ -678,6 +730,7 @@ internal fun AgentTaskDto.toModel(scrollbackFile: (String) -> File): AgentTask? 
                     .filter { (_, path) -> path.isNotBlank() }
                     .map { (name, path) -> AgentSkill(name = name, description = "", path = path) },
                     contextBundleIds = queued.contextBundleIds,
+                    attachments = queued.attachments.map { it.toModel() },
                     provenance = queued.provenance?.toModel(),
                 )
             }
@@ -799,6 +852,7 @@ internal fun AgentStoreState.toFileDto(): AgentsFileDto = AgentsFileDto(
             fastMode = task.fastMode,
             openClawNewSession = task.openClawNewSession,
             imagePaths = task.imagePaths,
+            attachments = task.attachments.map { it.toDto() },
             skillNames = task.skills.map { it.name },
             skillPaths = task.skills.map { it.path },
             goal = task.goal.orEmpty(),
@@ -809,6 +863,7 @@ internal fun AgentStoreState.toFileDto(): AgentsFileDto = AgentsFileDto(
                     skillNames = queued.skills.map { it.name },
                     skillPaths = queued.skills.map { it.path },
                     contextBundleIds = queued.contextBundleIds,
+                    attachments = queued.attachments.map { it.toDto() },
                     provenance = queued.provenance?.toDto(),
                 )
             },
@@ -1120,24 +1175,33 @@ private fun ProjectTask.toDto(): ProjectTaskDto = ProjectTaskDto(
 
 private fun AgentThreadChangeSnapshotDto.toModel(): AgentThreadChangeSnapshot = AgentThreadChangeSnapshot(
     summary = AgentChangeSummary(files.map { AgentFileChange(it.path, it.additions, it.deletions) }),
-    diffs = diffs.associate { diff ->
-        diff.path to AgentFileDiff(
-            path = diff.path,
-            lines = diff.lines.map { line ->
-                DiffLine(
-                    kind = DiffLineKind.entries.firstOrNull { it.name == line.kind } ?: DiffLineKind.Context,
-                    text = line.text,
-                    oldLineNumber = line.oldLineNumber,
-                    newLineNumber = line.newLineNumber,
-                )
-            },
-            additions = diff.additions,
-            deletions = diff.deletions,
-            isBinary = diff.isBinary,
-            isNewFile = diff.isNewFile,
+    diffs = diffs.associate { it.path to it.toModel() },
+)
+
+internal fun AgentFileDiffDto.toModel(): AgentFileDiff = AgentFileDiff(
+    path = path,
+    lines = lines.map { line ->
+        DiffLine(
+            kind = DiffLineKind.entries.firstOrNull { it.name == line.kind } ?: DiffLineKind.Context,
+            text = line.text,
+            oldLineNumber = line.oldLineNumber,
+            newLineNumber = line.newLineNumber,
         )
     },
+    additions = additions,
+    deletions = deletions,
+    isBinary = isBinary,
+    isNewFile = isNewFile,
 )
+
+/**
+ * Marks a task loaded from the summary-only projection so persistence knows its empty [diffs] map
+ * means "not read", not "no changes". See [AgentThreadChangeSnapshot.diffsHydrated].
+ */
+internal fun AgentTask.withUnhydratedDiffs(): AgentTask {
+    val changes = completedChanges ?: return this
+    return copy(completedChanges = changes.copy(diffs = emptyMap(), diffsHydrated = false))
+}
 
 private fun AgentThreadChangeSnapshot.toDto(): AgentThreadChangeSnapshotDto = AgentThreadChangeSnapshotDto(
     files = summary.files.map { AgentFileChangeDto(it.path, it.additions, it.deletions) },

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopChatAttachmentService.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopChatAttachmentService.kt
@@ -1,0 +1,651 @@
+package app.andy.desktop.service.agents
+
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentAttachmentKind
+import app.andy.model.ChatAttachmentLimits
+import app.andy.model.countTextLines
+import app.andy.model.shouldAttachLargeText
+import app.andy.service.ChatAttachmentService
+import app.andy.service.ChatAttachmentUploadSession
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.util.Base64
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Disk-backed chat text attachments.
+ *
+ * Staging lives under `~/.andy/attachments-staging/<id>/`. Once a task has a cwd, the
+ * authoritative readable copy is hard-linked (or copied) to
+ * `<cwd>/.andy/<taskId>/attachments/<safe-name>` so ACP's cwd jail can read it.
+ */
+class DesktopChatAttachmentService(
+    private val stagingRoot: File = File(System.getProperty("user.home"), ".andy/attachments-staging"),
+    /** Injectable for tests; production uses [ChatAttachmentLimits.MaxStagedBytesPerDraft]. */
+    private val maxStagedBytesPerDraft: Long = ChatAttachmentLimits.MaxStagedBytesPerDraft,
+) : ChatAttachmentService {
+    private val mutex = Mutex()
+    /** Committed staged bytes + in-flight upload reservations, keyed by draft. */
+    private val draftBytes = ConcurrentHashMap<String, Long>()
+    private val uploads = ConcurrentHashMap<String, UploadState>()
+    private val stagedMeta = ConcurrentHashMap<String, StagedMeta>()
+
+    /** Test helper: current reserved/committed draft byte total. */
+    internal fun draftByteTotal(draftKey: String): Long = draftBytes[draftKey] ?: 0L
+
+    override suspend fun stageText(
+        text: String,
+        displayName: String,
+        draftKey: String?,
+    ): Result<AgentAttachment> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            runCatching {
+                val bytes = text.encodeToByteArray()
+                if (bytes.size.toLong() > ChatAttachmentLimits.MaxAttachmentBytes) {
+                    error(
+                        "Attachment exceeds ${ChatAttachmentLimits.MaxAttachmentBytes / (1024 * 1024)} MiB limit " +
+                            "(${bytes.size} bytes).",
+                    )
+                }
+                draftKey?.let { key ->
+                    val next = (draftBytes[key] ?: 0L) + bytes.size
+                    if (next > maxStagedBytesPerDraft) {
+                        error("Draft attachment budget exceeded (1 GiB). Remove an attachment and try again.")
+                    }
+                }
+                ensureFreeSpace(bytes.size.toLong())
+                val id = newAttachmentId()
+                val safeName = sanitizeFileName(displayName)
+                val dir = File(stagingRoot, id).also { it.mkdirs() }
+                val target = File(dir, safeName)
+                val tmp = File(dir, ".$safeName.tmp")
+                val digest = MessageDigest.getInstance("SHA-256")
+                var lineCount = 0L
+                var prevWasNewline = true
+                BufferedOutputStream(FileOutputStream(tmp)).use { out ->
+                    var offset = 0
+                    while (offset < bytes.size) {
+                        val end = minOf(offset + 64 * 1024, bytes.size)
+                        val slice = bytes.copyOfRange(offset, end)
+                        digest.update(slice)
+                        out.write(slice)
+                        for (b in slice) {
+                            when (b) {
+                                '\n'.code.toByte() -> {
+                                    lineCount++
+                                    prevWasNewline = true
+                                }
+                                else -> prevWasNewline = false
+                            }
+                        }
+                        offset = end
+                    }
+                }
+                if (bytes.isNotEmpty() && !prevWasNewline) lineCount++
+                if (bytes.isEmpty()) lineCount = 0
+                if (!tmp.renameTo(target)) {
+                    target.delete()
+                    check(tmp.renameTo(target)) { "Failed to finalize staged attachment." }
+                }
+                val sha = digest.digest().toHex()
+                val attachment = AgentAttachment(
+                    id = id,
+                    displayName = safeName,
+                    kind = AgentAttachmentKind.Text,
+                    mediaType = "text/plain; charset=utf-8",
+                    byteCount = bytes.size.toLong(),
+                    lineCount = lineCount,
+                    sha256 = sha,
+                    relativePath = null,
+                )
+                stagedMeta[id] = StagedMeta(draftKey = draftKey, file = target, byteCount = attachment.byteCount)
+                draftKey?.let { draftBytes.merge(it, attachment.byteCount) { a, b -> a + b } }
+                writeSidecar(dir, attachment)
+                attachment
+            }
+        }
+    }
+
+    override suspend fun discardStaged(attachmentId: String): Boolean = withContext(Dispatchers.IO) {
+        mutex.withLock { discardStagedLocked(attachmentId) }
+    }
+
+    override suspend fun materializeForTask(
+        taskId: String,
+        cwd: String?,
+        attachments: List<AgentAttachment>,
+    ): List<AgentAttachment> = withContext(Dispatchers.IO) {
+        if (attachments.isEmpty()) return@withContext emptyList()
+        mutex.withLock {
+            val destRoot = taskAttachmentsDir(cwd, taskId).also { it.mkdirs() }
+            val createdDests = mutableListOf<File>()
+            val toRelease = mutableListOf<String>()
+            try {
+                val results = attachments.map { attachment ->
+                    if (!isSafeId(attachment.id)) {
+                        error("Invalid attachment id: ${attachment.id}")
+                    }
+                    // Prefer an already-materialized task-relative copy so retry/restart works
+                    // without depending on in-memory stagedMeta. Only reuse paths that
+                    // canonicalize inside this task's attachments directory.
+                    val reusable = resolveReusableMaterializedFile(cwd, taskId, attachment)
+                    if (reusable != null) {
+                        verifyIntegrity(reusable, attachment)
+                        val relative = ".andy/$taskId/attachments/${reusable.name}"
+                        return@map attachment.copy(displayName = reusable.name, relativePath = relative)
+                    }
+                    val source = resolveStagedFile(attachment)
+                        ?: error("Staged attachment not found: ${attachment.id}")
+                    verifyIntegrity(source, attachment)
+                    val safeName = uniqueSafeName(destRoot, attachment.displayName)
+                    val dest = File(destRoot, safeName)
+                    hardLinkOrCopy(source, dest)
+                    createdDests += dest
+                    verifyIntegrity(dest, attachment.copy(displayName = safeName))
+                    val relative = ".andy/$taskId/attachments/$safeName"
+                    toRelease += attachment.id
+                    attachment.copy(displayName = safeName, relativePath = relative)
+                }
+                // Release staging only after every attachment materialized successfully.
+                toRelease.forEach { releaseStagedAfterMaterialize(it) }
+                results
+            } catch (error: Exception) {
+                createdDests.forEach { dest -> runCatching { dest.delete() } }
+                throw error
+            }
+        }
+    }
+
+    override suspend fun discardDraft(draftKey: String) = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            val ids = stagedMeta.filterValues { it.draftKey == draftKey }.keys.toList()
+            ids.forEach { id ->
+                stagedMeta.remove(id)
+                File(stagingRoot, id).deleteRecursively()
+            }
+            val inFlight = uploads.filterValues { it.draftKey == draftKey }.keys.toList()
+            inFlight.forEach { id ->
+                uploads.remove(id)
+                File(stagingRoot, id).deleteRecursively()
+            }
+            draftBytes.remove(draftKey)
+            Unit
+        }
+    }
+
+    override suspend fun expireAbandonedStaging(maxAgeMillis: Long) = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!stagingRoot.isDirectory) return@withLock
+            val cutoff = System.currentTimeMillis() - maxAgeMillis
+            stagingRoot.listFiles()?.forEach { dir ->
+                if (!dir.isDirectory) return@forEach
+                if (dir.lastModified() in 1 until cutoff) {
+                    val id = dir.name
+                    uploads.remove(id)?.let { state ->
+                        releaseDraftBytes(state.draftKey, state.expectedBytes)
+                    }
+                    stagedMeta.remove(id)?.let { meta ->
+                        releaseDraftBytes(meta.draftKey, meta.byteCount)
+                    }
+                    dir.deleteRecursively()
+                }
+            }
+        }
+    }
+
+    override suspend fun beginUpload(
+        displayName: String,
+        byteCount: Long,
+        sha256: String,
+        mediaType: String,
+        draftKey: String?,
+    ): Result<ChatAttachmentUploadSession> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            runCatching {
+                if (byteCount <= 0L) error("byteCount must be positive")
+                if (byteCount > ChatAttachmentLimits.MaxAttachmentBytes) {
+                    error("Attachment exceeds ${ChatAttachmentLimits.MaxAttachmentBytes / (1024 * 1024)} MiB limit.")
+                }
+                if (!sha256.matches(SHA256_HEX)) error("Invalid sha256")
+                // Reserve declared bytes immediately so concurrent begins cannot exceed the budget.
+                draftKey?.let { key ->
+                    val next = (draftBytes[key] ?: 0L) + byteCount
+                    if (next > maxStagedBytesPerDraft) {
+                        error("Draft attachment budget exceeded (1 GiB).")
+                    }
+                    draftBytes[key] = next
+                }
+                try {
+                    ensureFreeSpace(byteCount)
+                    val uploadId = newAttachmentId()
+                    val safeName = sanitizeFileName(displayName)
+                    val dir = File(stagingRoot, uploadId).also { it.mkdirs() }
+                    val partial = File(dir, ".$safeName.partial")
+                    partial.outputStream().close()
+                    uploads[uploadId] = UploadState(
+                        uploadId = uploadId,
+                        displayName = safeName,
+                        expectedBytes = byteCount,
+                        expectedSha256 = sha256.lowercase(),
+                        mediaType = mediaType,
+                        draftKey = draftKey,
+                        partialFile = partial,
+                        nextSequence = 0,
+                        writtenBytes = 0L,
+                        digest = MessageDigest.getInstance("SHA-256"),
+                        lineCount = 0L,
+                        prevWasNewline = true,
+                        reservationHeld = draftKey != null,
+                    )
+                    ChatAttachmentUploadSession(uploadId, safeName, byteCount, sha256.lowercase())
+                } catch (error: Exception) {
+                    draftKey?.let { releaseDraftBytes(it, byteCount) }
+                    throw error
+                }
+            }
+        }
+    }
+
+    override suspend fun appendUploadChunk(
+        uploadId: String,
+        sequence: Int,
+        base64Chunk: String,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            runCatching {
+                val state = uploads[uploadId] ?: error("Unknown upload id")
+                if (sequence != state.nextSequence) {
+                    error("Out-of-order chunk: expected ${state.nextSequence}, got $sequence")
+                }
+                val decoded = try {
+                    Base64.getDecoder().decode(base64Chunk)
+                } catch (_: IllegalArgumentException) {
+                    error("Invalid Base64 chunk")
+                }
+                if (decoded.isEmpty()) error("Empty chunk")
+                if (decoded.size > ChatAttachmentLimits.UploadChunkBytes + 4096) {
+                    error("Chunk exceeds upload size limit")
+                }
+                val nextBytes = state.writtenBytes + decoded.size
+                if (nextBytes > state.expectedBytes) {
+                    error("Upload exceeds declared byteCount")
+                }
+                FileOutputStream(state.partialFile, true).use { it.write(decoded) }
+                state.digest.update(decoded)
+                for (b in decoded) {
+                    when (b) {
+                        '\n'.code.toByte() -> {
+                            state.lineCount++
+                            state.prevWasNewline = true
+                        }
+                        else -> state.prevWasNewline = false
+                    }
+                }
+                state.writtenBytes = nextBytes
+                state.nextSequence++
+                Unit
+            }
+        }
+    }
+
+    override suspend fun commitUpload(uploadId: String): Result<AgentAttachment> = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            runCatching {
+                val state = uploads.remove(uploadId) ?: error("Unknown upload id")
+                fun fail(message: String): Nothing {
+                    if (state.reservationHeld) {
+                        releaseDraftBytes(state.draftKey, state.expectedBytes)
+                    }
+                    state.partialFile.parentFile?.deleteRecursively()
+                    error(message)
+                }
+                if (state.writtenBytes != state.expectedBytes) {
+                    fail("Upload incomplete: ${state.writtenBytes}/${state.expectedBytes} bytes")
+                }
+                val sha = state.digest.digest().toHex()
+                if (sha != state.expectedSha256) {
+                    fail("SHA-256 mismatch")
+                }
+                var lineCount = state.lineCount
+                if (state.writtenBytes > 0 && !state.prevWasNewline) lineCount++
+                if (state.writtenBytes == 0L) lineCount = 0
+                val dir = state.partialFile.parentFile!!
+                val target = File(dir, state.displayName)
+                if (!state.partialFile.renameTo(target)) {
+                    target.delete()
+                    check(state.partialFile.renameTo(target)) { "Failed to finalize upload" }
+                }
+                val attachment = AgentAttachment(
+                    id = uploadId,
+                    displayName = state.displayName,
+                    kind = AgentAttachmentKind.Text,
+                    mediaType = state.mediaType,
+                    byteCount = state.writtenBytes,
+                    lineCount = lineCount,
+                    sha256 = sha,
+                )
+                // Reservation already counted toward draftBytes — convert to staged ownership
+                // without double-counting.
+                stagedMeta[uploadId] = StagedMeta(state.draftKey, target, attachment.byteCount)
+                writeSidecar(dir, attachment)
+                attachment
+            }
+        }
+    }
+
+    override suspend fun cancelUpload(uploadId: String): Boolean = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            // In-progress upload: release reservation and delete partials.
+            val state = uploads.remove(uploadId)
+            if (state != null) {
+                if (state.reservationHeld) {
+                    releaseDraftBytes(state.draftKey, state.expectedBytes)
+                }
+                File(stagingRoot, uploadId).deleteRecursively()
+                return@withLock true
+            }
+            // Committed-but-unsent staged attachment (remote cleanup after a failed chat
+            // mutation): discard the staged body too.
+            discardStagedLocked(uploadId)
+        }
+    }
+
+    override suspend fun readStagedChunk(
+        attachmentId: String,
+        offset: Long,
+        maxBytes: Int,
+    ): ByteArray? = withContext(Dispatchers.IO) {
+        if (!isSafeId(attachmentId) || offset < 0L || maxBytes <= 0) return@withContext null
+        val file = resolveStagedFile(
+            AgentAttachment(
+                id = attachmentId,
+                displayName = "x",
+                byteCount = 0,
+                sha256 = "",
+            ),
+        ) ?: return@withContext null
+        val length = file.length()
+        if (offset >= length) return@withContext ByteArray(0)
+        val toRead = minOf(maxBytes.toLong(), length - offset).toInt()
+        ByteArray(toRead).also { buf ->
+            FileInputStream(file).use { input ->
+                var skipped = 0L
+                while (skipped < offset) {
+                    val n = input.skip(offset - skipped)
+                    if (n <= 0L) break
+                    skipped += n
+                }
+                var read = 0
+                while (read < toRead) {
+                    val n = input.read(buf, read, toRead - read)
+                    if (n < 0) break
+                    read += n
+                }
+                if (read != toRead) {
+                    return@withContext buf.copyOf(read)
+                }
+            }
+        }
+    }
+
+    override suspend fun spilloverPromptIfNeeded(
+        taskId: String,
+        cwd: String?,
+        prompt: String,
+    ): String = withContext(Dispatchers.IO) {
+        if (!shouldAttachLargeText(prompt)) return@withContext prompt
+        mutex.withLock {
+            val destRoot = taskAttachmentsDir(cwd, taskId).also { it.mkdirs() }
+            val safeName = uniqueSafeName(destRoot, "prompt-spill.txt")
+            val dest = File(destRoot, safeName)
+            val tmp = File(destRoot, ".$safeName.tmp")
+            val digest = MessageDigest.getInstance("SHA-256")
+            val bytes = prompt.encodeToByteArray()
+            BufferedOutputStream(FileOutputStream(tmp)).use { out ->
+                digest.update(bytes)
+                out.write(bytes)
+            }
+            if (!tmp.renameTo(dest)) {
+                dest.delete()
+                check(tmp.renameTo(dest)) { "Failed to write prompt spillover" }
+            }
+            val sha = digest.digest().toHex()
+            val lines = countTextLines(prompt)
+            val relative = ".andy/$taskId/attachments/$safeName"
+            buildString {
+                append("The full prompt was too large to pass inline (")
+                append(bytes.size)
+                append(" bytes, ")
+                append(lines)
+                append(" lines). It was written to ")
+                append(relative)
+                append(" (sha256=")
+                append(sha)
+                append("). Inspect that file with bounded reads/searches before responding.")
+            }
+        }
+    }
+
+    /** Test helper: absolute staged file for [attachmentId]. */
+    internal fun stagedFile(attachmentId: String): File? =
+        stagedMeta[attachmentId]?.file ?: resolveStagedFile(
+            AgentAttachment(
+                id = attachmentId,
+                displayName = "x",
+                byteCount = 0,
+                sha256 = "",
+            ),
+        )
+
+    private fun discardStagedLocked(attachmentId: String): Boolean {
+        if (!isSafeId(attachmentId)) return false
+        val meta = stagedMeta.remove(attachmentId)
+        meta?.let { releaseDraftBytes(it.draftKey, it.byteCount) }
+        val dir = File(stagingRoot, attachmentId)
+        if (!dir.isDirectory) return meta != null
+        dir.deleteRecursively()
+        return true
+    }
+
+    private fun releaseDraftBytes(draftKey: String?, bytes: Long) {
+        if (draftKey == null || bytes <= 0L) return
+        draftBytes.compute(draftKey) { _, total ->
+            val next = (total ?: 0L) - bytes
+            if (next <= 0L) null else next
+        }
+    }
+
+    /**
+     * Drops the staging directory after a successful materialize. Safe because the
+     * task-owned copy (hard link or independent file) already verified.
+     */
+    private fun releaseStagedAfterMaterialize(attachmentId: String) {
+        val meta = stagedMeta.remove(attachmentId)
+        meta?.let { releaseDraftBytes(it.draftKey, it.byteCount) }
+        File(stagingRoot, attachmentId).deleteRecursively()
+    }
+
+    private fun resolveStagedFile(attachment: AgentAttachment): File? {
+        stagedMeta[attachment.id]?.file?.takeIf { it.isFile }?.let { return it }
+        val dir = File(stagingRoot, attachment.id)
+        if (!dir.isDirectory) return null
+        val named = File(dir, sanitizeFileName(attachment.displayName))
+        if (named.isFile) return named
+        return dir.listFiles()?.firstOrNull { it.isFile && !it.name.startsWith('.') && !it.name.endsWith(".json") }
+    }
+
+    /**
+     * Returns a reusable materialized file only when [AgentAttachment.relativePath] resolves
+     * canonically inside `<cwd>/.andy/<taskId>/attachments/`. Rejects traversal, absolute, and
+     * sibling-task paths.
+     */
+    private fun resolveReusableMaterializedFile(
+        cwd: String?,
+        taskId: String,
+        attachment: AgentAttachment,
+    ): File? {
+        val relative = attachment.relativePath?.takeIf { it.isNotBlank() } ?: return null
+        if (cwd.isNullOrBlank()) return null
+        if (!isSafeTaskRelativeAttachmentPath(relative, taskId)) return null
+        val attachmentsRoot = taskAttachmentsDir(cwd, taskId).canonicalFile
+        val candidate = File(cwd, relative).canonicalFile
+        val rootPath = attachmentsRoot.path
+        val candidatePath = candidate.path
+        val inside = candidatePath == rootPath ||
+            candidatePath.startsWith(rootPath + File.separator)
+        if (!inside) return null
+        if (candidate.parentFile?.canonicalFile != attachmentsRoot) return null
+        if (!candidate.isFile) return null
+        return candidate
+    }
+
+    private fun verifyIntegrity(file: File, attachment: AgentAttachment) {
+        if (file.length() != attachment.byteCount) {
+            error("Attachment size mismatch for ${attachment.id}")
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+        BufferedInputStream(FileInputStream(file)).use { input ->
+            val buf = ByteArray(64 * 1024)
+            while (true) {
+                val n = input.read(buf)
+                if (n < 0) break
+                digest.update(buf, 0, n)
+            }
+        }
+        val sha = digest.digest().toHex()
+        if (attachment.sha256.isNotBlank() && sha != attachment.sha256.lowercase()) {
+            error("Attachment hash mismatch for ${attachment.id}")
+        }
+    }
+
+    private fun hardLinkOrCopy(source: File, dest: File) {
+        dest.parentFile?.mkdirs()
+        dest.delete()
+        val linked = runCatching {
+            Files.createLink(dest.toPath(), source.toPath())
+            true
+        }.getOrDefault(false)
+        if (!linked) {
+            source.copyTo(dest, overwrite = true)
+        }
+    }
+
+    private fun writeSidecar(dir: File, attachment: AgentAttachment) {
+        File(dir, "meta.json").writeText(
+            buildString {
+                append('{')
+                append("\"id\":\"").append(attachment.id).append("\",")
+                append("\"displayName\":\"").append(attachment.displayName).append("\",")
+                append("\"byteCount\":").append(attachment.byteCount).append(',')
+                append("\"lineCount\":").append(attachment.lineCount ?: 0).append(',')
+                append("\"sha256\":\"").append(attachment.sha256).append('"')
+                append('}')
+            },
+        )
+    }
+
+    private fun ensureFreeSpace(needed: Long) {
+        val usable = stagingRoot.usableSpace.takeIf { stagingRoot.exists() || stagingRoot.mkdirs() }
+            ?: File(System.getProperty("user.home")).usableSpace
+        // Require some headroom beyond the file itself.
+        if (usable in 1 until needed + (64L * 1024 * 1024)) {
+            error("Insufficient disk space to stage attachment")
+        }
+    }
+
+    private data class StagedMeta(
+        val draftKey: String?,
+        val file: File,
+        val byteCount: Long,
+    )
+
+    private class UploadState(
+        val uploadId: String,
+        val displayName: String,
+        val expectedBytes: Long,
+        val expectedSha256: String,
+        val mediaType: String,
+        val draftKey: String?,
+        val partialFile: File,
+        var nextSequence: Int,
+        var writtenBytes: Long,
+        val digest: MessageDigest,
+        var lineCount: Long,
+        var prevWasNewline: Boolean,
+        val reservationHeld: Boolean,
+    )
+
+    companion object {
+        private val SAFE_ID = Regex("^[A-Za-z0-9._-]{1,128}$")
+        private val SHA256_HEX = Regex("^[a-fA-F0-9]{64}$")
+
+        fun taskAttachmentsDir(cwd: String?, taskId: String): File =
+            File(AgentWorkflowArtifacts.dirFor(cwd?.let(::File), taskId), "attachments")
+
+        fun isSafeId(id: String): Boolean = SAFE_ID.matches(id)
+
+        /**
+         * True when [relative] is exactly `.andy/<taskId>/attachments/<safe-file>` with no
+         * traversal or absolute segments. Used before trusting a persisted relativePath.
+         */
+        fun isSafeTaskRelativeAttachmentPath(relative: String, taskId: String): Boolean {
+            if (relative.isBlank() || relative.startsWith("/") || relative.startsWith("\\")) return false
+            if (relative.contains('\\') || relative.contains('\u0000')) return false
+            val parts = relative.split('/')
+            if (parts.size != 4) return false
+            if (parts[0] != ".andy") return false
+            if (parts[1] != taskId || !isSafeId(taskId)) return false
+            if (parts[2] != "attachments") return false
+            val name = parts[3]
+            return name.matches(Regex("^[A-Za-z0-9._-]{1,128}$")) && name != "." && name != ".."
+        }
+
+        fun sanitizeFileName(name: String): String {
+            val base = name.trim().substringAfterLast('/').substringAfterLast('\\')
+                .ifBlank { "pasted.txt" }
+            val cleaned = buildString(base.length.coerceAtMost(120)) {
+                for (ch in base.take(120)) {
+                    append(
+                        when {
+                            ch.isLetterOrDigit() || ch in "._-" -> ch
+                            ch == ' ' -> '-'
+                            else -> '_'
+                        },
+                    )
+                }
+            }.trim('.').ifBlank { "pasted.txt" }
+            return if (cleaned.contains('.')) cleaned else "$cleaned.txt"
+        }
+
+        fun uniqueSafeName(dir: File, desired: String): String {
+            val safe = sanitizeFileName(desired)
+            if (!File(dir, safe).exists()) return safe
+            val stem = safe.substringBeforeLast('.', safe)
+            val ext = safe.substringAfterLast('.', missingDelimiterValue = "").let {
+                if (it.isEmpty() || it == safe) ".txt" else ".$it"
+            }
+            var i = 2
+            while (true) {
+                val candidate = "$stem-$i$ext"
+                if (!File(dir, candidate).exists()) return candidate
+                i++
+            }
+        }
+
+        fun newAttachmentId(): String = "att-" + UUID.randomUUID().toString().replace("-", "")
+
+        private fun ByteArray.toHex(): String = joinToString("") { b ->
+            ((b.toInt() and 0xff) + 0x100).toString(16).substring(1)
+        }
+    }
+}

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopTranscriptSearchIndex.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/DesktopTranscriptSearchIndex.kt
@@ -1,0 +1,291 @@
+package app.andy.desktop.service.agents
+
+import app.andy.desktop.service.agents.acp.AcpTranscriptStore
+import app.andy.model.AgentEvent
+import app.andy.model.TranscriptSearchHit
+import app.andy.store.TranscriptSearchSql
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Incremental FTS5 index over ACP transcript body text for Cmd+K.
+ *
+ * Searchable content: user messages, assistant text, tool titles/summaries.
+ * Thinking blocks and full tool output dumps are intentionally skipped.
+ */
+class DesktopTranscriptSearchIndex(
+    private val driver: SqlDriver,
+    private val transcriptFileFor: (taskId: String) -> File,
+) {
+    private val mutex = Mutex()
+    private val loadStore = AcpTranscriptStore(fileFor = transcriptFileFor)
+
+    data class TaskRef(
+        val taskId: String,
+        val projectId: String?,
+        val title: String,
+        val projectName: String?,
+        val updatedAtMillis: Long,
+    )
+
+    fun search(
+        query: String,
+        tasks: List<TaskRef>,
+        excludeTaskIds: Set<String> = emptySet(),
+        limit: Int = 40,
+    ): Flow<TranscriptSearchHit> = flow {
+        val trimmed = query.trim()
+        if (trimmed.length < MIN_QUERY_CHARS) return@flow
+        val fts = ftsMatchQuery(trimmed) ?: return@flow
+        val byId = tasks.associateBy { it.taskId }
+        val eligible = tasks.filter { it.taskId !in excludeTaskIds }
+        if (eligible.isEmpty()) return@flow
+
+        val emitted = linkedSetOf<String>()
+        val indexedHits = mutex.withLock {
+            queryFts(fts, limit * 2)
+        }
+        for ((taskId, body) in indexedHits) {
+            currentCoroutineContext().ensureActive()
+            if (taskId in excludeTaskIds || taskId in emitted) continue
+            val ref = byId[taskId] ?: continue
+            val snippet = snippetFor(body, trimmed) ?: continue
+            emitted += taskId
+            emit(
+                TranscriptSearchHit(
+                    taskId = taskId,
+                    projectId = ref.projectId,
+                    title = ref.title.ifBlank { "Untitled chat" },
+                    projectName = ref.projectName,
+                    snippet = snippet,
+                    atMillis = ref.updatedAtMillis,
+                ),
+            )
+            if (emitted.size >= limit) return@flow
+        }
+
+        // Incomplete docs, plus complete docs whose on-disk transcript changed since index
+        // (follow-ups can land after backfill marked the chat complete).
+        val coldOrStale = eligible
+            .asSequence()
+            .filter { it.taskId !in emitted }
+            .sortedByDescending { it.updatedAtMillis }
+            .toList()
+        for (ref in coldOrStale) {
+            currentCoroutineContext().ensureActive()
+            if (emitted.size >= limit) return@flow
+            val body = mutex.withLock {
+                val state = readState(ref.taskId)
+                if (state != null && state.complete && sourceUnchanged(ref.taskId, state)) {
+                    null
+                } else {
+                    reindexTaskUnlocked(ref.taskId)
+                    readBody(ref.taskId)
+                }
+            } ?: continue
+            val snippet = snippetFor(body, trimmed) ?: continue
+            emitted += ref.taskId
+            emit(
+                TranscriptSearchHit(
+                    taskId = ref.taskId,
+                    projectId = ref.projectId,
+                    title = ref.title.ifBlank { "Untitled chat" },
+                    projectName = ref.projectName,
+                    snippet = snippet,
+                    atMillis = ref.updatedAtMillis,
+                ),
+            )
+        }
+    }.flowOn(Dispatchers.IO)
+
+    suspend fun reindexTask(taskId: String) = withContext(Dispatchers.IO) {
+        mutex.withLock { reindexTaskUnlocked(taskId) }
+    }
+
+    suspend fun removeTask(taskId: String) = withContext(Dispatchers.IO) {
+        mutex.withLock { removeTaskUnlocked(taskId) }
+    }
+
+    /** Idle backfill: index tasks newest-first that are not yet complete. */
+    suspend fun backfill(taskIdsNewestFirst: List<String>) = withContext(Dispatchers.IO) {
+        for (taskId in taskIdsNewestFirst) {
+            mutex.withLock {
+                val state = readState(taskId)
+                if (state?.complete == true && sourceUnchanged(taskId, state)) return@withLock
+                reindexTaskUnlocked(taskId)
+            }
+        }
+    }
+
+    private fun reindexTaskUnlocked(taskId: String): String {
+        val file = transcriptFileFor(taskId)
+        val mtime = file.takeIf { it.isFile }?.lastModified() ?: 0L
+        val len = file.takeIf { it.isFile }?.length() ?: 0L
+        val events = runCatching { loadStore.load(taskId) }.getOrDefault(emptyList())
+        val body = buildSearchableBody(events)
+        writeDoc(taskId, body, mtime, len, complete = true)
+        return body
+    }
+
+    private fun removeTaskUnlocked(taskId: String) {
+        driver.execute(null, TranscriptSearchSql.DELETE_FTS_FOR_TASK, 1) { bindString(0, taskId) }
+        driver.execute(null, TranscriptSearchSql.DELETE_DOC, 1) { bindString(0, taskId) }
+    }
+
+    private fun writeDoc(taskId: String, body: String, mtime: Long, len: Long, complete: Boolean) {
+        driver.execute(null, TranscriptSearchSql.DELETE_FTS_FOR_TASK, 1) { bindString(0, taskId) }
+        if (body.isNotBlank()) {
+            driver.execute(null, TranscriptSearchSql.INSERT_FTS, 2) {
+                bindString(0, taskId)
+                bindString(1, body)
+            }
+        }
+        driver.execute(null, TranscriptSearchSql.UPSERT_DOC, 5) {
+            bindString(0, taskId)
+            bindString(1, body)
+            bindLong(2, mtime)
+            bindLong(3, len)
+            bindLong(4, if (complete) 1L else 0L)
+        }
+    }
+
+    private fun queryFts(matchQuery: String, limit: Int): List<Pair<String, String>> =
+        driver.executeQuery(
+            identifier = null,
+            sql = TranscriptSearchSql.SEARCH_FTS,
+            parameters = 2,
+            binders = {
+                bindString(0, matchQuery)
+                bindLong(1, limit.toLong())
+            },
+            mapper = { cursor ->
+                val rows = mutableListOf<Pair<String, String>>()
+                while (cursor.next().value) {
+                    val taskId = cursor.getString(0) ?: continue
+                    val body = cursor.getString(1) ?: continue
+                    rows += taskId to body
+                }
+                QueryResult.Value(rows)
+            },
+        ).value
+
+    private fun completeTaskIds(): Set<String> =
+        driver.executeQuery(
+            identifier = null,
+            sql = "SELECT task_id FROM transcript_search_doc WHERE complete = 1",
+            parameters = 0,
+            mapper = { cursor ->
+                val ids = mutableSetOf<String>()
+                while (cursor.next().value) {
+                    cursor.getString(0)?.let(ids::add)
+                }
+                QueryResult.Value(ids)
+            },
+        ).value
+
+    private fun readBody(taskId: String): String? = readState(taskId)?.body
+
+    private data class DocState(
+        val body: String,
+        val sourceMtime: Long,
+        val sourceLen: Long,
+        val complete: Boolean,
+    )
+
+    private fun readState(taskId: String): DocState? =
+        driver.executeQuery(
+            identifier = null,
+            sql = TranscriptSearchSql.SELECT_DOC,
+            parameters = 1,
+            binders = { bindString(0, taskId) },
+            mapper = { cursor ->
+                if (!cursor.next().value) {
+                    QueryResult.Value(null)
+                } else {
+                    QueryResult.Value(
+                        DocState(
+                            body = cursor.getString(0).orEmpty(),
+                            sourceMtime = cursor.getLong(1) ?: 0L,
+                            sourceLen = cursor.getLong(2) ?: 0L,
+                            complete = (cursor.getLong(3) ?: 0L) != 0L,
+                        ),
+                    )
+                }
+            },
+        ).value
+
+    private fun sourceUnchanged(taskId: String, state: DocState): Boolean {
+        val file = transcriptFileFor(taskId)
+        if (!file.isFile) return state.sourceLen == 0L
+        return file.lastModified() == state.sourceMtime && file.length() == state.sourceLen
+    }
+
+    companion object {
+        const val MIN_QUERY_CHARS = 2
+
+        fun buildSearchableBody(events: List<AgentEvent>): String {
+            if (events.isEmpty()) return ""
+            val parts = ArrayList<String>(events.size)
+            for (event in events) {
+                searchableText(event)?.takeIf { it.isNotBlank() }?.let(parts::add)
+            }
+            return parts.joinToString("\n")
+        }
+
+        fun searchableText(event: AgentEvent): String? = when (event) {
+            is AgentEvent.UserMessage -> event.text
+            is AgentEvent.AssistantText -> event.text.takeUnless { event.isStreamDelta }
+            is AgentEvent.ToolCall -> {
+                val title = event.toolName.trim()
+                val summary = event.summary.trim()
+                when {
+                    title.isBlank() && summary.isBlank() -> null
+                    title.isBlank() -> summary
+                    summary.isBlank() || summary == title -> title
+                    else -> "$title $summary"
+                }
+            }
+            is AgentEvent.TaskResult -> event.finalText
+            else -> null
+        }
+
+        fun ftsMatchQuery(raw: String): String? {
+            val tokens = raw
+                .lowercase()
+                .split(Regex("[\\s\\p{Punct}]+"))
+                .map { it.filter { ch -> ch.isLetterOrDigit() } }
+                .filter { it.length >= MIN_QUERY_CHARS }
+            if (tokens.isEmpty()) return null
+            // Prefix tokens only — input is already stripped to alphanumerics so MATCH stays safe.
+            return tokens.joinToString(" AND ") { "$it*" }
+        }
+
+        fun snippetFor(body: String, query: String, radius: Int = 56): String? {
+            val needle = query.trim().split(Regex("\\s+")).firstOrNull { it.length >= MIN_QUERY_CHARS }
+                ?: return null
+            val idx = body.indexOf(needle, ignoreCase = true)
+            if (idx < 0) {
+                // FTS may match stemmed/prefix forms; fall back to a head snippet when body matched.
+                val head = body.trim().replace(Regex("\\s+"), " ")
+                if (head.isEmpty()) return null
+                return if (head.length <= radius * 2) head else head.take(radius * 2).trimEnd() + "…"
+            }
+            val start = (idx - radius).coerceAtLeast(0)
+            val end = (idx + needle.length + radius).coerceAtMost(body.length)
+            val slice = body.substring(start, end).replace(Regex("\\s+"), " ").trim()
+            val prefix = if (start > 0) "…" else ""
+            val suffix = if (end < body.length) "…" else ""
+            return prefix + slice + suffix
+        }
+    }
+}

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/OrchestrationSkillContent.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/OrchestrationSkillContent.kt
@@ -163,37 +163,73 @@ internal val ANDY_HANDOFF_SKILL: String =
 
     ## The handoff prompt
 
-    The receiving agent has zero context. Include:
+    The receiving agent has zero context. It cannot see this chat's transcript, plan
+    UI, or prior tool results. Anything the child must know must appear in the
+    prompt you pass to `chat.start`.
+
+    ### When a plan already exists (required)
+
+    If this conversation already produced an implementation plan, design doc, or
+    user-approved plan (assistant message, plan-mode entries, or similar), you
+    **must** include that plan **verbatim** under `## Plan`.
+
+    Rules:
+
+    - Copy the full plan text exactly — every section, code snippet, file path,
+      threshold, and checklist item.
+    - Do **not** paraphrase, compress, or rewrite it into `## Decisions` /
+      `## Acceptance criteria`. Those sections are for when there is no plan.
+    - Prefacing with a one-line "implement this plan exactly" is fine; replacing
+      the plan body with a summary is not.
+    - If the user said "implement this plan" / "exact plan" / similar, the Plan
+      section is the source of truth for the child.
+    - For long plans, write the full prompt to a temp file and pass that file's
+      contents into `chat.start` so nothing is truncated in a shell argument.
+
+    ### Prompt shape
 
     ```
     ## Task
-    [Imperative description.]
+    [Imperative description. If handing off a plan: "Implement the Plan below exactly."]
 
     ## Context
-    [Why this task exists, required context.]
+    [Why this task exists, required background. Keep short when ## Plan is present.]
+
+    ## Plan
+    [PASTE THE FULL APPROVED PLAN VERBATIM HERE — or omit this section only when
+     no plan exists in the parent conversation.]
 
     ## Relevant files
     - `path/to/file.ts` — [what it is and why it matters]
+    [Optional when ## Plan already lists files exhaustively; still include any
+     files the plan omitted that the child will touch.]
 
     ## Current state
-    [What's done, what works, what doesn't.]
+    [What's done, what works, what doesn't. Dirty worktree / overlapping edits.]
 
     ## What was tried
     - [Approach] — [why it failed or was abandoned]
 
     ## Decisions
-    - [Decision — rationale]
+    [Only when ## Plan is absent. Otherwise omit, or list only post-plan deltas
+     that are not already in ## Plan.]
 
     ## Acceptance criteria
-    - [ ] [Criterion]
+    [Only when ## Plan is absent or lacks a checklist. Otherwise omit — do not
+     duplicate a summarized version of the plan's criteria.]
 
     ## Constraints
     - [Must-not / must-preserve]
+    - Implement the ## Plan completely when present; do not stop after a partial slice.
     ```
 
     **Preserve task semantics.** Investigate-only → "DO NOT edit files." Fix →
     "implement the fix." Refactor → "refactor, not rewrite." Carry the user's
     exact intent.
+
+    **Anti-pattern:** turning a numbered implementation plan into bullet
+    "Decisions" and a shortened acceptance list. The child should receive the
+    same plan the user approved in the parent chat.
 
     ## Launch
 
@@ -201,7 +237,7 @@ internal val ANDY_HANDOFF_SKILL: String =
     2. Call `chat.start` with:
        - `agent`: resolved AgentKind
        - `title`: `[Handoff] ` + short summary
-       - `prompt`: the full briefing
+       - `prompt`: the full briefing (including verbatim `## Plan` when applicable)
        - omit `autonomy` so the receiver inherits this task's dial (Full stays Full),
          unless the handoff is investigate-only — then `autonomy: "ReadOnly"` +
          no-edits suffix

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/SqliteAgentStore.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/SqliteAgentStore.kt
@@ -1,7 +1,11 @@
 package app.andy.desktop.service.agents
 
+import app.andy.model.AgentFileDiff
 import app.andy.model.KanbanBoard
+import app.andy.store.AgentJsonSql
 import app.andy.store.openAndyAgentDatabase
+import app.cash.sqldelight.db.QueryResult
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import java.io.File
 
@@ -18,13 +22,22 @@ internal class SqliteAgentStore(
         encodeDefaults = true
     }
 
-    private val db = openAndyAgentDatabase(dbFile)
+    private val handle = openAndyAgentDatabase(dbFile)
+    private val db = handle.database
+    private val driver = handle.driver
+
+    /** Shared FTS driver for Cmd+K transcript search; caller supplies transcript file resolution. */
+    fun transcriptSearchIndex(transcriptFileFor: (String) -> File): DesktopTranscriptSearchIndex =
+        DesktopTranscriptSearchIndex(driver, transcriptFileFor)
 
     fun load(scrollbackFile: (String) -> File): AgentStoreState {
-        val tasks = db.agentStoreQueries.selectAllTasks().executeAsList().mapNotNull { row ->
+        // The lite projection strips completedChanges.diffs in SQL, so decoded snapshots are
+        // summary-only and must be marked unhydrated for the save path to protect them.
+        val tasks = selectAllTaskPayloadsLite().mapNotNull { payload ->
             runCatching {
-                json.decodeFromString(AgentTaskDto.serializer(), row.payload)
+                json.decodeFromString(AgentTaskDto.serializer(), payload)
                     .toModel(scrollbackFile)
+                    ?.withUnhydratedDiffs()
             }.getOrNull()
         }
         val workflows = db.agentStoreQueries.selectAllWorkflows().executeAsList().mapNotNull { row ->
@@ -57,6 +70,69 @@ internal class SqliteAgentStore(
             maxConcurrent = maxConcurrent.coerceIn(1, 64),
             projectWorkflows = workflows,
             legacyTranscriptChatsArchived = legacyArchived,
+        )
+    }
+
+    /** Task payloads with `completedChanges.diffs` stripped by SQLite; see [AgentJsonSql]. */
+    private fun selectAllTaskPayloadsLite(): List<String> =
+        driver.executeQuery(
+            identifier = null,
+            sql = AgentJsonSql.SELECT_ALL_TASKS_LITE,
+            parameters = 0,
+            mapper = { cursor ->
+                val payloads = mutableListOf<String>()
+                while (cursor.next().value) {
+                    cursor.getString(1)?.let(payloads::add)
+                }
+                QueryResult.Value(payloads.toList())
+            },
+        ).value
+
+    /**
+     * Reads one task's stored diffs, which [load] deliberately skipped. Returns an empty map when
+     * the task has no stored diffs; callers cannot distinguish that from "never captured", which
+     * matches the old in-memory behaviour for a chat that changed nothing.
+     */
+    fun loadTaskDiffs(taskId: String): Map<String, AgentFileDiff> {
+        val raw = driver.executeQuery(
+            identifier = null,
+            sql = AgentJsonSql.SELECT_TASK_DIFFS,
+            parameters = 1,
+            binders = { bindString(0, taskId) },
+            mapper = { cursor ->
+                QueryResult.Value(if (cursor.next().value) cursor.getString(0) else null)
+            },
+        ).value?.takeIf { it.isNotBlank() } ?: return emptyMap()
+        return runCatching {
+            json.decodeFromString(ListSerializer(AgentFileDiffDto.serializer()), raw)
+                .associate { it.path to it.toModel() }
+        }.getOrElse { emptyMap() }
+    }
+
+    /** Writes an unhydrated task, splicing its stored diffs back; see [AgentJsonSql]. */
+    private fun writeTaskPreservingDiffs(task: AgentTaskDto, payload: String, now: Long) {
+        db.agentStoreQueries.insertTaskIfAbsent(
+            id = task.id,
+            status = task.status,
+            agent = task.agent,
+            created_at_millis = task.createdAtMillis,
+            updated_at_millis = now,
+            payload = payload,
+        )
+        driver.execute(
+            identifier = null,
+            sql = AgentJsonSql.UPDATE_TASK_PRESERVING_DIFFS,
+            parameters = 8,
+            binders = {
+                bindString(0, task.status)
+                bindString(1, task.agent)
+                bindLong(2, task.createdAtMillis)
+                bindLong(3, now)
+                bindString(4, payload)
+                bindString(5, payload)
+                bindString(6, payload)
+                bindString(7, task.id)
+            },
         )
     }
 
@@ -105,17 +181,27 @@ internal class SqliteAgentStore(
 
         val now = System.currentTimeMillis()
         val dto = state.toFileDto()
+        // Tasks whose diffs were never read off disk must go through the preserving statement, so
+        // skip the old delete-everything-then-reinsert: it would drop the diffs we mean to keep.
+        val unhydrated = state.tasks
+            .filter { it.completedChanges?.diffsHydrated == false }
+            .mapTo(mutableSetOf()) { it.id }
         db.agentStoreQueries.transaction {
-            db.agentStoreQueries.deleteAllTasks()
+            db.agentStoreQueries.deleteTasksNotIn(dto.tasks.map { it.id })
             dto.tasks.forEach { task ->
-                db.agentStoreQueries.upsertTask(
-                    id = task.id,
-                    status = task.status,
-                    agent = task.agent,
-                    created_at_millis = task.createdAtMillis,
-                    updated_at_millis = now,
-                    payload = json.encodeToString(AgentTaskDto.serializer(), task),
-                )
+                val payload = json.encodeToString(AgentTaskDto.serializer(), task)
+                if (task.id in unhydrated) {
+                    writeTaskPreservingDiffs(task, payload, now)
+                } else {
+                    db.agentStoreQueries.upsertTask(
+                        id = task.id,
+                        status = task.status,
+                        agent = task.agent,
+                        created_at_millis = task.createdAtMillis,
+                        updated_at_millis = now,
+                        payload = payload,
+                    )
+                }
             }
             db.agentStoreQueries.deleteAllWorkflows()
             dto.projectWorkflows.forEach { workflow ->

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpTranscriptStore.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/agents/acp/AcpTranscriptStore.kt
@@ -1,6 +1,8 @@
 package app.andy.desktop.service.agents.acp
 
 import app.andy.model.AcpToolCallPresentation
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentAttachmentKind
 import app.andy.model.AgentEvent
 import app.andy.model.coalesceAgentStreamDeltas
 import app.andy.model.AgentPlanEntry
@@ -139,6 +141,7 @@ private data class TranscriptEvent(
     val model: String = "",
     val skills: List<TranscriptSkill> = emptyList(),
     val images: List<String> = emptyList(),
+    val attachments: List<TranscriptAttachment> = emptyList(),
     val toolImages: List<String> = emptyList(),
     val toolName: String = "",
     val toolCallId: String = "",
@@ -195,6 +198,16 @@ private data class TranscriptEvent(
 )
 
 @Serializable private data class TranscriptSkill(val name: String, val path: String)
+@Serializable private data class TranscriptAttachment(
+    val id: String,
+    val displayName: String,
+    val kind: String = "Text",
+    val mediaType: String = "text/plain; charset=utf-8",
+    val byteCount: Long = 0,
+    val lineCount: Long = 0,
+    val sha256: String = "",
+    val relativePath: String = "",
+)
 @Serializable private data class TranscriptQuotaWindow(val label: String, val fraction: Float? = null, val resetAt: Long? = null, val detail: String? = null)
 @Serializable private data class TranscriptPlanEntry(val content: String, val status: String)
 @Serializable private data class TranscriptCommand(val name: String, val description: String, val inputHint: String? = null)
@@ -205,7 +218,25 @@ private fun AgentEvent.toDto(): TranscriptEvent = when (this) {
     is AgentEvent.SessionStarted -> TranscriptEvent("session", atMillis, sessionId = sessionId.orEmpty(), model = model.orEmpty())
     is AgentEvent.AssistantText -> TranscriptEvent("assistant", atMillis, text = text, isStreamDelta = isStreamDelta)
     is AgentEvent.Thinking -> TranscriptEvent("thinking", atMillis, text = text, isStreamDelta = isStreamDelta)
-    is AgentEvent.UserMessage -> TranscriptEvent("user", atMillis, text = text, skills = skills.map { TranscriptSkill(it.name, it.path) }, images = imagePaths)
+    is AgentEvent.UserMessage -> TranscriptEvent(
+        "user",
+        atMillis,
+        text = text,
+        skills = skills.map { TranscriptSkill(it.name, it.path) },
+        images = imagePaths,
+        attachments = attachments.map {
+            TranscriptAttachment(
+                id = it.id,
+                displayName = it.displayName,
+                kind = it.kind.name,
+                mediaType = it.mediaType,
+                byteCount = it.byteCount,
+                lineCount = it.lineCount ?: 0,
+                sha256 = it.sha256,
+                relativePath = it.relativePath.orEmpty(),
+            )
+        },
+    )
     is AgentEvent.ToolCall -> TranscriptEvent("tool", atMillis, toolName = toolName, toolCallId = toolCallId.orEmpty(), summary = summary, detail = detail, toolKind = kind?.name.orEmpty(), toolState = state.name, locations = locations, toolImages = images.map { it.dataUri })
     is AgentEvent.ToolResult -> TranscriptEvent("tool-result", atMillis, toolName = toolName.orEmpty(), summary = summary, detail = detail, isError = isError, quotaWindows = quotaWindows.map { TranscriptQuotaWindow(it.label, it.remainingFraction, it.resetAtMillis, it.detail) })
     is AgentEvent.TaskError -> TranscriptEvent("error", atMillis, text = message)
@@ -255,7 +286,24 @@ private fun TranscriptEvent.toModel(): AgentEvent? = when (type) {
     "session" -> AgentEvent.SessionStarted(atMillis, sessionId.takeIf { it.isNotBlank() }, model.takeIf { it.isNotBlank() })
     "assistant" -> AgentEvent.AssistantText(atMillis, text, isStreamDelta)
     "thinking" -> AgentEvent.Thinking(atMillis, text, isStreamDelta)
-    "user" -> AgentEvent.UserMessage(atMillis, text, skills.map { AgentSkill(it.name, "", it.path) }, images)
+    "user" -> AgentEvent.UserMessage(
+        atMillis,
+        text,
+        skills.map { AgentSkill(it.name, "", it.path) },
+        images,
+        attachments.map {
+            AgentAttachment(
+                id = it.id,
+                displayName = it.displayName,
+                kind = AgentAttachmentKind.entries.firstOrNull { kind -> kind.name == it.kind } ?: AgentAttachmentKind.Text,
+                mediaType = it.mediaType,
+                byteCount = it.byteCount,
+                lineCount = it.lineCount.takeIf { count -> count > 0 },
+                sha256 = it.sha256,
+                relativePath = it.relativePath.takeIf { path -> path.isNotBlank() },
+            )
+        },
+    )
     "tool" -> {
         val storedKind = AgentToolKind.entries.firstOrNull { it.name == toolKind } ?: AgentToolKind.Other
         val resolvedKind = if (storedKind == AgentToolKind.Other) {

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/hub/McpHubOAuthStore.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/hub/McpHubOAuthStore.kt
@@ -85,9 +85,11 @@ class McpHubOAuthStore(
     }
 
     companion object {
+        private val cursorAuthJson = Json { ignoreUnknownKeys = true }
+
         internal fun parseCursorMcpAuth(file: File, serverId: String): McpHubOAuthTokens? {
             val root = runCatching {
-                Json { ignoreUnknownKeys = true }.parseToJsonElement(file.readText()).jsonObject
+                cursorAuthJson.parseToJsonElement(file.readText()).jsonObject
             }.getOrNull() ?: return null
             val serverObj = root[serverId]?.jsonObject ?: return null
             val tokens = serverObj["tokens"]?.jsonObject ?: return null

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/NetworkAccessAuth.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/NetworkAccessAuth.kt
@@ -146,9 +146,9 @@ internal val NetworkAccessAuthPlugin = createApplicationPlugin(
 
         if (resolved != null) {
             if (provided != null && path != "/api/auth/login") {
-                tokenLimiter.clear(pluginConfig.sessionStore.fingerprint(provided))
+                tokenLimiter.resetKey(pluginConfig.sessionStore.fingerprint(provided))
             }
-            ipLimiter.clear(remote)
+            ipLimiter.resetKey(remote)
             call.attributes.put(
                 NetworkAccessAuthFingerprintKey,
                 resolved.fingerprint,
@@ -341,7 +341,7 @@ internal fun evaluateNetworkAccessAuth(
     val resolved = sessionStore.resolveAuth(tokenHeaderOrQuery, expectedToken)
     if (resolved != null) {
         if (!scopeAllows(requiredScope, resolved.scope)) return HttpStatusCode.Forbidden
-        limiter.clear(remoteHost)
+        limiter.resetKey(remoteHost)
         return null
     }
     if (limiter.isBlocked(remoteHost)) return HttpStatusCode.TooManyRequests

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebChatRoutes.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebChatRoutes.kt
@@ -455,7 +455,16 @@ internal fun Application.installWebChatRoutes(
                 if (message.isEmpty() && attachments.isEmpty()) {
                     return@post call.respondJsonError(HttpStatusCode.BadRequest, "message required")
                 }
-                agents.resume(id, message, attachments = attachments)
+                // Await attachment materialization/upload so a missing or changed staging file is
+                // reported to the caller, letting the web client keep and retry the draft. The
+                // provider turn itself continues asynchronously.
+                val prepared = agents.resumePrepared(id, message, attachments = attachments)
+                prepared.exceptionOrNull()?.let { error ->
+                    return@post call.respondJsonError(
+                        HttpStatusCode.BadRequest,
+                        error.message ?: "failed to prepare reply attachments",
+                    )
+                }
                 call.respondText(
                     buildJsonObject {
                         put("ok", true)

--- a/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebChatRoutes.kt
+++ b/data/agents/src/desktopMain/kotlin/app/andy/desktop/service/webchat/WebChatRoutes.kt
@@ -29,8 +29,10 @@ import app.andy.model.providerLoginRemoteInstructions
 import app.andy.model.WorkspaceState
 import app.andy.service.ActionConfigStore
 import app.andy.service.AgentRunService
+import app.andy.service.ChatAttachmentService
 import app.andy.service.ProjectWorkflowService
 import app.andy.service.WorkspaceStore
+import app.andy.desktop.service.parseAttachmentsArg
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
@@ -38,8 +40,8 @@ import io.ktor.server.application.call
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.request.contentLength
 import io.ktor.server.request.receiveChannel
-import io.ktor.utils.io.core.readBytes
 import io.ktor.utils.io.readRemaining
+import kotlinx.io.readByteArray
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
@@ -65,6 +67,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
@@ -75,7 +78,7 @@ private const val WebChatMaxBodyBytes = 1_048_576L
 private suspend fun io.ktor.server.application.ApplicationCall.receiveBoundedText(maxBytes: Long): String? {
     if ((request.contentLength() ?: 0L) > maxBytes) return null
     val channel = receiveChannel()
-    val bytes = channel.readRemaining(maxBytes + 1).readBytes()
+    val bytes = channel.readRemaining(maxBytes + 1).readByteArray()
     if (bytes.size > maxBytes) return null
     return bytes.decodeToString()
 }
@@ -113,6 +116,7 @@ internal fun Application.installWebChatRoutes(
     projectWorkflows: () -> ProjectWorkflowService? = { null },
     actionConfig: () -> ActionConfigStore? = { null },
     workspaceStore: () -> WorkspaceStore? = { null },
+    chatAttachments: () -> ChatAttachmentService? = { null },
     push: WebPushService,
     attention: AttentionHub = AttentionHub(),
     networkAccess: NetworkAccessWebConfig = NetworkAccessWebConfig(),
@@ -437,14 +441,137 @@ internal fun Application.installWebChatRoutes(
                     return@post call.respondJsonError(HttpStatusCode.BadRequest, "message must be string")
                 }
                 val message = body.requiredString("message")?.trim().orEmpty()
-                if (message.isEmpty()) {
+                val attachments = when (val raw = body["attachments"]) {
+                    null, JsonNull -> emptyList()
+                    else -> runCatching {
+                        parseAttachmentsArg(mapOf("attachments" to raw))
+                    }.getOrElse {
+                        return@post call.respondJsonError(
+                            HttpStatusCode.BadRequest,
+                            it.message ?: "invalid attachments",
+                        )
+                    }
+                }
+                if (message.isEmpty() && attachments.isEmpty()) {
                     return@post call.respondJsonError(HttpStatusCode.BadRequest, "message required")
                 }
-                agents.resume(id, message)
+                agents.resume(id, message, attachments = attachments)
                 call.respondText(
                     buildJsonObject {
                         put("ok", true)
                         put("id", id)
+                    }.toString(),
+                    ContentType.Application.Json,
+                )
+            }
+
+            post("/attachments/begin") {
+                val attachments = chatAttachments()
+                    ?: return@post call.respondJsonError(
+                        HttpStatusCode.ServiceUnavailable,
+                        "attachment service unavailable",
+                    )
+                val body = call.receiveJsonObject()
+                    ?: return@post call.respondJsonError(HttpStatusCode.BadRequest, "invalid json")
+                val displayName = body.requiredString("displayName")?.trim().orEmpty()
+                val sha256 = body.requiredString("sha256")?.trim().orEmpty()
+                val byteCount = body["byteCount"]?.let { el ->
+                    (el as? JsonPrimitive)?.longOrNull
+                        ?: el.asJsonStringOrNull()?.toLongOrNull()
+                }
+                if (displayName.isEmpty() || sha256.isEmpty() || byteCount == null) {
+                    return@post call.respondJsonError(
+                        HttpStatusCode.BadRequest,
+                        "displayName, byteCount, and sha256 required",
+                    )
+                }
+                val session = attachments.beginUpload(
+                    displayName = displayName,
+                    byteCount = byteCount,
+                    sha256 = sha256,
+                    mediaType = body.requiredString("mediaType")?.trim()
+                        ?: "text/plain; charset=utf-8",
+                    draftKey = body.requiredString("draftKey")?.trim(),
+                ).getOrElse {
+                    return@post call.respondJsonError(HttpStatusCode.BadRequest, it.message ?: "begin failed")
+                }
+                call.respondText(
+                    buildJsonObject {
+                        put("uploadId", session.uploadId)
+                        put("displayName", session.displayName)
+                        put("expectedBytes", session.expectedBytes)
+                        put("expectedSha256", session.expectedSha256)
+                    }.toString(),
+                    ContentType.Application.Json,
+                )
+            }
+
+            post("/attachments/{uploadId}/append") {
+                val attachments = chatAttachments()
+                    ?: return@post call.respondJsonError(
+                        HttpStatusCode.ServiceUnavailable,
+                        "attachment service unavailable",
+                    )
+                val uploadId = call.parameters["uploadId"].orEmpty()
+                val body = call.receiveJsonObject()
+                    ?: return@post call.respondJsonError(HttpStatusCode.BadRequest, "invalid json")
+                val sequence = body["sequence"]?.let { el ->
+                    (el as? JsonPrimitive)?.contentOrNull?.toIntOrNull()
+                        ?: (el as? JsonPrimitive)?.longOrNull?.toInt()
+                } ?: return@post call.respondJsonError(HttpStatusCode.BadRequest, "sequence required")
+                val chunk = body.requiredString("base64Chunk").orEmpty()
+                if (chunk.isEmpty()) {
+                    return@post call.respondJsonError(HttpStatusCode.BadRequest, "base64Chunk required")
+                }
+                attachments.appendUploadChunk(uploadId, sequence, chunk).getOrElse {
+                    return@post call.respondJsonError(HttpStatusCode.BadRequest, it.message ?: "append failed")
+                }
+                call.respondText(
+                    buildJsonObject {
+                        put("ok", true)
+                        put("uploadId", uploadId)
+                        put("sequence", sequence)
+                    }.toString(),
+                    ContentType.Application.Json,
+                )
+            }
+
+            post("/attachments/{uploadId}/commit") {
+                val attachments = chatAttachments()
+                    ?: return@post call.respondJsonError(
+                        HttpStatusCode.ServiceUnavailable,
+                        "attachment service unavailable",
+                    )
+                val uploadId = call.parameters["uploadId"].orEmpty()
+                val attachment = attachments.commitUpload(uploadId).getOrElse {
+                    return@post call.respondJsonError(HttpStatusCode.BadRequest, it.message ?: "commit failed")
+                }
+                call.respondText(
+                    buildJsonObject {
+                        put("id", attachment.id)
+                        put("displayName", attachment.displayName)
+                        put("kind", attachment.kind.name)
+                        put("mediaType", attachment.mediaType)
+                        put("byteCount", attachment.byteCount)
+                        attachment.lineCount?.let { put("lineCount", it) }
+                        put("sha256", attachment.sha256)
+                    }.toString(),
+                    ContentType.Application.Json,
+                )
+            }
+
+            post("/attachments/{uploadId}/cancel") {
+                val attachments = chatAttachments()
+                    ?: return@post call.respondJsonError(
+                        HttpStatusCode.ServiceUnavailable,
+                        "attachment service unavailable",
+                    )
+                val uploadId = call.parameters["uploadId"].orEmpty()
+                val cancelled = attachments.cancelUpload(uploadId)
+                call.respondText(
+                    buildJsonObject {
+                        put("ok", cancelled)
+                        put("uploadId", uploadId)
                     }.toString(),
                     ContentType.Application.Json,
                 )
@@ -660,7 +787,18 @@ internal fun Application.installWebChatRoutes(
                 val autonomyName = body.requiredString("autonomy")?.trim().orEmpty()
                 val title = body.requiredString("title")?.trim()
                 val projectId = body.requiredString("projectId")?.trim()?.takeIf { it.isNotBlank() }
-                if (prompt.isEmpty()) {
+                val attachments = when (val raw = body["attachments"]) {
+                    null, JsonNull -> emptyList()
+                    else -> runCatching {
+                        parseAttachmentsArg(mapOf("attachments" to raw))
+                    }.getOrElse {
+                        return@post call.respondJsonError(
+                            HttpStatusCode.BadRequest,
+                            it.message ?: "invalid attachments",
+                        )
+                    }
+                }
+                if (prompt.isEmpty() && attachments.isEmpty()) {
                     return@post call.respondJsonError(HttpStatusCode.BadRequest, "prompt required")
                 }
                 if (agentName.isEmpty()) {
@@ -710,7 +848,8 @@ internal fun Application.installWebChatRoutes(
                     if (agent.isLocalModelBackend) prefixedLocalModelId(agent, raw) else raw
                 }
                 val draft = AgentTaskDraft(
-                        title = title?.takeIf { it.isNotBlank() } ?: prompt.take(48),
+                        title = title?.takeIf { it.isNotBlank() }
+                            ?: prompt.take(48).ifBlank { attachments.firstOrNull()?.displayName.orEmpty() },
                         prompt = prompt,
                         agent = agent,
                         localRuntime = runtime,
@@ -718,6 +857,7 @@ internal fun Application.installWebChatRoutes(
                         directory = resolvedDirectory,
                         autonomy = autonomy,
                         model = model,
+                        attachments = attachments,
                     )
                 draft.localModelLaunchError()?.let { message ->
                     return@post call.respondJsonError(HttpStatusCode.BadRequest, message)

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentToolsWorktreeTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentToolsWorktreeTest.kt
@@ -303,5 +303,6 @@ private class FakeWorktreeAgentRunService(
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) = Unit
 }

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/McpChatStartAutonomyInheritanceTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/McpChatStartAutonomyInheritanceTest.kt
@@ -484,5 +484,6 @@ private class FakeAutonomyAgentRunService : AgentRunService by UnavailableAgentR
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) = Unit
 }

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/McpChatSubscribeTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/McpChatSubscribeTest.kt
@@ -621,6 +621,7 @@ private class FakeSubscribeAgentRunService : AgentRunService by UnavailableAgent
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) {
         resumeCalls += ResumeCall(taskId, followUp, imagePaths)
     }
@@ -632,6 +633,7 @@ private class FakeSubscribeAgentRunService : AgentRunService by UnavailableAgent
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) {
         queueCalls += QueueCall(taskId, followUp, imagePaths)
     }

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/ParseAttachmentsArgTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/ParseAttachmentsArgTest.kt
@@ -1,0 +1,79 @@
+package app.andy.desktop.service
+
+import app.andy.desktop.service.agents.DesktopChatAttachmentService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class ParseAttachmentsArgTest {
+    @Test
+    fun ignoresClientProvidedRelativePathOnInboundDescriptors() {
+        val args = mapOf(
+            "attachments" to JsonArray(
+                listOf(
+                    buildJsonObject {
+                        put("id", "att-abc123")
+                        put("displayName", "paste.txt")
+                        put("byteCount", 100)
+                        put("sha256", "ab".repeat(32))
+                        put("relativePath", "../../etc/passwd")
+                    },
+                ),
+            ),
+        )
+        val parsed = parseAttachmentsArg(args)
+        assertEquals(1, parsed.size)
+        assertNull(parsed.single().relativePath)
+        assertEquals("att-abc123", parsed.single().id)
+    }
+
+    @Test
+    fun acceptsManagedDescriptorWithoutRelativePath() {
+        val args = mapOf(
+            "attachments" to JsonArray(
+                listOf(
+                    buildJsonObject {
+                        put("id", "att-xyz789")
+                        put("displayName", "big.txt")
+                        put("byteCount", 2048)
+                        put("sha256", "cd".repeat(32))
+                        put("lineCount", 40)
+                    },
+                ),
+            ),
+        )
+        val parsed = parseAttachmentsArg(args).single()
+        assertNull(parsed.relativePath)
+        assertEquals(2048L, parsed.byteCount)
+        assertEquals(40L, parsed.lineCount)
+        assertTrue(
+            DesktopChatAttachmentService.isSafeTaskRelativeAttachmentPath(
+                ".andy/task-1/attachments/big.txt",
+                "task-1",
+            ),
+        )
+        assertFalse(
+            DesktopChatAttachmentService.isSafeTaskRelativeAttachmentPath(
+                ".andy/other/attachments/big.txt",
+                "task-1",
+            ),
+        )
+        assertFalse(
+            DesktopChatAttachmentService.isSafeTaskRelativeAttachmentPath(
+                "/abs/path",
+                "task-1",
+            ),
+        )
+        assertFalse(
+            DesktopChatAttachmentService.isSafeTaskRelativeAttachmentPath(
+                ".andy/task-1/attachments/../secrets.txt",
+                "task-1",
+            ),
+        )
+    }
+}

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/ChatAttachmentStartupExpiryTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/ChatAttachmentStartupExpiryTest.kt
@@ -1,0 +1,124 @@
+package app.andy.desktop.service.agents
+
+import app.andy.model.ActionProject
+import app.andy.model.ActionsConfig
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentKind
+import app.andy.model.AgentTask
+import app.andy.model.WorkspaceState
+import app.andy.service.ActionConfigStore
+import app.andy.service.ChatAttachmentService
+import app.andy.service.ChatAttachmentUploadSession
+import app.andy.service.CommandResult
+import app.andy.service.McpServerService
+import app.andy.service.WorkspaceStore
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+class ChatAttachmentStartupExpiryTest {
+    @Test
+    fun expiresAbandonedStagingDuringServiceStartup() = runBlocking {
+        val root = File.createTempFile("andy-attach-expiry", null).also { it.delete(); it.mkdirs() }
+        val store = DesktopAgentTaskStore(File(root, "agents.db"))
+        store.save(
+            AgentStoreState(
+                binaryOverrides = AgentKind.entries.associate { it.cliName to "/bin/sh" },
+            ),
+        )
+        val attachments = RecordingChatAttachments()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val service = DesktopAgentRunService(
+            scope = scope,
+            store = store,
+            locator = AgentCliLocator(),
+            adapters = mapOf(
+                AgentKind.Codex to object : AgentCliAdapter {
+                    override val kind: AgentKind = AgentKind.Codex
+                    override fun buildInteractiveCommand(binary: String, task: AgentTask, mcpUrl: String?): List<String> =
+                        listOf(binary, "-c", "exit 0")
+                    override fun buildInteractiveResumeCommand(
+                        binary: String,
+                        task: AgentTask,
+                        mcpUrl: String?,
+                        followUp: String?,
+                        followUpImagePaths: List<String>,
+                    ): List<String>? = null
+                    override fun interactiveResumeCommand(binary: String, task: AgentTask): String = binary
+                },
+            ),
+            worktrees = WorktreeManager(File(root, "worktrees")),
+            mcp = object : McpServerService {
+                override val status = MutableStateFlow("stopped")
+                override val running = MutableStateFlow(false)
+                override suspend fun start(port: Int): CommandResult = CommandResult.success()
+                override suspend fun stop(): CommandResult = CommandResult.success()
+                override fun getSnippet(clientName: String, port: Int): String = ""
+                override fun getClients(): List<String> = emptyList()
+                override fun isAutoWriteSupported(clientName: String): Boolean = false
+                override fun writeConfig(clientName: String, port: Int): Boolean = false
+                override fun getToolNames(): List<String> = emptyList()
+            },
+            workspaceStore = object : WorkspaceStore {
+                override suspend fun load(): WorkspaceState = WorkspaceState()
+                override suspend fun save(state: WorkspaceState) = Unit
+            },
+            actionConfig = object : ActionConfigStore {
+                override suspend fun load(): ActionsConfig = ActionsConfig(
+                    projects = listOf(ActionProject("p", "P", root.absolutePath)),
+                )
+                override suspend fun save(config: ActionsConfig) = Unit
+            },
+            enableProbes = false,
+            terminalMode = AgentTerminalMode.DirectPty,
+            chatAttachments = attachments,
+        )
+        try {
+            service.awaitReady()
+            withTimeout(5_000) {
+                while (attachments.expireCalls.get() == 0) delay(20)
+            }
+            assertTrue(attachments.expireCalls.get() >= 1)
+        } finally {
+            runCatching { service.close() }
+            scope.cancel()
+            root.deleteRecursively()
+        }
+    }
+
+    private class RecordingChatAttachments : ChatAttachmentService {
+        val expireCalls = AtomicInteger(0)
+        override suspend fun stageText(text: String, displayName: String, draftKey: String?): Result<AgentAttachment> =
+            Result.failure(UnsupportedOperationException())
+        override suspend fun discardStaged(attachmentId: String) = false
+        override suspend fun materializeForTask(taskId: String, cwd: String?, attachments: List<AgentAttachment>) =
+            attachments
+        override suspend fun discardDraft(draftKey: String) = Unit
+        override suspend fun expireAbandonedStaging(maxAgeMillis: Long) {
+            expireCalls.incrementAndGet()
+        }
+        override suspend fun beginUpload(
+            displayName: String,
+            byteCount: Long,
+            sha256: String,
+            mediaType: String,
+            draftKey: String?,
+        ): Result<ChatAttachmentUploadSession> = Result.failure(UnsupportedOperationException())
+        override suspend fun appendUploadChunk(uploadId: String, sequence: Int, base64Chunk: String): Result<Unit> =
+            Result.failure(UnsupportedOperationException())
+        override suspend fun commitUpload(uploadId: String): Result<AgentAttachment> =
+            Result.failure(UnsupportedOperationException())
+        override suspend fun cancelUpload(uploadId: String) = false
+        override suspend fun readStagedChunk(attachmentId: String, offset: Long, maxBytes: Int): ByteArray? = null
+        override suspend fun spilloverPromptIfNeeded(taskId: String, cwd: String?, prompt: String) = prompt
+    }
+}

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStoreTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopAgentTaskStoreTest.kt
@@ -42,6 +42,7 @@ import app.andy.model.ProjectWorkflowState
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 
@@ -141,9 +142,99 @@ class DesktopAgentTaskStoreTest {
         )
         store.save(AgentStoreState(tasks = listOf(task), binaryOverrides = mapOf("codex" to "/bin/codex"), maxConcurrent = 4))
         val loaded = store.load()
-        assertEquals(listOf(task), loaded.tasks)
+        // Diffs are deliberately left on disk; everything else round-trips verbatim.
+        val expected = task.copy(
+            completedChanges = task.completedChanges?.copy(diffs = emptyMap(), diffsHydrated = false),
+        )
+        assertEquals(listOf(expected), loaded.tasks)
         assertEquals(mapOf("codex" to "/bin/codex"), loaded.binaryOverrides)
         assertEquals(4, loaded.maxConcurrent)
+        assertEquals(task.completedChanges?.diffs, store.loadCompletedDiffs("task-abc"))
+    }
+
+    /** A task with completed changes, diffs included. */
+    private fun taskWithDiffs(id: String, text: String = "new") = AgentTask(
+        id = id,
+        title = "t",
+        prompt = "p",
+        agent = AgentKind.Codex,
+        cwd = "/tmp",
+        originDir = "/tmp",
+        status = AgentStatus.Done,
+        createdAtMillis = 1,
+        completedChanges = AgentThreadChangeSnapshot(
+            summary = AgentChangeSummary(listOf(AgentFileChange("src/Main.kt", additions = 1, deletions = 0))),
+            diffs = mapOf(
+                "src/Main.kt" to AgentFileDiff(
+                    path = "src/Main.kt",
+                    lines = listOf(DiffLine(DiffLineKind.Addition, text, newLineNumber = 1)),
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun savingASummaryOnlyTaskKeepsItsStoredDiffs() = withStore { store ->
+        val task = taskWithDiffs("task-keep")
+        store.save(AgentStoreState(tasks = listOf(task)))
+
+        // Simulate the app's real cycle: load (summary-only), mutate something unrelated, save.
+        val loaded = store.load().tasks.single()
+        assertEquals(false, loaded.completedChanges?.diffsHydrated)
+        assertTrue(loaded.completedChanges?.diffs.isNullOrEmpty())
+        store.save(AgentStoreState(tasks = listOf(loaded.copy(unread = true, title = "renamed"))))
+
+        assertEquals(task.completedChanges?.diffs, store.loadCompletedDiffs("task-keep"))
+        val reloaded = store.load().tasks.single()
+        assertEquals("renamed", reloaded.title)
+        assertTrue(reloaded.unread)
+        assertEquals(
+            task.completedChanges?.summary,
+            reloaded.completedChanges?.summary,
+        )
+    }
+
+    @Test
+    fun clearingCompletedChangesWritesThrough() = withStore { store ->
+        store.save(AgentStoreState(tasks = listOf(taskWithDiffs("task-undo"))))
+        val loaded = store.load().tasks.single()
+
+        // Undo nulls completedChanges; that must not be defeated by the preserving write.
+        store.save(AgentStoreState(tasks = listOf(loaded.copy(completedChanges = null))))
+
+        assertEquals(emptyMap(), store.loadCompletedDiffs("task-undo"))
+        assertNull(store.load().tasks.single().completedChanges)
+    }
+
+    @Test
+    fun freshlyCapturedDiffsReplaceStoredOnes() = withStore { store ->
+        store.save(AgentStoreState(tasks = listOf(taskWithDiffs("task-recapture", text = "first"))))
+        val loaded = store.load().tasks.single()
+
+        // A new capture arrives hydrated, so it must overwrite rather than be spliced over.
+        val recaptured = taskWithDiffs("task-recapture", text = "second")
+        store.save(AgentStoreState(tasks = listOf(loaded.copy(completedChanges = recaptured.completedChanges))))
+
+        val diffs = store.loadCompletedDiffs("task-recapture")
+        assertEquals("second", diffs["src/Main.kt"]?.lines?.single()?.text)
+    }
+
+    @Test
+    fun taskWithoutStoredDiffsLoadsEmpty() = withStore { store ->
+        val noChanges = taskWithDiffs("task-plain").copy(completedChanges = null)
+        store.save(AgentStoreState(tasks = listOf(noChanges)))
+        assertEquals(emptyMap(), store.loadCompletedDiffs("task-plain"))
+        assertEquals(emptyMap(), store.loadCompletedDiffs("task-does-not-exist"))
+    }
+
+    @Test
+    fun deletingATaskRemovesItsRow() = withStore { store ->
+        store.save(AgentStoreState(tasks = listOf(taskWithDiffs("task-a"), taskWithDiffs("task-b"))))
+        val remaining = store.load().tasks.filter { it.id == "task-a" }
+        store.save(AgentStoreState(tasks = remaining))
+
+        assertEquals(listOf("task-a"), store.load().tasks.map { it.id })
+        assertEquals(emptyMap(), store.loadCompletedDiffs("task-b"))
     }
 
     @Test

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopChatAttachmentServiceTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopChatAttachmentServiceTest.kt
@@ -1,0 +1,343 @@
+package app.andy.desktop.service.agents
+
+import app.andy.model.ChatAttachmentLimits
+import app.andy.model.shouldAttachLargeText
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.security.MessageDigest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DesktopChatAttachmentServiceTest {
+    private lateinit var root: File
+    private lateinit var service: DesktopChatAttachmentService
+
+    @BeforeTest
+    fun setUp() {
+        root = File.createTempFile("andy-attach-", ".dir").also {
+            it.delete()
+            it.mkdirs()
+        }
+        service = DesktopChatAttachmentService(stagingRoot = root)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun stagesTextAtomicallyWithHashAndLineCount() = runBlocking {
+        val text = (1..2_500).joinToString("\n") { "line-$it" }
+        assertTrue(shouldAttachLargeText(text))
+        val attachment = service.stageText(text, displayName = "paste.txt", draftKey = "draft-1").getOrThrow()
+        val file = service.stagedFile(attachment.id)!!
+        assertTrue(file.isFile)
+        assertEquals(text, file.readText())
+        assertEquals(sha256(text), attachment.sha256)
+        assertEquals(2_500L, attachment.lineCount)
+        assertEquals(text.encodeToByteArray().size.toLong(), attachment.byteCount)
+        assertEquals("paste.txt", attachment.displayName)
+    }
+
+    @Test
+    fun rejectsTraversalDisplayNames() = runBlocking {
+        val attachment = service.stageText("hello", displayName = "../../evil.txt").getOrThrow()
+        assertFalse(attachment.displayName.contains(".."))
+        assertTrue(File(root, attachment.id).listFiles()!!.none { it.path.contains("..") })
+    }
+
+    @Test
+    fun materializesUnderTaskCwdAttachments() = runBlocking {
+        val text = "x".repeat(ChatAttachmentLimits.InlineMaxBytes.toInt() + 10)
+        val staged = service.stageText(text, displayName = "big.txt").getOrThrow()
+        val cwd = File(root, "project").also { it.mkdirs() }
+        val materialized = service.materializeForTask("task-abc", cwd.absolutePath, listOf(staged))
+        val relative = materialized.single().relativePath!!
+        assertEquals(".andy/task-abc/attachments/big.txt", relative)
+        val onDisk = File(cwd, relative)
+        assertTrue(onDisk.isFile)
+        assertEquals(text, onDisk.readText())
+        assertEquals(sha256(text), materialized.single().sha256)
+    }
+
+    @Test
+    fun uploadChunkProtocolVerifiesIntegrity() = runBlocking {
+        val payload = "chunked-" + "z".repeat(100_000)
+        val bytes = payload.encodeToByteArray()
+        val begin = service.beginUpload(
+            displayName = "upload.txt",
+            byteCount = bytes.size.toLong(),
+            sha256 = sha256(payload),
+        ).getOrThrow()
+        val mid = bytes.size / 2
+        service.appendUploadChunk(begin.uploadId, 0, java.util.Base64.getEncoder().encodeToString(bytes.copyOfRange(0, mid)))
+            .getOrThrow()
+        service.appendUploadChunk(begin.uploadId, 1, java.util.Base64.getEncoder().encodeToString(bytes.copyOfRange(mid, bytes.size)))
+            .getOrThrow()
+        val committed = service.commitUpload(begin.uploadId).getOrThrow()
+        assertEquals(bytes.size.toLong(), committed.byteCount)
+        assertEquals(sha256(payload), committed.sha256)
+    }
+
+    @Test
+    fun uploadRejectsHashMismatch() = runBlocking {
+        val payload = "bad-hash"
+        val begin = service.beginUpload(
+            displayName = "bad.txt",
+            byteCount = payload.encodeToByteArray().size.toLong(),
+            sha256 = "0".repeat(64),
+        ).getOrThrow()
+        service.appendUploadChunk(
+            begin.uploadId,
+            0,
+            java.util.Base64.getEncoder().encodeToString(payload.encodeToByteArray()),
+        ).getOrThrow()
+        assertTrue(service.commitUpload(begin.uploadId).isFailure)
+    }
+
+    @Test
+    fun spilloverReplacesOversizedPrompt() = runBlocking {
+        val huge = "p".repeat(ChatAttachmentLimits.InlineMaxBytes.toInt() + 50)
+        val cwd = File(root, "spill-project").also { it.mkdirs() }
+        val spilled = service.spilloverPromptIfNeeded("task-spill", cwd.absolutePath, huge)
+        assertTrue(spilled.length < 2_000)
+        assertTrue(spilled.contains(".andy/task-spill/attachments/"))
+        assertFalse(spilled.contains(huge.take(100)))
+        val files = File(cwd, ".andy/task-spill/attachments").listFiles()!!.filter { it.isFile }
+        assertEquals(1, files.size)
+        assertEquals(huge, files.single().readText())
+    }
+
+    @Test
+    fun discardRemovesOnlyOwnedStaging() = runBlocking {
+        val a = service.stageText("a".repeat(70_000), draftKey = "d1").getOrThrow()
+        val b = service.stageText("b".repeat(70_000), draftKey = "d2").getOrThrow()
+        assertTrue(service.discardStaged(a.id))
+        assertFalse(File(root, a.id).exists())
+        assertTrue(File(root, b.id).exists())
+        service.discardDraft("d2")
+        assertFalse(File(root, b.id).exists())
+    }
+
+    @Test
+    fun largeGeneratedFixtureStagesMaterializesAndBoundsPrompt() = runBlocking {
+        val fixture = File(root, "generated-9mib.txt")
+        val line = "0123456789abcdef\n".toByteArray()
+        val targetBytes = 9L * 1024 * 1024
+        java.io.FileOutputStream(fixture).use { out ->
+            var written = 0L
+            while (written < targetBytes) {
+                out.write(line)
+                written += line.size
+            }
+        }
+        assertTrue(fixture.length() in (8L * 1024 * 1024)..(10L * 1024 * 1024))
+
+        val digest = MessageDigest.getInstance("SHA-256")
+        var lineCount = 0L
+        var prevWasNewline = true
+        fixture.inputStream().use { input ->
+            val buf = ByteArray(64 * 1024)
+            while (true) {
+                val n = input.read(buf)
+                if (n < 0) break
+                digest.update(buf, 0, n)
+                for (i in 0 until n) {
+                    when (buf[i]) {
+                        '\n'.code.toByte() -> {
+                            lineCount++
+                            prevWasNewline = true
+                        }
+                        else -> prevWasNewline = false
+                    }
+                }
+            }
+        }
+        if (fixture.length() > 0 && !prevWasNewline) lineCount++
+        val sha = digest.digest().joinToString("") { b ->
+            ((b.toInt() and 0xff) + 0x100).toString(16).substring(1)
+        }
+
+        val begin = service.beginUpload(
+            displayName = "generated-9mib.txt",
+            byteCount = fixture.length(),
+            sha256 = sha,
+        ).getOrThrow()
+        var offset = 0L
+        var sequence = 0
+        fixture.inputStream().use { input ->
+            val buf = ByteArray(ChatAttachmentLimits.UploadChunkBytes)
+            while (true) {
+                val n = input.read(buf)
+                if (n < 0) break
+                val chunk = if (n == buf.size) buf else buf.copyOf(n)
+                service.appendUploadChunk(
+                    begin.uploadId,
+                    sequence,
+                    java.util.Base64.getEncoder().encodeToString(chunk),
+                ).getOrThrow()
+                offset += n
+                sequence++
+            }
+        }
+        assertEquals(fixture.length(), offset)
+        val staged = service.commitUpload(begin.uploadId).getOrThrow()
+        assertEquals(fixture.length(), staged.byteCount)
+        assertEquals(sha, staged.sha256)
+        assertEquals(lineCount, staged.lineCount)
+
+        val cwd = File(root, "big-project").also { it.mkdirs() }
+        val materialized = service.materializeForTask("task-big", cwd.absolutePath, listOf(staged))
+        val relative = materialized.single().relativePath!!
+        val onDisk = File(cwd, relative)
+        assertTrue(onDisk.isFile)
+        assertEquals(fixture.length(), onDisk.length())
+        assertEquals(sha, materialized.single().sha256)
+        assertFalse(File(root, staged.id).exists(), "staging must be released after materialize")
+
+        val prompt = app.andy.model.promptWithAttachmentHints("summarize this file", materialized)
+        assertTrue(prompt.length < 4_000, "prompt must stay bounded, was ${prompt.length}")
+        assertTrue(prompt.contains(relative))
+        assertTrue(prompt.contains(sha))
+        assertFalse(prompt.contains("0123456789abcdef".repeat(20)))
+
+        // Restart / retry without in-memory stagedMeta: rematerialize from task-relative copy.
+        val restarted = DesktopChatAttachmentService(stagingRoot = File(root, "empty-staging").also { it.mkdirs() })
+        val again = restarted.materializeForTask("task-big", cwd.absolutePath, materialized)
+        assertEquals(relative, again.single().relativePath)
+        assertTrue(File(cwd, relative).isFile)
+    }
+
+    @Test
+    fun expireAbandonedStagingRemovesOnlyOldEntries() = runBlocking {
+        val old = service.stageText("o".repeat(70_000), displayName = "old.txt").getOrThrow()
+        val fresh = service.stageText("f".repeat(70_000), displayName = "fresh.txt").getOrThrow()
+        val oldDir = File(root, old.id)
+        assertTrue(oldDir.setLastModified(System.currentTimeMillis() - 48L * 60 * 60 * 1000))
+        service.expireAbandonedStaging(maxAgeMillis = 24L * 60 * 60 * 1000)
+        assertFalse(oldDir.exists())
+        assertTrue(File(root, fresh.id).exists())
+    }
+
+    @Test
+    fun multiAttachmentMaterializeIsAtomicOnFailure() = runBlocking {
+        val a = service.stageText("a".repeat(70_000), displayName = "a.txt").getOrThrow()
+        val b = service.stageText("b".repeat(70_000), displayName = "b.txt").getOrThrow()
+        // Corrupt the second staging source so materialize fails after the first dest is created.
+        File(root, b.id).deleteRecursively()
+        val cwd = File(root, "atomic-project").also { it.mkdirs() }
+        assertFails {
+            service.materializeForTask("task-atomic", cwd.absolutePath, listOf(a, b))
+        }
+        assertTrue(File(root, a.id).exists(), "first staging source must be retained")
+        val destDir = File(cwd, ".andy/task-atomic/attachments")
+        val leftovers = destDir.listFiles()?.filter { it.isFile }.orEmpty()
+        assertTrue(leftovers.isEmpty(), "partial dest files must be cleaned: $leftovers")
+    }
+
+    @Test
+    fun rejectsTraversalAndSiblingRelativePathsOnReuse() = runBlocking {
+        val staged = service.stageText("safe-body-" + "z".repeat(70_000), displayName = "safe.txt").getOrThrow()
+        val cwd = File(root, "path-project").also { it.mkdirs() }
+        val good = service.materializeForTask("task-path", cwd.absolutePath, listOf(staged)).single()
+        val onDisk = File(cwd, good.relativePath!!)
+        assertTrue(onDisk.isFile)
+
+        // Sibling task file that happens to match size/hash must not be selectable.
+        val siblingDir = File(cwd, ".andy/other-task/attachments").also { it.mkdirs() }
+        val sibling = File(siblingDir, "evil.txt")
+        onDisk.copyTo(sibling, overwrite = true)
+
+        val traversal = good.copy(relativePath = "../../.andy/other-task/attachments/evil.txt")
+        val absolute = good.copy(relativePath = sibling.absolutePath)
+        val siblingRelative = good.copy(relativePath = ".andy/other-task/attachments/evil.txt")
+
+        // Without staging (already released), unsafe relativePath must not reuse sibling files.
+        assertFails { service.materializeForTask("task-path", cwd.absolutePath, listOf(traversal)) }
+        assertFails { service.materializeForTask("task-path", cwd.absolutePath, listOf(absolute)) }
+        assertFails { service.materializeForTask("task-path", cwd.absolutePath, listOf(siblingRelative)) }
+
+        // Canonical same-task path still works after restart-style rematerialize.
+        val again = service.materializeForTask("task-path", cwd.absolutePath, listOf(good))
+        assertEquals(good.relativePath, again.single().relativePath)
+    }
+
+    @Test
+    fun beginUploadReservesDraftBudgetAndReleasesOnCancel() = runBlocking {
+        val tight = DesktopChatAttachmentService(
+            stagingRoot = File(root, "budget").also { it.mkdirs() },
+            maxStagedBytesPerDraft = 1_000L,
+        )
+        val placeholderSha = "ab".repeat(32)
+        val first = tight.beginUpload("one.txt", byteCount = 600, sha256 = placeholderSha, draftKey = "draft")
+            .getOrThrow()
+        assertEquals(600L, tight.draftByteTotal("draft"))
+        assertTrue(
+            tight.beginUpload("two.txt", byteCount = 600, sha256 = placeholderSha, draftKey = "draft").isFailure,
+            "second begin must fail while first reservation is held",
+        )
+        assertEquals(600L, tight.draftByteTotal("draft"))
+        assertTrue(tight.cancelUpload(first.uploadId))
+        assertEquals(0L, tight.draftByteTotal("draft"))
+
+        val body = ByteArray(400) { 'x'.code.toByte() }
+        val realSha = MessageDigest.getInstance("SHA-256").digest(body).joinToString("") { b ->
+            ((b.toInt() and 0xff) + 0x100).toString(16).substring(1)
+        }
+        val begin = tight.beginUpload("ok.txt", byteCount = 400, sha256 = realSha, draftKey = "draft").getOrThrow()
+        assertEquals(400L, tight.draftByteTotal("draft"))
+        tight.appendUploadChunk(begin.uploadId, 0, java.util.Base64.getEncoder().encodeToString(body)).getOrThrow()
+        val committed = tight.commitUpload(begin.uploadId).getOrThrow()
+        assertEquals(400L, committed.byteCount)
+        assertEquals(400L, tight.draftByteTotal("draft"), "commit must not double-count reservation")
+        assertTrue(tight.beginUpload("overflow.txt", byteCount = 700, sha256 = placeholderSha, draftKey = "draft").isFailure)
+        assertTrue(tight.beginUpload("fit.txt", byteCount = 600, sha256 = placeholderSha, draftKey = "draft").isSuccess)
+        assertEquals(1_000L, tight.draftByteTotal("draft"))
+    }
+
+    @Test
+    fun hashFailureReleasesReservation() = runBlocking {
+        val tight = DesktopChatAttachmentService(stagingRoot = File(root, "hash-budget").also { it.mkdirs() }, maxStagedBytesPerDraft = 500L)
+        val body = ByteArray(200) { 'y'.code.toByte() }
+        val begin = tight.beginUpload(
+            displayName = "bad.txt",
+            byteCount = 200,
+            sha256 = "0".repeat(64),
+            draftKey = "d",
+        ).getOrThrow()
+        assertEquals(200L, tight.draftByteTotal("d"))
+        tight.appendUploadChunk(begin.uploadId, 0, java.util.Base64.getEncoder().encodeToString(body)).getOrThrow()
+        assertTrue(tight.commitUpload(begin.uploadId).isFailure)
+        assertEquals(0L, tight.draftByteTotal("d"))
+    }
+
+    @Test
+    fun expireAbandonedStagingDecrementsDraftTotals() = runBlocking {
+        val staged = service.stageText("e".repeat(70_000), draftKey = "expire-draft").getOrThrow()
+        assertTrue(service.draftByteTotal("expire-draft") > 0L)
+        val dir = File(root, staged.id)
+        assertTrue(dir.setLastModified(System.currentTimeMillis() - 48L * 60 * 60 * 1000))
+        service.expireAbandonedStaging(maxAgeMillis = 24L * 60 * 60 * 1000)
+        assertFalse(dir.exists())
+        assertEquals(0L, service.draftByteTotal("expire-draft"))
+    }
+
+    @Test
+    fun cancelUploadDiscardsCommittedStagedAttachment() = runBlocking {
+        val staged = service.stageText("c".repeat(70_000), displayName = "committed.txt").getOrThrow()
+        assertTrue(File(root, staged.id).exists())
+        assertTrue(service.cancelUpload(staged.id), "cancel must discard committed staging")
+        assertFalse(File(root, staged.id).exists())
+    }
+
+    private fun sha256(text: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(text.encodeToByteArray())
+        return digest.joinToString("") { b -> ((b.toInt() and 0xff) + 0x100).toString(16).substring(1) }
+    }
+}

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopTranscriptSearchIndexTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/DesktopTranscriptSearchIndexTest.kt
@@ -1,0 +1,209 @@
+package app.andy.desktop.service.agents
+
+import app.andy.model.AgentEvent
+import app.andy.store.openAndyAgentDatabase
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DesktopTranscriptSearchIndexTest {
+    @Test
+    fun searchableTextSkipsThinkingAndToolDetail() {
+        assertEquals(
+            "hello",
+            DesktopTranscriptSearchIndex.searchableText(AgentEvent.UserMessage(1L, "hello")),
+        )
+        assertEquals(
+            "reply",
+            DesktopTranscriptSearchIndex.searchableText(AgentEvent.AssistantText(1L, "reply")),
+        )
+        assertNull(
+            DesktopTranscriptSearchIndex.searchableText(
+                AgentEvent.AssistantText(1L, "delta", isStreamDelta = true),
+            ),
+        )
+        assertNull(
+            DesktopTranscriptSearchIndex.searchableText(AgentEvent.Thinking(1L, "secret plan")),
+        )
+        assertEquals(
+            "Read path/to/file",
+            DesktopTranscriptSearchIndex.searchableText(
+                AgentEvent.ToolCall(1L, "Read", "path/to/file", detail = "huge dump"),
+            ),
+        )
+    }
+
+    @Test
+    fun ftsMatchQueryBuildsPrefixAnd() {
+        assertEquals("auth* AND token*", DesktopTranscriptSearchIndex.ftsMatchQuery("auth token"))
+        assertNull(DesktopTranscriptSearchIndex.ftsMatchQuery("a"))
+        assertNull(DesktopTranscriptSearchIndex.ftsMatchQuery("  "))
+    }
+
+    @Test
+    fun snippetSurroundsMatch() {
+        val body = "alpha beta gamma delta epsilon"
+        val snippet = DesktopTranscriptSearchIndex.snippetFor(body, "gamma", radius = 6)
+        assertNotNull(snippet)
+        assertTrue(snippet.contains("gamma"))
+    }
+
+    @Test
+    fun searchStreamsHitFromIndexedTranscript() = runBlocking {
+        val root = File.createTempFile("andy-transcript-search", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        try {
+            val dbFile = File(root, "agents.db")
+            val handle = openAndyAgentDatabase(dbFile)
+            val taskId = "chat-1"
+            val transcript = File(root, "$taskId/transcript.jsonl")
+            transcript.parentFile.mkdirs()
+            val store = app.andy.desktop.service.agents.acp.AcpTranscriptStore(fileFor = { File(root, "$it/transcript.jsonl") })
+            store.append(taskId, AgentEvent.UserMessage(1L, "please wire oauth refresh"))
+            store.append(taskId, AgentEvent.AssistantText(2L, "Sure, updating the token path"))
+
+            val index = DesktopTranscriptSearchIndex(handle.driver) { id ->
+                File(root, "$id/transcript.jsonl")
+            }
+            index.reindexTask(taskId)
+
+            val hits = index.search(
+                query = "oauth",
+                tasks = listOf(
+                    DesktopTranscriptSearchIndex.TaskRef(
+                        taskId = taskId,
+                        projectId = "proj",
+                        title = "OAuth work",
+                        projectName = "Andy",
+                        updatedAtMillis = 10L,
+                    ),
+                ),
+            ).toList()
+
+            assertEquals(1, hits.size)
+            assertEquals(taskId, hits.single().taskId)
+            assertTrue(hits.single().snippet.contains("oauth", ignoreCase = true))
+            assertEquals("Andy", hits.single().projectName)
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun coldTaskIsIndexedDuringSearch() = runBlocking {
+        val root = File.createTempFile("andy-transcript-cold", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        try {
+            val dbFile = File(root, "agents.db")
+            val handle = openAndyAgentDatabase(dbFile)
+            val taskId = "cold-1"
+            val store = app.andy.desktop.service.agents.acp.AcpTranscriptStore(fileFor = { File(root, "$it/transcript.jsonl") })
+            File(root, taskId).mkdirs()
+            store.append(taskId, AgentEvent.UserMessage(1L, "unique-zebra-phrase in body"))
+
+            val index = DesktopTranscriptSearchIndex(handle.driver) { id ->
+                File(root, "$id/transcript.jsonl")
+            }
+            // Do not reindex upfront — search should cold-index.
+            val hits = index.search(
+                query = "zebra",
+                tasks = listOf(
+                    DesktopTranscriptSearchIndex.TaskRef(
+                        taskId = taskId,
+                        projectId = null,
+                        title = "Cold",
+                        projectName = null,
+                        updatedAtMillis = 1L,
+                    ),
+                ),
+            ).toList()
+            assertEquals(1, hits.size)
+            assertTrue(hits.single().snippet.contains("zebra", ignoreCase = true))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun excludeTaskIdsSkipsHits() = runBlocking {
+        val root = File.createTempFile("andy-transcript-exclude", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        try {
+            val handle = openAndyAgentDatabase(File(root, "agents.db"))
+            val taskId = "ex-1"
+            val store = app.andy.desktop.service.agents.acp.AcpTranscriptStore(fileFor = { File(root, "$it/transcript.jsonl") })
+            File(root, taskId).mkdirs()
+            store.append(taskId, AgentEvent.UserMessage(1L, "needle in transcript"))
+            val index = DesktopTranscriptSearchIndex(handle.driver) { id ->
+                File(root, "$id/transcript.jsonl")
+            }
+            index.reindexTask(taskId)
+            val hits = index.search(
+                query = "needle",
+                tasks = listOf(
+                    DesktopTranscriptSearchIndex.TaskRef(taskId, null, "T", null, 1L),
+                ),
+                excludeTaskIds = setOf(taskId),
+            ).toList()
+            assertTrue(hits.isEmpty())
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun removeTaskClearsIndex() = runBlocking {
+        val root = File.createTempFile("andy-transcript-remove", null).also {
+            it.delete()
+            it.mkdirs()
+        }
+        try {
+            val handle = openAndyAgentDatabase(File(root, "agents.db"))
+            val taskId = "rm-1"
+            val store = app.andy.desktop.service.agents.acp.AcpTranscriptStore(fileFor = { File(root, "$it/transcript.jsonl") })
+            File(root, taskId).mkdirs()
+            store.append(taskId, AgentEvent.UserMessage(1L, "vanishing text"))
+            val index = DesktopTranscriptSearchIndex(handle.driver) { id ->
+                File(root, "$id/transcript.jsonl")
+            }
+            index.reindexTask(taskId)
+            index.removeTask(taskId)
+            // Delete transcript so cold path cannot revive the hit.
+            File(root, "$taskId/transcript.jsonl").delete()
+            val hits = index.search(
+                query = "vanishing",
+                tasks = listOf(
+                    DesktopTranscriptSearchIndex.TaskRef(taskId, null, "T", null, 1L),
+                ),
+            ).toList()
+            assertTrue(hits.isEmpty())
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun buildSearchableBodyJoinsParts() {
+        val body = DesktopTranscriptSearchIndex.buildSearchableBody(
+            listOf(
+                AgentEvent.UserMessage(1L, "one"),
+                AgentEvent.Thinking(2L, "skip"),
+                AgentEvent.AssistantText(3L, "two"),
+            ),
+        )
+        assertEquals("one\ntwo", body)
+        assertFalse(body.contains("skip"))
+    }
+}

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/TemporaryChatLifecycleTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/agents/TemporaryChatLifecycleTest.kt
@@ -141,6 +141,24 @@ class TemporaryChatLifecycleTest {
         assertFalse(tempDir.exists())
     }
 
+    @Test
+    fun deletingPermanentChatRemovesOnlyThatTasksWorkflowArtifacts() = withService { harness ->
+        val keep = harness.service.createAndStart(harness.draft("keep me"))
+        val remove = harness.service.createAndStart(harness.draft("delete me"))
+        val keepDir = AgentWorkflowArtifacts.dirFor(harness.projectDir, keep.id).also { it.mkdirs() }
+        val removeDir = AgentWorkflowArtifacts.dirFor(harness.projectDir, remove.id).also { it.mkdirs() }
+        File(keepDir, "attachments").mkdirs()
+        File(File(keepDir, "attachments"), "keep.txt").writeText("sibling")
+        File(removeDir, "attachments").mkdirs()
+        File(File(removeDir, "attachments"), "gone.txt").writeText("delete")
+
+        harness.service.delete(remove.id, removeWorktree = false)
+
+        assertFalse(removeDir.exists(), "deleted chat's .andy/<taskId> must be removed")
+        assertTrue(keepDir.exists(), "sibling task artifacts must survive")
+        assertEquals("sibling", File(keepDir, "attachments/keep.txt").readText())
+    }
+
     private class Harness(
         val service: DesktopAgentRunService,
         val store: DesktopAgentTaskStore,

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/automations/DesktopAutomationServiceTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/automations/DesktopAutomationServiceTest.kt
@@ -404,6 +404,7 @@ private class FakeAutomationAgentRuns : AgentRunService by UnavailableAgentRunSe
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) {
         resumeCalls += taskId to followUp
         _tasks.value = _tasks.value.map { task ->

--- a/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/webchat/WebChatHttpServerTest.kt
+++ b/data/agents/src/desktopTest/kotlin/app/andy/desktop/service/webchat/WebChatHttpServerTest.kt
@@ -1017,6 +1017,7 @@ class WebChatHttpServerTest {
             skills: List<app.andy.model.AgentSkill>,
             contextBundleIds: List<String>,
             provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
         ) {
             lastResume = taskId to followUp
             _tasks.value = _tasks.value.map { task ->

--- a/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/voice/GlobalHotKeyRegistrar.kt
+++ b/data/platform-tools/src/desktopMain/kotlin/app/andy/desktop/service/voice/GlobalHotKeyRegistrar.kt
@@ -75,61 +75,71 @@ internal object MacOsGlobalHotKeyRegistrar : GlobalHotKeyRegistrar {
     override val lastError: StateFlow<String?> = _lastError.asStateFlow()
 
     @Volatile private var loaded: Boolean? = null
-    private var handle: Int = -1
+    private val lock = Any()
+    @Volatile private var handle: Int = -1
 
     override fun register(spec: GlobalHotKeySpec?): Boolean {
-        _lastError.value = null
-        if (spec == null) {
-            unregister()
-            return true
-        }
-        if (!ensureLoaded()) {
-            _lastError.value = "macOS voice bridge unavailable"
-            return false
-        }
-        val mapped = CarbonHotKeyMapping.fromPackedKeyCode(
-            packedKeyCode = spec.packedKeyCode,
-            ctrl = spec.ctrl,
-            meta = spec.meta,
-            alt = spec.alt,
-            shift = spec.shift,
-        )
-        if (mapped == null) {
-            _lastError.value = "That key combination cannot be registered as a global hotkey"
-            unregister()
-            return false
-        }
-        return try {
-            val newHandle = MacOsGlobalHotKeyBridge.nativeRegisterHotKey(
-                mapped.virtualKeyCode,
-                mapped.carbonModifiers,
-            )
-            if (newHandle < 0) {
-                _lastError.value = "Failed to register global hotkey with macOS (status $newHandle)"
-                handle = -1
-                voiceDebugLog("GlobalHotKey: register failed status=$newHandle key=0x${mapped.virtualKeyCode.toString(16)} mods=0x${mapped.carbonModifiers.toString(16)}")
-                false
-            } else {
-                handle = newHandle
-                voiceDebugLog("GlobalHotKey: register requested handle=$newHandle key=0x${mapped.virtualKeyCode.toString(16)} mods=0x${mapped.carbonModifiers.toString(16)}")
-                true
+        synchronized(lock) {
+            _lastError.value = null
+            if (spec == null) {
+                unregisterLocked()
+                return true
             }
-        } catch (t: Throwable) {
-            _lastError.value = t.message ?: "Failed to register global hotkey"
-            handle = -1
-            voiceDebugLog("GlobalHotKey: register threw ${t.message}")
-            false
+            if (!ensureLoaded()) {
+                _lastError.value = "macOS voice bridge unavailable"
+                return false
+            }
+            val mapped = CarbonHotKeyMapping.fromPackedKeyCode(
+                packedKeyCode = spec.packedKeyCode,
+                ctrl = spec.ctrl,
+                meta = spec.meta,
+                alt = spec.alt,
+                shift = spec.shift,
+            )
+            if (mapped == null) {
+                _lastError.value = "That key combination cannot be registered as a global hotkey"
+                unregisterLocked()
+                return false
+            }
+            return try {
+                val newHandle = MacOsGlobalHotKeyBridge.nativeRegisterHotKey(
+                    mapped.virtualKeyCode,
+                    mapped.carbonModifiers,
+                )
+                if (newHandle < 0) {
+                    _lastError.value = "Failed to register global hotkey with macOS (status $newHandle)"
+                    handle = -1
+                    voiceDebugLog("GlobalHotKey: register failed status=$newHandle key=0x${mapped.virtualKeyCode.toString(16)} mods=0x${mapped.carbonModifiers.toString(16)}")
+                    false
+                } else {
+                    handle = newHandle
+                    voiceDebugLog("GlobalHotKey: register requested handle=$newHandle key=0x${mapped.virtualKeyCode.toString(16)} mods=0x${mapped.carbonModifiers.toString(16)}")
+                    true
+                }
+            } catch (t: Throwable) {
+                _lastError.value = t.message ?: "Failed to register global hotkey"
+                handle = -1
+                voiceDebugLog("GlobalHotKey: register threw ${t.message}")
+                false
+            }
         }
     }
 
     /**
      * Called from JNI on the AppKit main thread once Carbon has rejected the registration that
      * [register] kicked off. [status] is a negated OSStatus (or -1 when the handler failed).
+     * Ignores failures for a handle that is no longer current (stale async work).
      */
-    fun notifyRegisterFailed(status: Int) {
-        handle = -1
-        _lastError.value = "Failed to register global hotkey with macOS (status $status)"
-        voiceDebugLog("GlobalHotKey: register failed async status=$status")
+    fun notifyRegisterFailed(failedHandle: Int, status: Int) {
+        synchronized(lock) {
+            if (handle != failedHandle) {
+                voiceDebugLog("GlobalHotKey: ignoring stale register failure handle=$failedHandle status=$status current=$handle")
+                return
+            }
+            handle = -1
+            _lastError.value = "Failed to register global hotkey with macOS (status $status)"
+            voiceDebugLog("GlobalHotKey: register failed async status=$status")
+        }
     }
 
     /** Called from JNI on the AppKit main thread via [MacOsGlobalHotKeyBridge.dispatchHotKeyPressed]. */
@@ -146,7 +156,7 @@ internal object MacOsGlobalHotKeyRegistrar : GlobalHotKeyRegistrar {
         }
     }
 
-    private fun unregister() {
+    private fun unregisterLocked() {
         if (handle < 0 && loaded != true) return
         if (ensureLoaded()) {
             runCatching { MacOsGlobalHotKeyBridge.nativeUnregisterHotKey(handle) }
@@ -176,8 +186,8 @@ internal object MacOsGlobalHotKeyBridge {
 
     /** Static entry the async registration path invokes on failure — keep `@JvmStatic`. */
     @JvmStatic
-    fun dispatchRegisterFailed(status: Int) {
-        MacOsGlobalHotKeyRegistrar.notifyRegisterFailed(status)
+    fun dispatchRegisterFailed(handle: Int, status: Int) {
+        MacOsGlobalHotKeyRegistrar.notifyRegisterFailed(handle, status)
     }
 
     @JvmStatic

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
@@ -39,6 +39,8 @@ import app.andy.model.AgentSessionMode
 import app.andy.model.AgentSkill
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskDraft
+import app.andy.model.TranscriptSearchHit
+import app.andy.desktop.service.agents.DesktopTranscriptSearchIndex
 import app.andy.model.Automation
 import app.andy.model.AutomationDraft
 import app.andy.model.WorktreeBaseOption
@@ -54,13 +56,17 @@ import app.andy.model.ProjectTaskKind
 import app.andy.model.ProjectWorkflowState
 import app.andy.service.AgentRunService
 import app.andy.service.AutomationService
+import app.andy.service.ChatAttachmentService
 import app.andy.service.CommandResult
 import app.andy.service.ProjectWorkflowService
+import app.andy.service.UnavailableChatAttachmentService
+import app.andy.model.AgentAttachment
 import app.andy.terminal.TmuxAndy
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -106,6 +112,11 @@ class McpAgentRunClient(
     private val scope: CoroutineScope,
     private val socketPath: File,
     private val cliLocator: AgentCliLocator = AgentCliLocator(),
+    /**
+     * Local staging service on the GUI host. Remote chat mutations upload through
+     * chat.attachment_* before sending daemon-side descriptors.
+     */
+    private val localAttachments: ChatAttachmentService = UnavailableChatAttachmentService,
 ) : AgentRunService, ProjectWorkflowService, AutomationService {
     private val json = Json { ignoreUnknownKeys = true }
     private val idSeq = AtomicLong(1)
@@ -197,6 +208,13 @@ class McpAgentRunClient(
             sharedAgentTaskStore.archiveFile(taskId).isFile
         File(sharedAgentTaskStore.resolvedContentDirBlocking(taskId, compressed), "transcript.jsonl")
     })
+    private val transcriptSearch by lazy {
+        sharedAgentTaskStore.transcriptSearchIndex { taskId ->
+            val compressed = _tasks.value.firstOrNull { it.id == taskId }?.transcriptCompressed == true ||
+                sharedAgentTaskStore.archiveFile(taskId).isFile
+            File(sharedAgentTaskStore.resolvedContentDirBlocking(taskId, compressed), "transcript.jsonl")
+        }
+    }
 
     private var localBridge: DesktopAgentRunService? = null
 
@@ -257,25 +275,30 @@ class McpAgentRunClient(
         if (appForeground) clientViewingTaskId.get()?.let(::setOf).orEmpty() else emptySet()
 
     private suspend fun refreshTasks() {
-        refreshComposerOptions()
-        refreshProviderDefaults()
-        // Snapshot before the fetch: the list we are about to request is produced after the
-        // daemon acknowledged these reads, so it already reflects them.
-        val settledReads = daemonAckedReadTaskIds.toSet()
-        val raw = callTool("chat.list", emptyMap())
-        val arr = runCatching { json.parseToJsonElement(raw).jsonArray }.getOrNull() ?: return
-        // Keep a lightweight task list for the GUI; lifecycle fields must round-trip so
-        // badges/labels match the daemon (startedAtMillis drives isQueued).
-        val refreshedTasks = arr.mapNotNull { el -> parseListedTask(el.jsonObject) }
-        dropSettledClientReads(clientReadTaskIds, daemonAckedReadTaskIds, settledReads)
-        dropConfirmedClientReads(clientReadTaskIds, refreshedTasks)
-        _tasks.value = mergeRefreshedAgentTasks(
-            refreshed = refreshedTasks,
-            clientReadTaskIds = clientReadTaskIds,
-            viewingTaskIds = viewingTaskIdsForMerge(),
-        ).filterNot { it.id in locallyDeletedTaskIds }
-        locallyDeletedTaskIds.removeAll { deletedId -> refreshedTasks.none { it.id == deletedId } }
-        if (!tasksLoaded.isCompleted) tasksLoaded.complete(Unit)
+        try {
+            refreshComposerOptions()
+            refreshProviderDefaults()
+            // Snapshot before the fetch: the list we are about to request is produced after the
+            // daemon acknowledged these reads, so it already reflects them.
+            val settledReads = daemonAckedReadTaskIds.toSet()
+            val raw = callTool("chat.list", emptyMap())
+            val arr = runCatching { json.parseToJsonElement(raw).jsonArray }.getOrNull()
+            if (arr == null) return
+            // Keep a lightweight task list for the GUI; lifecycle fields must round-trip so
+            // badges/labels match the daemon (startedAtMillis drives isQueued).
+            val refreshedTasks = arr.mapNotNull { el -> parseListedTask(el.jsonObject) }
+            dropSettledClientReads(clientReadTaskIds, daemonAckedReadTaskIds, settledReads)
+            dropConfirmedClientReads(clientReadTaskIds, refreshedTasks)
+            _tasks.value = mergeRefreshedAgentTasks(
+                refreshed = refreshedTasks,
+                clientReadTaskIds = clientReadTaskIds,
+                viewingTaskIds = viewingTaskIdsForMerge(),
+            ).filterNot { it.id in locallyDeletedTaskIds }
+            locallyDeletedTaskIds.removeAll { deletedId -> refreshedTasks.none { it.id == deletedId } }
+        } finally {
+            // Always complete — parse/RPC failure must not hang plugin attach forever.
+            if (!tasksLoaded.isCompleted) tasksLoaded.complete(Unit)
+        }
     }
 
     override suspend fun awaitTasksLoaded() {
@@ -456,6 +479,18 @@ class McpAgentRunClient(
         hierarchyNodeId?.let { put("hierarchyNodeId", it) }
         packageName?.let { put("packageName", it) }
         kanbanCardId?.let { put("kanbanCardId", it) }
+    }
+
+    /** Descriptor-only serialization for managed text attachments (never bodies). */
+    private fun app.andy.model.AgentAttachment.toJsonObject(): JsonObject = buildJsonObject {
+        put("id", id)
+        put("displayName", displayName)
+        put("kind", kind.name)
+        put("mediaType", mediaType)
+        put("byteCount", byteCount)
+        lineCount?.let { put("lineCount", it) }
+        put("sha256", sha256)
+        relativePath?.let { put("relativePath", it) }
     }
 
     private fun JsonObject.string(key: String): String? =
@@ -723,57 +758,62 @@ class McpAgentRunClient(
     override fun refreshSlashCommands(agent: AgentKind, directory: String?) = Unit
 
     override suspend fun createAndStart(draft: AgentTaskDraft): AgentTask {
-        val raw = callTool(
-            "chat.start",
-            buildMap {
-                put("prompt", JsonPrimitive(draft.prompt))
-                put("agent", JsonPrimitive(draft.agent.name))
-                put("title", JsonPrimitive(draft.title))
-                draft.projectId?.let { put("projectId", JsonPrimitive(it)) }
-                draft.directory?.let { put("directory", JsonPrimitive(it)) }
-                put("useWorktree", JsonPrimitive(draft.useWorktree))
-                draft.existingWorktreePath?.takeIf { it.isNotBlank() }?.let {
-                    put("existingWorktreePath", JsonPrimitive(it))
-                }
-                draft.baseWorktreeTaskId?.let { put("baseWorktreeTaskId", JsonPrimitive(it)) }
-                draft.baseRef?.takeIf { it.isNotBlank() }?.let { put("baseRef", JsonPrimitive(it)) }
-                put("attachAndyMcp", JsonPrimitive(draft.attachAndyMcp))
-                put("autonomy", JsonPrimitive(draft.autonomy.name))
-                draft.model?.takeIf { it.isNotBlank() }?.let { put("model", JsonPrimitive(it)) }
-                if (draft.imagePaths.isNotEmpty()) {
-                    put("imagePaths", JsonArray(draft.imagePaths.map { JsonPrimitive(it) }))
-                }
-                // Managed evidence bundle ids only (§4) — never a local filesystem path.
-                if (draft.contextBundleIds.isNotEmpty()) {
-                    put("contextBundleIds", JsonArray(draft.contextBundleIds.map { JsonPrimitive(it) }))
-                }
-                draft.provenance?.let { put("provenance", it.toJsonObject()) }
-                draft.lane?.let { put("lane", JsonPrimitive(it.name)) }
-                draft.vendorSessionId?.takeIf { it.isNotBlank() }?.let {
-                    put("vendorSessionId", JsonPrimitive(it))
-                }
-            },
-        )
-        refreshTasks()
-        val id = runCatching {
-            json.parseToJsonElement(raw).jsonObject["id"]?.jsonPrimitive?.content
-        }.getOrNull()
-        val listed = id?.let { taskId -> _tasks.value.firstOrNull { it.id == taskId } }
-        if (listed != null) return listed
-        val fallback = AgentTask(
-            id = id ?: UUID.randomUUID().toString(),
-            title = draft.title,
-            prompt = draft.prompt,
-            agent = draft.agent,
-            projectId = draft.projectId,
-            cwd = draft.directory,
-            attachAndyMcp = draft.attachAndyMcp,
-            lane = draft.lane ?: draft.agent.defaultLane(),
-            status = app.andy.model.AgentStatus.Working,
-            createdAtMillis = System.currentTimeMillis(),
-        )
-        _tasks.value = _tasks.value + fallback
-        return fallback
+        return withRemoteAttachments(draft.attachments) { remoteAttachments ->
+            val raw = callTool(
+                "chat.start",
+                buildMap {
+                    put("prompt", JsonPrimitive(draft.prompt))
+                    put("agent", JsonPrimitive(draft.agent.name))
+                    put("title", JsonPrimitive(draft.title))
+                    draft.projectId?.let { put("projectId", JsonPrimitive(it)) }
+                    draft.directory?.let { put("directory", JsonPrimitive(it)) }
+                    put("useWorktree", JsonPrimitive(draft.useWorktree))
+                    draft.existingWorktreePath?.takeIf { it.isNotBlank() }?.let {
+                        put("existingWorktreePath", JsonPrimitive(it))
+                    }
+                    draft.baseWorktreeTaskId?.let { put("baseWorktreeTaskId", JsonPrimitive(it)) }
+                    draft.baseRef?.takeIf { it.isNotBlank() }?.let { put("baseRef", JsonPrimitive(it)) }
+                    put("attachAndyMcp", JsonPrimitive(draft.attachAndyMcp))
+                    put("autonomy", JsonPrimitive(draft.autonomy.name))
+                    draft.model?.takeIf { it.isNotBlank() }?.let { put("model", JsonPrimitive(it)) }
+                    if (draft.imagePaths.isNotEmpty()) {
+                        put("imagePaths", JsonArray(draft.imagePaths.map { JsonPrimitive(it) }))
+                    }
+                    if (remoteAttachments.isNotEmpty()) {
+                        put("attachments", JsonArray(remoteAttachments.map { it.toJsonObject() }))
+                    }
+                    // Managed evidence bundle ids only (§4) — never a local filesystem path.
+                    if (draft.contextBundleIds.isNotEmpty()) {
+                        put("contextBundleIds", JsonArray(draft.contextBundleIds.map { JsonPrimitive(it) }))
+                    }
+                    draft.provenance?.let { put("provenance", it.toJsonObject()) }
+                    draft.lane?.let { put("lane", JsonPrimitive(it.name)) }
+                    draft.vendorSessionId?.takeIf { it.isNotBlank() }?.let {
+                        put("vendorSessionId", JsonPrimitive(it))
+                    }
+                },
+            )
+            refreshTasks()
+            val id = runCatching {
+                json.parseToJsonElement(raw).jsonObject["id"]?.jsonPrimitive?.content
+            }.getOrNull()
+            val listed = id?.let { taskId -> _tasks.value.firstOrNull { it.id == taskId } }
+            if (listed != null) return@withRemoteAttachments listed
+            val fallback = AgentTask(
+                id = id ?: UUID.randomUUID().toString(),
+                title = draft.title,
+                prompt = draft.prompt,
+                agent = draft.agent,
+                projectId = draft.projectId,
+                cwd = draft.directory,
+                attachAndyMcp = draft.attachAndyMcp,
+                lane = draft.lane ?: draft.agent.defaultLane(),
+                status = app.andy.model.AgentStatus.Working,
+                createdAtMillis = System.currentTimeMillis(),
+            )
+            _tasks.value = _tasks.value + fallback
+            fallback
+        }
     }
 
     override fun stop(taskId: String) {
@@ -802,8 +842,27 @@ class McpAgentRunClient(
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) {
         scope.launch {
+            resumePrepared(taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments)
+                .onFailure { error ->
+                    patchTask(taskId) { it.copy(errorMessage = error.message) }
+                    System.err.println("andy: chat.resume attachment upload failed for $taskId: ${error.message}")
+                }
+        }
+    }
+
+    override suspend fun resumePrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
+    ): Result<Unit> = runCatching {
+        withRemoteAttachments(attachments) { remotes ->
             callTool(
                 "chat.resume",
                 buildMap {
@@ -812,6 +871,9 @@ class McpAgentRunClient(
                     if (imagePaths.isNotEmpty()) {
                         put("imagePaths", JsonArray(imagePaths.map { JsonPrimitive(it) }))
                     }
+                    if (remotes.isNotEmpty()) {
+                        put("attachments", JsonArray(remotes.map { it.toJsonObject() }))
+                    }
                     // Managed evidence bundle ids only (§4) — never a local filesystem path.
                     if (contextBundleIds.isNotEmpty()) {
                         put("contextBundleIds", JsonArray(contextBundleIds.map { JsonPrimitive(it) }))
@@ -819,7 +881,7 @@ class McpAgentRunClient(
                 },
             )
         }
-    }
+    }.map { }
 
     override fun reattachSession(taskId: String) {
         localBridge?.reattachSession(taskId)
@@ -902,8 +964,27 @@ class McpAgentRunClient(
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) {
         scope.launch {
+            queueFollowUpPrepared(taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments)
+                .onFailure { error ->
+                    patchTask(taskId) { it.copy(errorMessage = error.message) }
+                    System.err.println("andy: chat.queue_follow_up attachment upload failed for $taskId: ${error.message}")
+                }
+        }
+    }
+
+    override suspend fun queueFollowUpPrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
+    ): Result<Unit> = runCatching {
+        withRemoteAttachments(attachments) { remotes ->
             callTool(
                 "chat.queue_follow_up",
                 buildMap {
@@ -912,11 +993,49 @@ class McpAgentRunClient(
                     if (imagePaths.isNotEmpty()) {
                         put("imagePaths", JsonArray(imagePaths.map { JsonPrimitive(it) }))
                     }
+                    if (remotes.isNotEmpty()) {
+                        put("attachments", JsonArray(remotes.map { it.toJsonObject() }))
+                    }
                     if (contextBundleIds.isNotEmpty()) {
                         put("contextBundleIds", JsonArray(contextBundleIds.map { JsonPrimitive(it) }))
                     }
                 },
             )
+        }
+    }.map { }
+
+    /**
+     * Streams each local staged attachment to the daemon and returns remote descriptors.
+     * Never forwards GUI-local staging ids — those cannot be materialized on andyd.
+     * Locals are retained until the chat mutation succeeds.
+     */
+    private suspend fun uploadAttachmentsForRemote(
+        attachments: List<AgentAttachment>,
+    ): RemoteAttachmentUploadResult {
+        if (attachments.isEmpty()) return RemoteAttachmentUploadResult(emptyList(), emptyList())
+        return uploadLocalAttachmentsToRemote(
+            attachments = attachments,
+            readChunk = { id, offset, max -> localAttachments.readStagedChunk(id, offset, max) },
+            callTool = { name, args -> callTool(name, args) },
+        )
+    }
+
+    /**
+     * Uploads locals → runs [block] with remote descriptors → discards locals on success,
+     * or cancels every remote staging id created by this attempt on failure.
+     */
+    private suspend fun <T> withRemoteAttachments(
+        attachments: List<AgentAttachment>,
+        block: suspend (remotes: List<AgentAttachment>) -> T,
+    ): T {
+        val upload = uploadAttachmentsForRemote(attachments)
+        return try {
+            val result = block(upload.remotes)
+            discardLocalsAfterMutationSuccess(upload.localIds) { id -> localAttachments.discardStaged(id) }
+            result
+        } catch (error: Exception) {
+            cleanupRemoteAttachmentsAfterMutationFailure(upload.remotes) { name, args -> callTool(name, args) }
+            throw error
         }
     }
 
@@ -1083,6 +1202,19 @@ class McpAgentRunClient(
             }
         }
         return flow
+    }
+
+    override fun searchTranscripts(query: String): Flow<TranscriptSearchHit> {
+        val refs = _tasks.value.map { task ->
+            DesktopTranscriptSearchIndex.TaskRef(
+                taskId = task.id,
+                projectId = task.projectId,
+                title = task.title,
+                projectName = null,
+                updatedAtMillis = task.finishedAtMillis ?: task.createdAtMillis,
+            )
+        }
+        return transcriptSearch.search(query, refs)
     }
 
     override fun interactiveResumeCommand(taskId: String): String? =

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/McpAgentRunClient.kt
@@ -40,7 +40,6 @@ import app.andy.model.AgentSkill
 import app.andy.model.AgentTask
 import app.andy.model.AgentTaskDraft
 import app.andy.model.TranscriptSearchHit
-import app.andy.desktop.service.agents.DesktopTranscriptSearchIndex
 import app.andy.model.Automation
 import app.andy.model.AutomationDraft
 import app.andy.model.WorktreeBaseOption
@@ -70,6 +69,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
@@ -208,13 +209,6 @@ class McpAgentRunClient(
             sharedAgentTaskStore.archiveFile(taskId).isFile
         File(sharedAgentTaskStore.resolvedContentDirBlocking(taskId, compressed), "transcript.jsonl")
     })
-    private val transcriptSearch by lazy {
-        sharedAgentTaskStore.transcriptSearchIndex { taskId ->
-            val compressed = _tasks.value.firstOrNull { it.id == taskId }?.transcriptCompressed == true ||
-                sharedAgentTaskStore.archiveFile(taskId).isFile
-            File(sharedAgentTaskStore.resolvedContentDirBlocking(taskId, compressed), "transcript.jsonl")
-        }
-    }
 
     private var localBridge: DesktopAgentRunService? = null
 
@@ -1204,18 +1198,29 @@ class McpAgentRunClient(
         return flow
     }
 
-    override fun searchTranscripts(query: String): Flow<TranscriptSearchHit> {
-        val refs = _tasks.value.map { task ->
-            DesktopTranscriptSearchIndex.TaskRef(
-                taskId = task.id,
-                projectId = task.projectId,
-                title = task.title,
-                projectName = null,
-                updatedAtMillis = task.finishedAtMillis ?: task.createdAtMillis,
+    override fun searchTranscripts(query: String): Flow<TranscriptSearchHit> = flow {
+        if (query.trim().length < 2) return@flow
+        // Remote transcripts live on the host that owns andyd; delegate so the search sees the
+        // authoritative index instead of the GUI machine's (empty) local artifact directory.
+        val raw = runCatching {
+            callTool("chat.search", mapOf("query" to JsonPrimitive(query)))
+        }.getOrNull() ?: return@flow
+        val hits = runCatching { json.parseToJsonElement(raw).jsonArray }.getOrNull() ?: return@flow
+        for (element in hits) {
+            val obj = element as? JsonObject ?: continue
+            val taskId = obj.string("taskId") ?: continue
+            emit(
+                TranscriptSearchHit(
+                    taskId = taskId,
+                    projectId = obj.string("projectId")?.takeIf { it.isNotBlank() },
+                    title = obj.string("title").orEmpty(),
+                    projectName = obj.string("projectName")?.takeIf { it.isNotBlank() },
+                    snippet = obj.string("snippet").orEmpty(),
+                    atMillis = obj.long("atMillis") ?: 0L,
+                ),
             )
         }
-        return transcriptSearch.search(query, refs)
-    }
+    }.flowOn(Dispatchers.IO)
 
     override fun interactiveResumeCommand(taskId: String): String? =
         "tmux -L andy attach -t ${TmuxAndy.sessionName(taskId)}"

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/RemoteChatAttachmentUpload.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/RemoteChatAttachmentUpload.kt
@@ -1,0 +1,166 @@
+package app.andy.desktop.service
+
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentAttachmentKind
+import app.andy.model.ChatAttachmentLimits
+import java.util.Base64
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+
+/**
+ * Result of streaming local staged attachments to a remote andyd. Locals are retained until the
+ * caller confirms the final chat mutation succeeded ([discardLocalsAfterMutationSuccess]).
+ */
+internal data class RemoteAttachmentUploadResult(
+    val remotes: List<AgentAttachment>,
+    val localIds: List<String>,
+)
+
+/**
+ * Streams locally staged managed attachments to a remote andyd via
+ * `chat.attachment_begin` / `append` / `commit` in bounded chunks.
+ *
+ * Does **not** discard local sources — callers must call [discardLocalsAfterMutationSuccess]
+ * only after chat.start / resume / queue_follow_up succeeds. On any upload failure, every
+ * remote upload or committed staged id created by this attempt is cancelled/discarded and
+ * locals are left intact for retry.
+ */
+internal suspend fun uploadLocalAttachmentsToRemote(
+    attachments: List<AgentAttachment>,
+    readChunk: suspend (attachmentId: String, offset: Long, maxBytes: Int) -> ByteArray?,
+    callTool: suspend (name: String, arguments: Map<String, JsonElement>) -> String,
+    chunkBytes: Int = ChatAttachmentLimits.UploadChunkBytes,
+): RemoteAttachmentUploadResult {
+    if (attachments.isEmpty()) return RemoteAttachmentUploadResult(emptyList(), emptyList())
+    val committedRemoteIds = mutableListOf<String>()
+    val remotes = mutableListOf<AgentAttachment>()
+    try {
+        for (local in attachments) {
+            var uploadId: String? = null
+            var committed = false
+            try {
+                val beginRaw = callTool(
+                    "chat.attachment_begin",
+                    buildMap {
+                        put("displayName", JsonPrimitive(local.displayName))
+                        put("byteCount", JsonPrimitive(local.byteCount))
+                        put("sha256", JsonPrimitive(local.sha256))
+                        put("mediaType", JsonPrimitive(local.mediaType))
+                    },
+                )
+                uploadId = parseUploadId(beginRaw)
+                    ?: error("chat.attachment_begin did not return uploadId")
+                var offset = 0L
+                var sequence = 0
+                while (offset < local.byteCount) {
+                    val chunk = readChunk(local.id, offset, chunkBytes)
+                        ?: error("Staged attachment missing during upload: ${local.id}")
+                    if (chunk.isEmpty()) break
+                    callTool(
+                        "chat.attachment_append",
+                        mapOf(
+                            "uploadId" to JsonPrimitive(uploadId),
+                            "sequence" to JsonPrimitive(sequence),
+                            "base64Chunk" to JsonPrimitive(Base64.getEncoder().encodeToString(chunk)),
+                        ),
+                    )
+                    offset += chunk.size
+                    sequence++
+                }
+                if (offset != local.byteCount) {
+                    error("Uploaded $offset of ${local.byteCount} bytes for ${local.displayName}")
+                }
+                val commitRaw = callTool(
+                    "chat.attachment_commit",
+                    mapOf("uploadId" to JsonPrimitive(uploadId)),
+                )
+                val remote = parseAttachmentDescriptor(commitRaw)
+                committed = true
+                committedRemoteIds += remote.id
+                remotes += remote
+            } catch (error: Exception) {
+                if (!committed) {
+                    uploadId?.let { id -> cancelRemoteAttachment(callTool, id) }
+                }
+                throw IllegalStateException(
+                    "Failed to upload attachment ${local.displayName}: ${error.message ?: error::class.simpleName}",
+                    error,
+                )
+            }
+        }
+        return RemoteAttachmentUploadResult(
+            remotes = remotes,
+            localIds = attachments.map { it.id },
+        )
+    } catch (error: Exception) {
+        committedRemoteIds.forEach { id -> cancelRemoteAttachment(callTool, id) }
+        throw error
+    }
+}
+
+/** Best-effort cancel for in-progress or committed-but-unsent remote staging. */
+internal suspend fun cancelRemoteAttachment(
+    callTool: suspend (name: String, arguments: Map<String, JsonElement>) -> String,
+    attachmentOrUploadId: String,
+) {
+    runCatching {
+        callTool(
+            "chat.attachment_cancel",
+            mapOf("uploadId" to JsonPrimitive(attachmentOrUploadId)),
+        )
+    }
+}
+
+/** After a successful chat mutation, drop GUI-local staging copies. */
+internal suspend fun discardLocalsAfterMutationSuccess(
+    localIds: List<String>,
+    discardLocal: suspend (attachmentId: String) -> Unit,
+) {
+    localIds.forEach { id -> runCatching { discardLocal(id) } }
+}
+
+/** After a failed chat mutation, drop every remote staging id created for that attempt. */
+internal suspend fun cleanupRemoteAttachmentsAfterMutationFailure(
+    remotes: List<AgentAttachment>,
+    callTool: suspend (name: String, arguments: Map<String, JsonElement>) -> String,
+) {
+    remotes.forEach { remote -> cancelRemoteAttachment(callTool, remote.id) }
+}
+
+private fun parseUploadId(raw: String): String? =
+    runCatching {
+        Json.parseToJsonElement(raw).jsonObject["uploadId"]?.jsonPrimitive?.contentOrNull
+    }.getOrNull()
+
+internal fun parseAttachmentDescriptor(raw: String): AgentAttachment {
+    val obj = Json.parseToJsonElement(raw).jsonObject
+    val id = obj["id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        ?: error("attachment commit missing id")
+    val displayName = obj["displayName"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        ?: error("attachment commit missing displayName")
+    val byteCount = obj["byteCount"]?.jsonPrimitive?.longOrNull
+        ?: error("attachment commit missing byteCount")
+    val sha256 = obj["sha256"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        ?: error("attachment commit missing sha256")
+    return AgentAttachment(
+        id = id,
+        displayName = displayName,
+        kind = AgentAttachmentKind.entries.firstOrNull {
+            it.name.equals(obj["kind"]?.jsonPrimitive?.contentOrNull, ignoreCase = true)
+        } ?: AgentAttachmentKind.Text,
+        mediaType = obj["mediaType"]?.jsonPrimitive?.contentOrNull
+            ?: "text/plain; charset=utf-8",
+        byteCount = byteCount,
+        lineCount = obj["lineCount"]?.jsonPrimitive?.longOrNull?.takeIf { it > 0 },
+        sha256 = sha256.lowercase(),
+        // Inbound remote descriptors never carry a GUI-relative path.
+        relativePath = null,
+    )
+}

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/DesktopRemoteSessionService.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/DesktopRemoteSessionService.kt
@@ -3,24 +3,30 @@ package app.andy.desktop.service.remote
 import app.andy.desktop.service.DesktopActionConfigStore
 import app.andy.desktop.service.CommandRunner
 import app.andy.desktop.service.DesktopLocalServerService
-import app.andy.service.WorkspaceStore
 import app.andy.desktop.service.McpAgentRunClient
 import app.andy.desktop.service.agents.DesktopAgentRunService
 import app.andy.model.ActionsConfig
 import app.andy.service.ActionRunService
 import app.andy.service.AgentRunService
 import app.andy.service.AutomationService
+import app.andy.service.ChatAttachmentService
 import app.andy.service.CommandResult
 import app.andy.service.LocalServerService
 import app.andy.service.RemoteHostCapabilities
+import app.andy.service.RemoteProjectScanStatus
 import app.andy.service.RemoteScreenAvailability
 import app.andy.service.RemoteSessionService
 import app.andy.service.RemoteSessionState
 import app.andy.service.RemoteSessionStatus
 import app.andy.service.RemoteShellEndpoint
+import app.andy.service.RemoteTargetProjects
+import app.andy.service.UnavailableChatAttachmentService
+import app.andy.service.WorkspaceStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -52,6 +58,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
+/** Floor between background project scans, so tab switches don't fan out ssh on every focus. */
+private const val ScanMinIntervalMillis = 30_000L
+
 /**
  * SSH-tunnels remote `andyd.sock` + `tmux -L andy` into local temp sockets, capability-gates
  * the remote daemon, then swaps [SwappableAgentBackend] / automations onto a remote
@@ -71,17 +80,29 @@ class DesktopRemoteSessionService(
     private val localLocalServers: LocalServerService? = null,
     private val agentRunsForLocalServers: AgentRunService? = null,
     private val actionRunsForLocalServers: ActionRunService? = null,
+    private val localAttachments: ChatAttachmentService = UnavailableChatAttachmentService,
 ) : RemoteSessionService {
     private val json = Json { ignoreUnknownKeys = true }
     private val mutex = Mutex()
     private val _state = MutableStateFlow(
-        RemoteSessionState(savedTargets = workspaceStore.state?.value?.savedSshTargets.orEmpty()),
+        RemoteSessionState(
+            savedTargets = workspaceStore.state?.value?.savedSshTargets.orEmpty(),
+            targetAliases = workspaceStore.state?.value?.sshTargetAliases.orEmpty(),
+        ),
     )
     override val state: StateFlow<RemoteSessionState> = _state.asStateFlow()
     private val _remoteActionsConfig = MutableStateFlow<ActionsConfig?>(null)
     override val remoteActionsConfig: StateFlow<ActionsConfig?> = _remoteActionsConfig.asStateFlow()
     private val _portForwards = MutableStateFlow<Map<Int, Int>>(emptyMap())
     override val portForwards: StateFlow<Map<Int, Int>> = _portForwards.asStateFlow()
+    private val _savedTargetProjects = MutableStateFlow<Map<String, RemoteTargetProjects>>(emptyMap())
+    override val savedTargetProjects: StateFlow<Map<String, RemoteTargetProjects>> =
+        _savedTargetProjects.asStateFlow()
+    private val projectScanner = RemoteProjectScanner()
+    private val scanMutex = Mutex()
+    private var scanJob: Job? = null
+    @Volatile
+    private var lastScanAtMillis = 0L
 
     private val tunnel = AtomicReference<TunnelHandles?>(null)
     private val remoteClient = AtomicReference<McpAgentRunClient?>(null)
@@ -104,8 +125,28 @@ class DesktopRemoteSessionService(
 
     init {
         scope.launch {
+            var lastScanKey: Pair<Boolean, List<String>>? = null
             workspaceStore.state?.collect { ws ->
-                _state.update { it.copy(savedTargets = ws.savedSshTargets) }
+                _state.update {
+                    it.copy(
+                        savedTargets = ws.savedSshTargets,
+                        targetAliases = ws.sshTargetAliases,
+                    )
+                }
+                // Paint the merged list from the last scan immediately, then refresh behind it.
+                val scanKey = ws.mergeRemoteProjects to ws.savedSshTargets
+                if (scanKey == lastScanKey) return@collect
+                lastScanKey = scanKey
+                if (!ws.mergeRemoteProjects) {
+                    _savedTargetProjects.value = emptyMap()
+                    return@collect
+                }
+                val connected = _state.value.target?.takeIf { _state.value.isRemote }
+                _savedTargetProjects.value = RemoteProjectScanner.seedFromCache(
+                    ws.remoteProjectCache,
+                    ws.savedSshTargets,
+                ).filterKeys { it != connected }
+                refreshSavedTargetProjects(force = true)
             }
         }
         Runtime.getRuntime().addShutdownHook(
@@ -146,7 +187,10 @@ class DesktopRemoteSessionService(
         if (warm != null) {
             if (warm.isAlive()) {
                 val result = runCatching { activateWarm(trimmed, warm) }
-                if (result.isSuccess) return Result.success(Unit)
+                if (result.isSuccess) {
+                    rescanAfterSessionChange()
+                    return Result.success(Unit)
+                }
                 destroyWarm(trimmed)
             } else {
                 destroyWarm(trimmed)
@@ -198,6 +242,7 @@ class DesktopRemoteSessionService(
         }
         SshAskpassBroker.clearActiveTarget()
         SshProcess.debugLog("connect OK target=$trimmed")
+        rescanAfterSessionChange()
         Result.success(Unit)
     }
 
@@ -255,10 +300,29 @@ class DesktopRemoteSessionService(
             }
         }
         workspaceStore.update { current ->
-            current.copy(savedSshTargets = current.savedSshTargets.filterNot { it == trimmed })
+            current.copy(
+                savedSshTargets = current.savedSshTargets.filterNot { it == trimmed },
+                sshTargetAliases = current.sshTargetAliases - trimmed,
+            )
         }
         SshAskpassBroker.forget(trimmed)
         runCatching { SshCredentialStore.delete(trimmed) }
+    }
+
+    override suspend fun renameSavedTargetAlias(target: String, alias: String) {
+        val trimmed = target.trim()
+        if (trimmed.isEmpty()) return
+        val label = alias.trim()
+        workspaceStore.update { current ->
+            if (trimmed !in current.savedSshTargets) return@update current
+            // Blank or identical to the SSH target clears the override.
+            val aliases = if (label.isEmpty() || label == trimmed) {
+                current.sshTargetAliases - trimmed
+            } else {
+                current.sshTargetAliases + (trimmed to label)
+            }
+            current.copy(sshTargetAliases = aliases)
+        }
     }
 
     private suspend fun connectLocked(target: String) = withContext(Dispatchers.IO) {
@@ -324,6 +388,7 @@ class DesktopRemoteSessionService(
         val client = McpAgentRunClient(
             scope = scope,
             socketPath = localAndyd,
+            localAttachments = localAttachments,
         )
         client.attachLocalTerminalBridge(attachBridge)
         client.setSshProbeTarget(target, controlPath)
@@ -466,6 +531,87 @@ class DesktopRemoteSessionService(
         remoteTerminalTaskIdsJob = null
         attachBridge.setForwardedTmuxSocket(null)
         attachBridge.setRemoteTerminalTaskIds(emptyList())
+    }
+
+    /**
+     * Kicks off a scan round and returns — results land on [savedTargetProjects] as each host
+     * answers, so a sleeping laptop never holds up the rest of the list.
+     */
+    override suspend fun refreshSavedTargetProjects(force: Boolean) {
+        if (!isSupportedPlatform()) return
+        val ws = workspaceStore.state?.value ?: runCatching { workspaceStore.load() }.getOrNull() ?: return
+        if (!ws.mergeRemoteProjects) {
+            _savedTargetProjects.value = emptyMap()
+            return
+        }
+        val now = System.currentTimeMillis()
+        scanMutex.withLock {
+            val running = scanJob
+            if (running?.isActive == true) {
+                // A forced round follows a connect/disconnect, so its answer supersedes whatever
+                // the in-flight round was about to publish for the old active host.
+                if (!force) return
+                running.cancel()
+            }
+            if (!force && now - lastScanAtMillis < ScanMinIntervalMillis) return
+            lastScanAtMillis = now
+            scanJob = scope.launch { scanSavedTargets(ws.savedSshTargets) }
+        }
+    }
+
+    private suspend fun scanSavedTargets(savedTargets: List<String>) {
+        // The connected host's projects already *are* the list — never duplicate it as a remote row.
+        val activeTarget = _state.value.target?.takeIf { _state.value.isRemote }
+        val targets = savedTargets.filter { it != activeTarget }
+        if (targets.isEmpty()) {
+            _savedTargetProjects.value = emptyMap()
+            return
+        }
+        val before = _savedTargetProjects.value
+        _savedTargetProjects.value = targets.associateWith { target ->
+            before[target]?.copy(status = RemoteProjectScanStatus.Scanning)
+                ?: RemoteTargetProjects(target, RemoteProjectScanStatus.Scanning)
+        }
+        val scanned = withContext(Dispatchers.IO) {
+            targets
+                .map { target -> async { projectScanner.scan(target, controlPathFor(target)) } }
+                .awaitAll()
+        }.associateBy { it.target }
+        // The user can switch the merge off mid-round; don't publish a list nobody asked for.
+        if (workspaceStore.state?.value?.mergeRemoteProjects == false) {
+            _savedTargetProjects.value = emptyMap()
+            return
+        }
+        _savedTargetProjects.value = targets.associateWith { target ->
+            val fresh = scanned[target] ?: return@associateWith before[target] ?: RemoteTargetProjects(target)
+            // A host that went quiet keeps showing what it had, greyed, rather than vanishing.
+            if (fresh.status == RemoteProjectScanStatus.Ok) {
+                fresh
+            } else {
+                fresh.copy(projects = before[target]?.projects.orEmpty())
+            }
+        }
+        runCatching {
+            workspaceStore.update { current ->
+                current.copy(
+                    remoteProjectCache = RemoteProjectScanner.updatedCache(
+                        previous = current.remoteProjectCache,
+                        scanned = scanned,
+                        savedTargets = current.savedSshTargets,
+                    ),
+                )
+            }
+        }
+    }
+
+    /** Live ControlMaster for [target] when it is active or warm — lets the scan skip re-auth. */
+    private fun controlPathFor(target: String): File? =
+        tunnel.get()?.takeIf { it.target == target }?.controlPath
+            ?: warmByTarget[target]?.handles?.controlPath
+
+    /** Connecting / disconnecting moves which host owns the main list, so re-scan the rest. */
+    private fun rescanAfterSessionChange() {
+        scope.launch { runCatching { refreshSavedTargetProjects(force = true) } }
     }
 
     private fun destroyWarm(target: String) {
@@ -621,6 +767,7 @@ class DesktopRemoteSessionService(
                 hostCapabilities = null,
             )
         }
+        rescanAfterSessionChange()
     }
 
     private fun teardownTunnelOnly() {

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/RemoteProjectScanner.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/RemoteProjectScanner.kt
@@ -150,11 +150,24 @@ private fun runActionsTomlRead(
         builder.redirectInput(ProcessBuilder.Redirect.PIPE)
     }
     val process = builder.start()
-    val stdout = process.inputStream.bufferedReader().readText()
-    val stderr = process.errorStream.bufferedReader().readText()
+    val stdoutSink = StringBuffer()
+    val stderrSink = StringBuffer()
+    val outReader = Thread { process.inputStream.bufferedReader().use { stdoutSink.append(it.readText()) } }
+    val errReader = Thread { process.errorStream.bufferedReader().use { stderrSink.append(it.readText()) } }
+    outReader.start()
+    errReader.start()
+    // Apply the timeout before blocking on output: a hung ssh/remote command must be destroyed
+    // after the wait window regardless of what its pipes emit, and draining both streams on
+    // separate threads avoids deadlocking when ssh fills the stderr pipe while stdout is read.
     val finished = process.waitFor(20, TimeUnit.SECONDS)
     if (!finished) {
         process.destroyForcibly()
+    }
+    outReader.join(5_000)
+    errReader.join(5_000)
+    val stdout = stdoutSink.toString()
+    val stderr = stderrSink.toString()
+    if (!finished) {
         return RemoteTomlRead(-1, stdout, stderr.ifBlank { "timed out" })
     }
     return RemoteTomlRead(process.exitValue(), stdout, stderr)

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/RemoteProjectScanner.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/RemoteProjectScanner.kt
@@ -1,0 +1,161 @@
+package app.andy.desktop.service.remote
+
+import app.andy.desktop.service.DesktopActionConfigStore
+import app.andy.model.ActionProject
+import app.andy.model.CachedRemoteProject
+import app.andy.service.RemoteProjectScanStatus
+import app.andy.service.RemoteTargetProjects
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/** Raw `ssh` outcome for one actions.toml read — [stdout] is the file body when [exitCode] is 0. */
+data class RemoteTomlRead(val exitCode: Int, val stdout: String, val stderr: String)
+
+private const val ReadActionsTomlCommand =
+    "if [ -f \"\$HOME/.andy/actions.toml\" ]; then cat \"\$HOME/.andy/actions.toml\"; fi"
+
+/**
+ * Reads project definitions off saved SSH hosts for the merged Projects list *without* connecting
+ * — no tunnel, no andyd, no backend swap. A host that is already warm or active passes its
+ * ControlMaster path so the read reuses that authenticated mux; everything else goes over a
+ * one-shot `BatchMode=yes` ssh that fails instead of prompting.
+ */
+class RemoteProjectScanner(
+    private val read: (target: String, controlPath: File?) -> RemoteTomlRead = ::sshReadActionsToml,
+) {
+    fun scan(target: String, controlPath: File?): RemoteTargetProjects {
+        val result = runCatching { read(target, controlPath) }
+            .getOrElse { err ->
+                return unavailable(target, err.message?.takeIf { it.isNotBlank() } ?: "ssh failed")
+            }
+        if (result.exitCode != 0) {
+            val detail = result.stderr.ifBlank { result.stdout }.trim().lines()
+                .firstOrNull { it.isNotBlank() }
+                ?: "exit ${result.exitCode}"
+            // A scan can only use credentials Andy already has. Say so, rather than leaving the
+            // user to wonder why a host they can clearly connect to lists nothing.
+            val hint = if (detail.contains("Permission denied", ignoreCase = true)) {
+                " Connect to this host once (and tick Remember password) so scans can reuse it."
+            } else {
+                ""
+            }
+            return unavailable(target, detail + hint)
+        }
+        val text = result.stdout.trim()
+        if (text.isEmpty()) {
+            return RemoteTargetProjects(target, RemoteProjectScanStatus.Ok, emptyList())
+        }
+        return runCatching { DesktopActionConfigStore.parseToml(text) }
+            .fold(
+                onSuccess = { config ->
+                    RemoteTargetProjects(target, RemoteProjectScanStatus.Ok, config.projects)
+                },
+                onFailure = { err ->
+                    unavailable(target, "~/.andy/actions.toml is invalid: ${err.message ?: err}")
+                },
+            )
+    }
+
+    private fun unavailable(target: String, error: String) =
+        RemoteTargetProjects(target, RemoteProjectScanStatus.Unavailable, emptyList(), error)
+
+    companion object {
+        /** Display-only projection persisted to workspace prefs so the list paints before SSH. */
+        fun toCache(projects: List<ActionProject>): List<CachedRemoteProject> =
+            projects.map { CachedRemoteProject(id = it.id, name = it.name, contextDir = it.contextDir) }
+
+        fun fromCache(cached: List<CachedRemoteProject>): List<ActionProject> =
+            cached.map { ActionProject(id = it.id, name = it.name, contextDir = it.contextDir) }
+
+        /**
+         * Initial flow value at launch: everything the last scan saw, marked
+         * [RemoteProjectScanStatus.Cached] until a fresh scan confirms it. Targets the user has
+         * since removed are dropped.
+         */
+        fun seedFromCache(
+            cache: Map<String, List<CachedRemoteProject>>,
+            savedTargets: List<String>,
+        ): Map<String, RemoteTargetProjects> =
+            savedTargets.mapNotNull { target ->
+                val cached = cache[target] ?: return@mapNotNull null
+                target to RemoteTargetProjects(
+                    target = target,
+                    status = RemoteProjectScanStatus.Cached,
+                    projects = fromCache(cached),
+                )
+            }.toMap()
+
+        /**
+         * Cache to persist after a scan round. A target that came back unavailable keeps its
+         * previous entry — a laptop being asleep shouldn't empty its projects out of the list.
+         */
+        fun updatedCache(
+            previous: Map<String, List<CachedRemoteProject>>,
+            scanned: Map<String, RemoteTargetProjects>,
+            savedTargets: List<String>,
+        ): Map<String, List<CachedRemoteProject>> =
+            savedTargets.mapNotNull { target ->
+                val fresh = scanned[target]
+                val entry = if (fresh != null && fresh.status == RemoteProjectScanStatus.Ok) {
+                    toCache(fresh.projects)
+                } else {
+                    previous[target]
+                }
+                entry?.let { target to it }
+            }.toMap()
+    }
+}
+
+/**
+ * Reads the file over `ssh`, never prompting. Three tiers, best first:
+ *
+ * 1. A live ControlMaster (host is active or warm) — already authenticated.
+ * 2. The password Andy saved in the OS keychain for this host, served through a probe-private
+ *    [SshScanAskpass]. Hosts that authenticate with a password — which Andy explicitly supports —
+ *    are unreachable any other way, since `BatchMode` rules password auth out.
+ * 3. `BatchMode=yes`, which covers key-auth hosts and fails cleanly on everything else.
+ */
+fun sshReadActionsToml(target: String, controlPath: File?): RemoteTomlRead {
+    val mux = controlPath?.takeIf { it.exists() }
+    if (mux != null) return runActionsTomlRead(target, SshProcess.batchOptions(mux), emptyMap())
+
+    val saved = runCatching { SshCredentialStore.load(target) }.getOrNull()
+    if (!saved.isNullOrEmpty()) {
+        SshScanAskpass.open(saved)?.use { askpass ->
+            return runActionsTomlRead(
+                target,
+                SshProcess.credentialProbeOptions(null),
+                askpass.environment,
+            )
+        }
+    }
+    return runActionsTomlRead(target, SshProcess.batchOptions(null), emptyMap())
+}
+
+private fun runActionsTomlRead(
+    target: String,
+    options: List<String>,
+    env: Map<String, String>,
+): RemoteTomlRead {
+    val cmd = buildList {
+        add("ssh")
+        addAll(options)
+        add(target)
+        add(ReadActionsTomlCommand)
+    }
+    // Never the shared interactive broker — a scan must not be able to raise a dialog.
+    val builder = SshProcess.processBuilder(cmd, askpass = false).redirectErrorStream(false)
+    if (env.isNotEmpty()) {
+        builder.environment().putAll(env)
+        builder.redirectInput(ProcessBuilder.Redirect.PIPE)
+    }
+    val process = builder.start()
+    val stdout = process.inputStream.bufferedReader().readText()
+    val stderr = process.errorStream.bufferedReader().readText()
+    val finished = process.waitFor(20, TimeUnit.SECONDS)
+    if (!finished) {
+        process.destroyForcibly()
+        return RemoteTomlRead(-1, stdout, stderr.ifBlank { "timed out" })
+    }
+    return RemoteTomlRead(process.exitValue(), stdout, stderr)
+}

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SshAskpass.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SshAskpass.kt
@@ -18,9 +18,19 @@ object SshAskpass {
         SshAskpassBroker.start()
         val sock = SshAskpassBroker.socketPath()?.absolutePath
             ?: error("SSH askpass broker failed to start")
+        return environmentEntriesFor(sock)
+    }
+
+    /**
+     * Same helper wiring pointed at a caller-owned socket. Background probes use this with a
+     * private responder so they answer from a saved credential without touching the interactive
+     * broker's per-target state (or its ability to open a dialog).
+     */
+    fun environmentEntriesFor(socketPath: String): Map<String, String> {
         // Touch helpers so paths exist before ssh runs.
         script
         pythonHelper
+        val sock = socketPath
         val env = linkedMapOf(
             "SSH_ASKPASS" to script.absolutePath,
             "SSH_ASKPASS_REQUIRE" to "force",

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SshProcess.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SshProcess.kt
@@ -47,10 +47,10 @@ object SshProcess {
     fun controlPathForPid(pid: Long = ProcessHandle.current().pid()): File =
         File(File("/tmp", "andy-r$pid").also { it.mkdirs() }, "mux")
 
-    private fun commonOptions(): List<String> = listOf(
+    private fun commonOptions(connectTimeoutSeconds: Int = 20): List<String> = listOf(
         "-o", "StrictHostKeyChecking=yes",
         "-o", "ForwardAgent=no",
-        "-o", "ConnectTimeout=20",
+        "-o", "ConnectTimeout=$connectTimeoutSeconds",
         "-o", "Compression=no",
         "-o", "IPQoS=lowdelay",
         // One prompt only — Cancel must not open 3 stacked Andy SSH dialogs.
@@ -85,8 +85,40 @@ object SshProcess {
     fun baseOptions(controlPath: File?): List<String> =
         if (controlPath != null) muxOptions(controlPath) else commonOptions()
 
-    fun processBuilder(command: List<String>): ProcessBuilder =
-        ProcessBuilder(command).also { SshAskpass.applyTo(it) }
+    /**
+     * Background probes that must never interrupt the user: `BatchMode=yes` makes OpenSSH fail
+     * instead of prompting, so a host needing a password reports an error rather than popping the
+     * askpass dialog. Reuses an existing master when [controlPath] is live (already authenticated).
+     */
+    fun batchOptions(controlPath: File?, connectTimeoutSeconds: Int = 8): List<String> = buildList {
+        addAll(commonOptions(connectTimeoutSeconds))
+        add("-o")
+        add("BatchMode=yes")
+        if (controlPath != null) {
+            add("-o")
+            add("ControlPath=${controlPath.absolutePath}")
+        }
+    }
+
+    /**
+     * Background probe that may use a *saved* password: no `BatchMode`, because that would rule
+     * password auth out entirely. Safe only when paired with a non-prompting askpass endpoint
+     * such as [SshScanAskpass] — `NumberOfPasswordPrompts=1` then bounds the attempt.
+     */
+    fun credentialProbeOptions(controlPath: File?, connectTimeoutSeconds: Int = 8): List<String> = buildList {
+        addAll(commonOptions(connectTimeoutSeconds))
+        if (controlPath != null) {
+            add("-o")
+            add("ControlPath=${controlPath.absolutePath}")
+        }
+    }
+
+    /**
+     * @param askpass false for [batchOptions] probes — without a prompt path there is nothing for
+     *   the askpass helper to do, and attaching it risks a dialog on a background scan.
+     */
+    fun processBuilder(command: List<String>, askpass: Boolean = true): ProcessBuilder =
+        ProcessBuilder(command).also { if (askpass) SshAskpass.applyTo(it) }
 
     fun exitMaster(controlPath: File) {
         if (!controlPath.exists()) return

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SshScanAskpass.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SshScanAskpass.kt
@@ -1,0 +1,58 @@
+package app.andy.desktop.service.remote
+
+import java.io.File
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.thread
+
+/**
+ * A private `SSH_ASKPASS` endpoint for one background probe, answering every prompt with one
+ * already-saved secret.
+ *
+ * Deliberately *not* [SshAskpassBroker]: that one is a process-wide singleton whose active target
+ * and keychain fallback belong to the interactive connect flow, and it opens a GUI dialog when it
+ * runs out of answers. A scan must never do either — so it gets its own socket, answers from the
+ * keychain, and lets `ssh` fail when that secret is wrong.
+ */
+class SshScanAskpass private constructor(
+    private val socket: File,
+    private val server: ServerSocketChannel,
+) : AutoCloseable {
+    val environment: Map<String, String> get() = SshAskpass.environmentEntriesFor(socket.absolutePath)
+
+    override fun close() {
+        runCatching { server.close() }
+        socket.delete()
+    }
+
+    companion object {
+        private val seq = AtomicLong(1)
+
+        /** @return null when the socket could not be created — callers fall back to BatchMode. */
+        fun open(secret: String): SshScanAskpass? = runCatching {
+            val file = File("/tmp", "andy-scan-ap-${ProcessHandle.current().pid()}-${seq.getAndIncrement()}.sock")
+            file.delete()
+            val channel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+            channel.bind(UnixDomainSocketAddress.of(file.toPath()))
+            runCatching {
+                Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("rw-------"))
+            }
+            val reply = (secret + "\n").toByteArray(StandardCharsets.UTF_8)
+            thread(name = "andy-ssh-scan-askpass", isDaemon = true) {
+                while (true) {
+                    val client = runCatching { channel.accept() }.getOrNull() ?: break
+                    // The prompt text is irrelevant: there is exactly one credential in play, and
+                    // answering repeatedly is safe because this socket serves a single probe.
+                    runCatching { client.use { it.write(ByteBuffer.wrap(reply.copyOf())) } }
+                }
+            }
+            SshScanAskpass(file, channel)
+        }.getOrNull()
+    }
+}

--- a/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SwappableAgentBackend.kt
+++ b/data/remote/src/desktopMain/kotlin/app/andy/desktop/service/remote/SwappableAgentBackend.kt
@@ -2,6 +2,7 @@ package app.andy.desktop.service.remote
 
 import app.andy.desktop.service.McpAgentRunClient
 import app.andy.desktop.service.agents.DesktopAgentRunService
+import app.andy.model.AgentAttachment
 import app.andy.model.AgentChangeSummary
 import app.andy.model.AgentCliStatus
 import app.andy.model.AgentContextualProvenance
@@ -23,6 +24,7 @@ import app.andy.model.ProjectBuildPairDraft
 import app.andy.model.ProjectSpecDraft
 import app.andy.model.ProjectTaskKind
 import app.andy.model.ProjectWorkflowState
+import app.andy.model.TranscriptSearchHit
 import app.andy.model.WorktreeBaseOption
 import app.andy.model.WorktreeDeleteOutcome
 import app.andy.model.WorktreeMergeOutcome
@@ -32,6 +34,7 @@ import app.andy.service.CommandResult
 import app.andy.service.ProjectWorkflowService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -171,7 +174,21 @@ class SwappableAgentBackend(
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
-    ) = runs().resume(taskId, followUp, imagePaths, skills, contextBundleIds, provenance)
+        attachments: List<AgentAttachment>,
+    ) = runs().resume(taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments)
+
+    override suspend fun resumePrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
+    ): Result<Unit> = runs().resumePrepared(
+        taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments,
+    )
+
     override fun reattachSession(taskId: String) = runs().reattachSession(taskId)
     override fun canReattachSession(taskId: String): Boolean = runs().canReattachSession(taskId)
     override val terminalSessionsRevision: StateFlow<Long> get() = runs().terminalSessionsRevision
@@ -191,7 +208,21 @@ class SwappableAgentBackend(
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
-    ) = runs().queueFollowUp(taskId, followUp, imagePaths, skills, contextBundleIds, provenance)
+        attachments: List<AgentAttachment>,
+    ) = runs().queueFollowUp(taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments)
+
+    override suspend fun queueFollowUpPrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String>,
+        skills: List<AgentSkill>,
+        contextBundleIds: List<String>,
+        provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
+    ): Result<Unit> = runs().queueFollowUpPrepared(
+        taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments,
+    )
+
     override fun removeQueuedFollowUp(taskId: String, queueIndex: Int) =
         runs().removeQueuedFollowUp(taskId, queueIndex)
     override fun sendQueuedFollowUp(taskId: String, queueIndex: Int) =
@@ -212,6 +243,7 @@ class SwappableAgentBackend(
     override fun archive(taskId: String) = runs().archive(taskId)
     override fun unarchive(taskId: String) = runs().unarchive(taskId)
     override fun events(taskId: String): StateFlow<List<AgentEvent>> = runs().events(taskId)
+    override fun searchTranscripts(query: String): Flow<TranscriptSearchHit> = runs().searchTranscripts(query)
     override fun interactiveResumeCommand(taskId: String): String? = runs().interactiveResumeCommand(taskId)
     override fun providerAppContinuationLabel(taskId: String): String? =
         runs().providerAppContinuationLabel(taskId)

--- a/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentEvidenceHandoffTest.kt
+++ b/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/McpAgentEvidenceHandoffTest.kt
@@ -345,6 +345,7 @@ private class FakeEvidenceAgentRunService : AgentRunService by UnavailableAgentR
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: app.andy.model.AgentContextualProvenance?,
+        attachments: List<app.andy.model.AgentAttachment>,
     ) {
         resumeCalls += ResumeCall(taskId, followUp, contextBundleIds, imagePaths)
     }

--- a/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/RemoteChatAttachmentUploadTest.kt
+++ b/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/RemoteChatAttachmentUploadTest.kt
@@ -1,0 +1,239 @@
+package app.andy.desktop.service
+
+import app.andy.model.AgentAttachment
+import app.andy.model.AgentAttachmentKind
+import app.andy.model.ChatAttachmentLimits
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+class RemoteChatAttachmentUploadTest {
+    @Test
+    fun uploadsInOrderAndPassesRemoteDescriptorNotLocalId() = runBlocking {
+        val localBody = "remote-upload-" + "x".repeat(300_000)
+        val localBytes = localBody.encodeToByteArray()
+        val local = AgentAttachment(
+            id = "att-local-gui",
+            displayName = "paste.txt",
+            kind = AgentAttachmentKind.Text,
+            byteCount = localBytes.size.toLong(),
+            lineCount = 1,
+            sha256 = sha256(localBody),
+        )
+        val calls = mutableListOf<String>()
+        var discardedLocal = false
+        val result = uploadLocalAttachmentsToRemote(
+            attachments = listOf(local),
+            readChunk = { id, offset, max ->
+                assertEquals(local.id, id)
+                val end = minOf(localBytes.size, (offset + max).toInt())
+                if (offset >= localBytes.size) ByteArray(0)
+                else localBytes.copyOfRange(offset.toInt(), end)
+            },
+            callTool = { name, args ->
+                calls += name
+                when (name) {
+                    "chat.attachment_begin" -> {
+                        assertEquals(local.displayName, args["displayName"]?.jsonPrimitive?.contentOrNull)
+                        assertEquals(local.byteCount, args["byteCount"]?.jsonPrimitive?.contentOrNull?.toLong())
+                        """{"uploadId":"att-remote-daemon","displayName":"paste.txt","expectedBytes":${local.byteCount},"expectedSha256":"${local.sha256}"}"""
+                    }
+                    "chat.attachment_append" -> {
+                        val seq = args["sequence"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+                        assertTrue(seq != null && seq >= 0)
+                        val b64 = args["base64Chunk"]?.jsonPrimitive?.contentOrNull
+                        assertFalse(b64.isNullOrBlank())
+                        Base64.getDecoder().decode(b64)
+                        """{"ok":true,"uploadId":"att-remote-daemon","sequence":$seq}"""
+                    }
+                    "chat.attachment_commit" -> {
+                        assertEquals("att-remote-daemon", args["uploadId"]?.jsonPrimitive?.contentOrNull)
+                        buildJsonObject {
+                            put("id", "att-remote-daemon")
+                            put("displayName", "paste.txt")
+                            put("kind", "Text")
+                            put("mediaType", "text/plain; charset=utf-8")
+                            put("byteCount", local.byteCount)
+                            put("lineCount", 1)
+                            put("sha256", local.sha256)
+                        }.toString()
+                    }
+                    "chat.attachment_cancel" -> error("should not cancel on success path")
+                    else -> error("unexpected tool $name")
+                }
+            },
+            chunkBytes = ChatAttachmentLimits.UploadChunkBytes,
+        )
+
+        assertEquals("att-remote-daemon", result.remotes.single().id)
+        assertEquals(listOf(local.id), result.localIds)
+        assertFalse(result.remotes.single().id == local.id)
+        assertTrue(calls.first() == "chat.attachment_begin")
+        assertTrue(calls.last() == "chat.attachment_commit")
+        assertTrue(calls.drop(1).dropLast(1).all { it == "chat.attachment_append" })
+        assertTrue(calls.count { it == "chat.attachment_append" } >= 2)
+
+        discardLocalsAfterMutationSuccess(result.localIds) {
+            discardedLocal = true
+            assertEquals(local.id, it)
+        }
+        assertTrue(discardedLocal)
+    }
+
+    @Test
+    fun secondUploadFailureCancelsFirstCommittedRemoteAndRetainsLocals() = runBlocking {
+        val first = tinyAttachment("att-local-1", "a.txt", "aaaa")
+        val second = tinyAttachment("att-local-2", "b.txt", "bbbb")
+        val cancelled = mutableListOf<String>()
+        val discardedLocals = mutableListOf<String>()
+        val calls = mutableListOf<String>()
+        var commitCount = 0
+        assertFailsWith<IllegalStateException> {
+            uploadLocalAttachmentsToRemote(
+                attachments = listOf(first, second),
+                readChunk = { id, _, _ ->
+                    when (id) {
+                        first.id -> "aaaa".toByteArray()
+                        second.id -> "bbbb".toByteArray()
+                        else -> null
+                    }
+                },
+                callTool = toolResponder(calls, cancelled) { name, args ->
+                    when (name) {
+                        "chat.attachment_begin" -> {
+                            val display = args["displayName"]?.jsonPrimitive?.contentOrNull
+                            val id = if (display == "a.txt") "att-remote-1" else "att-remote-2"
+                            """{"uploadId":"$id","displayName":"$display","expectedBytes":4,"expectedSha256":"${args["sha256"]?.jsonPrimitive?.contentOrNull}"}"""
+                        }
+                        "chat.attachment_append" -> """{"ok":true}"""
+                        "chat.attachment_commit" -> {
+                            commitCount++
+                            if (commitCount == 1) {
+                                buildJsonObject {
+                                    put("id", "att-remote-1")
+                                    put("displayName", "a.txt")
+                                    put("kind", "Text")
+                                    put("byteCount", 4)
+                                    put("sha256", first.sha256)
+                                }.toString()
+                            } else {
+                                error("simulated second commit failure")
+                            }
+                        }
+                        else -> error("unexpected $name")
+                    }
+                },
+            )
+        }
+        assertTrue(cancelled.contains("att-remote-1"), "first committed remote must be cleaned: $cancelled")
+        assertTrue(cancelled.contains("att-remote-2") || calls.contains("chat.attachment_cancel"))
+        assertTrue(discardedLocals.isEmpty())
+        assertFalse(calls.contains("chat.start") || calls.contains("chat.resume"))
+    }
+
+    @Test
+    fun chatMutationFailureCleansRemotesAndRetainsLocals() = runBlocking {
+        val local = tinyAttachment("att-local-keep", "keep.txt", "keep-me!!")
+        val cancelled = mutableListOf<String>()
+        val discardedLocals = mutableListOf<String>()
+        val calls = mutableListOf<String>()
+        val upload = uploadLocalAttachmentsToRemote(
+            attachments = listOf(local),
+            readChunk = { _, _, _ -> "keep-me!!".toByteArray() },
+            callTool = toolResponder(calls, cancelled) { name, _ ->
+                when (name) {
+                    "chat.attachment_begin" ->
+                        """{"uploadId":"att-remote-keep","displayName":"keep.txt","expectedBytes":9,"expectedSha256":"${local.sha256}"}"""
+                    "chat.attachment_append" -> """{"ok":true}"""
+                    "chat.attachment_commit" -> buildJsonObject {
+                        put("id", "att-remote-keep")
+                        put("displayName", "keep.txt")
+                        put("kind", "Text")
+                        put("byteCount", 9)
+                        put("sha256", local.sha256)
+                    }.toString()
+                    else -> error("unexpected $name")
+                }
+            },
+        )
+        assertEquals("att-remote-keep", upload.remotes.single().id)
+        assertEquals(listOf(local.id), upload.localIds)
+
+        // Simulate chat.start/resume failure after successful commits.
+        cleanupRemoteAttachmentsAfterMutationFailure(upload.remotes) { name, args ->
+            calls += name
+            cancelled += args["uploadId"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            """{"ok":true}"""
+        }
+        assertTrue(cancelled.contains("att-remote-keep"))
+        assertTrue(discardedLocals.isEmpty(), "locals must remain retryable")
+
+        // Success path: discard locals only after mutation.
+        discardedLocals.clear()
+        discardLocalsAfterMutationSuccess(upload.localIds) { discardedLocals += it }
+        assertEquals(listOf(local.id), discardedLocals)
+    }
+
+    @Test
+    fun uploadFailureCancelsRemoteAndDoesNotReturnLocalDescriptor() = runBlocking {
+        val local = AgentAttachment(
+            id = "att-local-fail",
+            displayName = "fail.txt",
+            byteCount = 10,
+            sha256 = "a".repeat(64),
+        )
+        val calls = mutableListOf<String>()
+        assertFailsWith<IllegalStateException> {
+            uploadLocalAttachmentsToRemote(
+                attachments = listOf(local),
+                readChunk = { _, _, _ -> "abcdefghij".toByteArray() },
+                callTool = { name, _ ->
+                    calls += name
+                    when (name) {
+                        "chat.attachment_begin" ->
+                            """{"uploadId":"att-up-1","displayName":"fail.txt","expectedBytes":10,"expectedSha256":"${local.sha256}"}"""
+                        "chat.attachment_append" -> error("simulated append failure")
+                        "chat.attachment_cancel" -> """{"ok":true}"""
+                        else -> error("unexpected $name")
+                    }
+                },
+            )
+        }
+        assertEquals(listOf("chat.attachment_begin", "chat.attachment_append", "chat.attachment_cancel"), calls)
+    }
+
+    private fun tinyAttachment(id: String, name: String, body: String) = AgentAttachment(
+        id = id,
+        displayName = name,
+        byteCount = body.encodeToByteArray().size.toLong(),
+        sha256 = sha256(body),
+    )
+
+    private fun toolResponder(
+        calls: MutableList<String>,
+        cancelled: MutableList<String>,
+        handle: (String, Map<String, JsonElement>) -> String,
+    ): suspend (String, Map<String, JsonElement>) -> String = { name, args ->
+        calls += name
+        if (name == "chat.attachment_cancel") {
+            cancelled += args["uploadId"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            """{"ok":true}"""
+        } else {
+            handle(name, args)
+        }
+    }
+
+    private fun sha256(text: String): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256").digest(text.encodeToByteArray())
+        return digest.joinToString("") { b -> ((b.toInt() and 0xff) + 0x100).toString(16).substring(1) }
+    }
+}

--- a/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/remote/RemoteProjectScannerTest.kt
+++ b/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/remote/RemoteProjectScannerTest.kt
@@ -1,0 +1,157 @@
+package app.andy.desktop.service.remote
+
+import app.andy.model.CachedRemoteProject
+import app.andy.service.RemoteProjectScanStatus
+import app.andy.service.RemoteTargetProjects
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val TwoProjectsToml = """
+version = 1
+
+[[projects]]
+id = "andy"
+name = "Andy"
+contextDir = "/Users/joe/Code/Andy"
+
+[[projects]]
+id = "site"
+name = "Site"
+contextDir = "/Users/joe/Code/site"
+"""
+
+class RemoteProjectScannerTest {
+    private fun scannerReturning(read: RemoteTomlRead) =
+        RemoteProjectScanner { _, _ -> read }
+
+    @Test
+    fun parsesProjectsFromRemoteToml() {
+        val result = scannerReturning(RemoteTomlRead(0, TwoProjectsToml, ""))
+            .scan("joe@studio", controlPath = null)
+
+        assertEquals(RemoteProjectScanStatus.Ok, result.status)
+        assertEquals(listOf("Andy", "Site"), result.projects.map { it.name })
+        assertEquals("/Users/joe/Code/Andy", result.projects.first().contextDir)
+    }
+
+    @Test
+    fun missingConfigIsAnEmptyOkNotAFailure() {
+        // The remote `if [ -f ... ]` guard prints nothing when the host has no actions.toml.
+        val result = scannerReturning(RemoteTomlRead(0, "", ""))
+            .scan("joe@studio", controlPath = null)
+
+        assertEquals(RemoteProjectScanStatus.Ok, result.status)
+        assertTrue(result.projects.isEmpty())
+    }
+
+    @Test
+    fun sshFailureReportsFirstStderrLine() {
+        val result = scannerReturning(
+            RemoteTomlRead(255, "", "ssh: Could not resolve hostname studio\nlost connection\n"),
+        ).scan("joe@studio", controlPath = null)
+
+        assertEquals(RemoteProjectScanStatus.Unavailable, result.status)
+        assertEquals("ssh: Could not resolve hostname studio", result.error)
+    }
+
+    @Test
+    fun authFailureTellsTheUserHowToMakeScansWork() {
+        val result = scannerReturning(
+            RemoteTomlRead(255, "", "joe@studio: Permission denied (publickey,password).\n"),
+        ).scan("joe@studio", controlPath = null)
+
+        assertTrue(result.error.orEmpty().contains("Connect to this host once"), "got: ${result.error}")
+    }
+
+    @Test
+    fun nonAuthFailureIsReportedWithoutTheConnectHint() {
+        val result = scannerReturning(RemoteTomlRead(255, "", "ssh: connect to host studio port 22: No route to host\n"))
+            .scan("joe@studio", controlPath = null)
+
+        assertEquals("ssh: connect to host studio port 22: No route to host", result.error)
+    }
+
+    @Test
+    fun unparseableTomlIsReportedRatherThanThrown() {
+        val result = scannerReturning(RemoteTomlRead(0, "this is not toml {{{", ""))
+            .scan("joe@studio", controlPath = null)
+
+        assertEquals(RemoteProjectScanStatus.Unavailable, result.status)
+        assertTrue(result.error.orEmpty().contains("invalid"), "got: ${result.error}")
+    }
+
+    @Test
+    fun readCrashIsReportedRatherThanThrown() {
+        val scanner = RemoteProjectScanner { _, _ -> error("ssh binary missing") }
+
+        val result = scanner.scan("joe@studio", controlPath = null)
+
+        assertEquals(RemoteProjectScanStatus.Unavailable, result.status)
+        assertEquals("ssh binary missing", result.error)
+    }
+
+    @Test
+    fun reusesControlMasterPathWhenGiven() {
+        var seenControlPath: File? = null
+        val scanner = RemoteProjectScanner { _, controlPath ->
+            seenControlPath = controlPath
+            RemoteTomlRead(0, "", "")
+        }
+        val mux = File("/tmp/andy-test-mux-scan")
+
+        scanner.scan("joe@studio", controlPath = mux)
+
+        assertEquals(mux, seenControlPath)
+    }
+
+    @Test
+    fun seedFromCacheDropsTargetsTheUserRemoved() {
+        val cache = mapOf(
+            "joe@studio" to listOf(CachedRemoteProject("andy", "Andy", "/Code/Andy")),
+            "joe@old-box" to listOf(CachedRemoteProject("legacy", "Legacy", "/Code/legacy")),
+        )
+
+        val seeded = RemoteProjectScanner.seedFromCache(cache, savedTargets = listOf("joe@studio"))
+
+        assertEquals(setOf("joe@studio"), seeded.keys)
+        assertEquals(RemoteProjectScanStatus.Cached, seeded.getValue("joe@studio").status)
+        assertEquals(listOf("Andy"), seeded.getValue("joe@studio").projects.map { it.name })
+    }
+
+    @Test
+    fun unavailableHostKeepsItsPreviouslyCachedProjects() {
+        val previous = mapOf(
+            "joe@studio" to listOf(CachedRemoteProject("andy", "Andy", "/Code/Andy")),
+        )
+        val scanned = mapOf(
+            "joe@studio" to RemoteTargetProjects(
+                target = "joe@studio",
+                status = RemoteProjectScanStatus.Unavailable,
+                error = "host is asleep",
+            ),
+        )
+
+        val updated = RemoteProjectScanner.updatedCache(previous, scanned, listOf("joe@studio"))
+
+        assertEquals(previous, updated)
+    }
+
+    @Test
+    fun successfulScanReplacesCacheAndPrunesRemovedTargets() {
+        val previous = mapOf(
+            "joe@studio" to listOf(CachedRemoteProject("andy", "Andy", "/Code/Andy")),
+            "joe@gone" to listOf(CachedRemoteProject("x", "X", "/x")),
+        )
+        val scanned = mapOf(
+            "joe@studio" to RemoteProjectScanner { _, _ -> RemoteTomlRead(0, TwoProjectsToml, "") }
+                .scan("joe@studio", null),
+        )
+
+        val updated = RemoteProjectScanner.updatedCache(previous, scanned, listOf("joe@studio"))
+
+        assertEquals(setOf("joe@studio"), updated.keys)
+        assertEquals(listOf("Andy", "Site"), updated.getValue("joe@studio").map { it.name })
+    }
+}

--- a/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/remote/SshProcessOptionsTest.kt
+++ b/data/remote/src/desktopTest/kotlin/app/andy/desktop/service/remote/SshProcessOptionsTest.kt
@@ -17,6 +17,33 @@ class SshProcessOptionsTest {
     }
 
     @Test
+    fun batchOptionsRefuseToPromptAndKeepTheProbeShort() {
+        val opts = SshProcess.batchOptions(null)
+        assertTrue(opts.contains("BatchMode=yes"))
+        assertTrue(opts.contains("ConnectTimeout=8"))
+        // ssh honours the first value for a repeated option — the probe timeout must win.
+        assertFalse(opts.contains("ConnectTimeout=20"))
+        assertFalse(opts.any { it.startsWith("ControlPath=") })
+    }
+
+    @Test
+    fun credentialProbeOptionsAllowPasswordAuthButBoundTheAttempt() {
+        val opts = SshProcess.credentialProbeOptions(null)
+        // BatchMode would rule password auth out entirely, which is the whole point of this path.
+        assertFalse(opts.contains("BatchMode=yes"))
+        assertTrue(opts.contains("NumberOfPasswordPrompts=1"))
+        assertTrue(opts.contains("ConnectTimeout=8"))
+    }
+
+    @Test
+    fun probeOptionsReuseAnExistingMasterWhenGiven() {
+        val path = File("/tmp/andy-test-mux")
+        assertTrue(SshProcess.batchOptions(path).contains("ControlPath=${path.absolutePath}"))
+        assertTrue(SshProcess.credentialProbeOptions(path).contains("ControlPath=${path.absolutePath}"))
+        assertFalse(SshProcess.batchOptions(path).any { it.startsWith("ControlMaster=") })
+    }
+
+    @Test
     fun muxAndBaseOptionsNeverRequestControlMasterAuto() {
         val path = File("/tmp/andy-test-mux")
         assertFalse(SshProcess.muxOptions(path).any { it.startsWith("ControlMaster=") })

--- a/data/workspace/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
+++ b/data/workspace/src/desktopMain/kotlin/app/andy/desktop/service/DesktopWorkspaceStore.kt
@@ -1,5 +1,6 @@
 package app.andy.desktop.service
 
+import app.andy.model.CachedRemoteProject
 import app.andy.model.IntentDraft
 import app.andy.model.PairedWifiDevice
 import app.andy.model.ProxyRule
@@ -24,6 +25,8 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -207,7 +210,10 @@ class DesktopWorkspaceStore(
             lmStudioBaseUrl = props.getProperty("lmStudioBaseUrl")?.takeIf { it.isNotBlank() } ?: WorkspaceState().lmStudioBaseUrl,
             lmStudioBearerToken = props.getProperty("lmStudioBearerToken").orEmpty(),
             savedSshTargets = props.getProperty("savedSshTargets").orEmpty().lines().filter { it.isNotBlank() },
+            sshTargetAliases = loadIndexedStringMap(props, "sshTargetAlias"),
             iosCmioIds = loadIndexedStringMap(props, "iosCmioId"),
+            mergeRemoteProjects = props.getProperty("mergeRemoteProjects")?.toBooleanStrictOrNull() ?: false,
+            remoteProjectCache = decodeRemoteProjectCache(props.getProperty("remoteProjectCache").orEmpty()),
             savedDockLayouts = decodeSavedDockLayouts(props.getProperty("savedDockLayouts").orEmpty()),
         ).also { mutableState.value = it }
     }
@@ -354,7 +360,10 @@ class DesktopWorkspaceStore(
             setProperty("lmStudioBaseUrl", state.lmStudioBaseUrl)
             setProperty("lmStudioBearerToken", state.lmStudioBearerToken)
             setProperty("savedSshTargets", state.savedSshTargets.joinToString("\n"))
+            saveIndexedStringMap(this, "sshTargetAlias", state.sshTargetAliases)
             saveIndexedStringMap(this, "iosCmioId", state.iosCmioIds)
+            setProperty("mergeRemoteProjects", state.mergeRemoteProjects.toString())
+            setProperty("remoteProjectCache", encodeRemoteProjectCache(state.remoteProjectCache))
             setProperty("savedDockLayouts", encodeSavedDockLayouts(state.savedDockLayouts))
         }
         file.outputStream().use { props.store(it, "Andy workspace") }
@@ -372,6 +381,16 @@ class DesktopWorkspaceStore(
         return runCatching {
             WorkspaceJson.decodeFromString(ListSerializer(IntentDraft.serializer()), value)
         }.getOrDefault(emptyList())
+    }
+
+    private fun encodeRemoteProjectCache(cache: Map<String, List<CachedRemoteProject>>): String =
+        if (cache.isEmpty()) "" else WorkspaceJson.encodeToString(RemoteProjectCacheSerializer, cache)
+
+    private fun decodeRemoteProjectCache(value: String): Map<String, List<CachedRemoteProject>> {
+        if (value.isBlank()) return emptyMap()
+        return runCatching {
+            WorkspaceJson.decodeFromString(RemoteProjectCacheSerializer, value)
+        }.getOrDefault(emptyMap())
     }
 
     private fun encodeSavedDockLayouts(layouts: List<SavedDockLayout>): String =
@@ -461,5 +480,7 @@ class DesktopWorkspaceStore(
 
     private companion object {
         val WorkspaceJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+        val RemoteProjectCacheSerializer =
+            MapSerializer(String.serializer(), ListSerializer(CachedRemoteProject.serializer()))
     }
 }

--- a/data/workspace/src/desktopTest/kotlin/app/andy/desktop/service/DesktopWorkspaceStoreTest.kt
+++ b/data/workspace/src/desktopTest/kotlin/app/andy/desktop/service/DesktopWorkspaceStoreTest.kt
@@ -2,6 +2,7 @@ package app.andy.desktop.service
 
 import app.andy.model.AgentMessageDeliveryMode
 import app.andy.model.AgentNotificationTiming
+import app.andy.model.CachedRemoteProject
 import app.andy.model.IntentDraft
 import app.andy.model.IntentMode
 import app.andy.model.SavedDockLayout
@@ -227,6 +228,14 @@ class DesktopWorkspaceStoreTest {
         DesktopWorkspaceStore(file).save(saved.copy(savedSshTargets = listOf("alice@box", "HostAlias")))
         assertEquals(listOf("alice@box", "HostAlias"), DesktopWorkspaceStore(file).load().savedSshTargets)
 
+        DesktopWorkspaceStore(file).save(
+            saved.copy(
+                savedSshTargets = listOf("alice@box"),
+                sshTargetAliases = mapOf("alice@box" to "Garden"),
+            ),
+        )
+        assertEquals(mapOf("alice@box" to "Garden"), DesktopWorkspaceStore(file).load().sshTargetAliases)
+
         DesktopWorkspaceStore(file).save(saved.copy(hostScreenshotEnabled = true))
         assertEquals(true, DesktopWorkspaceStore(file).load().hostScreenshotEnabled)
         DesktopWorkspaceStore(file).save(saved.copy(hostScreenshotEnabled = false))
@@ -385,5 +394,59 @@ class DesktopWorkspaceStoreTest {
         val loadedAfterCorrupt = DesktopWorkspaceStore(file).load()
         assertEquals(emptyList(), loadedAfterCorrupt.savedDockLayouts)
         assertEquals("testing-saved-layouts", loadedAfterCorrupt.logSearch)
+    }
+
+    @Test
+    fun roundTripsMergedRemoteProjectPreferences() = runBlocking {
+        val file = createTempDirectory("andy-workspace-remote").toFile().resolve("workspace.properties")
+        val state = WorkspaceState(
+            mergeRemoteProjects = true,
+            remoteProjectCache = mapOf(
+                "joe@studio" to listOf(
+                    CachedRemoteProject("proj-andy", "Andy", "/Users/joe/Code/Andy"),
+                    CachedRemoteProject("proj-site", "Site", "/Users/joe/Code/site"),
+                ),
+                "joe@builder" to listOf(CachedRemoteProject("proj-tools", "Tools", "/srv/tools")),
+            ),
+        )
+        DesktopWorkspaceStore(file).save(state)
+        val loaded = DesktopWorkspaceStore(file).load()
+
+        assertEquals(true, loaded.mergeRemoteProjects)
+        assertEquals(state.remoteProjectCache, loaded.remoteProjectCache)
+    }
+
+    @Test
+    fun mergeSettingSurvivesAnUnrelatedUpdate() = runBlocking {
+        // Regression: every update() re-reads the file, so a field the store forgets to persist
+        // is silently reverted by the next unrelated workspace write.
+        val file = createTempDirectory("andy-workspace-remote-update").toFile().resolve("workspace.properties")
+        val store = DesktopWorkspaceStore(file)
+        store.save(WorkspaceState(mergeRemoteProjects = true))
+
+        store.update { it.copy(logSearch = "something else") }
+
+        assertEquals(true, DesktopWorkspaceStore(file).load().mergeRemoteProjects)
+    }
+
+    @Test
+    fun corruptRemoteProjectCacheFallsBackToEmpty() = runBlocking {
+        val file = createTempDirectory("andy-workspace-remote-corrupt").toFile().resolve("workspace.properties")
+        DesktopWorkspaceStore(file).save(
+            WorkspaceState(
+                mergeRemoteProjects = true,
+                remoteProjectCache = mapOf("joe@studio" to listOf(CachedRemoteProject("p", "P", "/p"))),
+            ),
+        )
+        file.writeText(
+            file.readText().lines().joinToString("\n") { line ->
+                if (line.startsWith("remoteProjectCache=")) "remoteProjectCache={not:valid-json..." else line
+            },
+        )
+
+        val loaded = DesktopWorkspaceStore(file).load()
+
+        assertEquals(emptyMap(), loaded.remoteProjectCache)
+        assertEquals(true, loaded.mergeRemoteProjects)
     }
 }

--- a/domain/src/commonMain/kotlin/app/andy/model/AgentAttachmentModels.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/AgentAttachmentModels.kt
@@ -1,0 +1,142 @@
+package app.andy.model
+
+import kotlinx.serialization.Serializable
+
+/** Extensible attachment kinds; start with text files staged from large pastes. */
+@Serializable
+enum class AgentAttachmentKind {
+    Text,
+}
+
+/**
+ * Managed, disk-backed attachment descriptor. Bodies never live in task JSON, transcripts,
+ * MCP payloads, or provider argv — only this metadata plus a task-local relative path.
+ */
+@Serializable
+data class AgentAttachment(
+    val id: String,
+    val displayName: String,
+    val kind: AgentAttachmentKind = AgentAttachmentKind.Text,
+    val mediaType: String = "text/plain; charset=utf-8",
+    val byteCount: Long,
+    val lineCount: Long? = null,
+    val sha256: String,
+    /**
+     * Path relative to the task cwd once materialized, e.g.
+     * `.andy/<taskId>/attachments/pasted-….txt`. Null while still staged pre-launch.
+     */
+    val relativePath: String? = null,
+)
+
+/** Safety and conversion limits for large pasted / uploaded text. */
+object ChatAttachmentLimits {
+    /** UTF-8 byte budget before paste becomes a managed attachment. */
+    const val InlineMaxBytes: Long = 64L * 1024
+
+    /** Line budget before paste becomes a managed attachment. */
+    const val InlineMaxLines: Long = 2_000
+
+    /** Hard cap for a single text attachment. */
+    const val MaxAttachmentBytes: Long = 512L * 1024 * 1024
+
+    /** Cap on total staged bytes owned by one composer draft. */
+    const val MaxStagedBytesPerDraft: Long = 1024L * 1024 * 1024
+
+    /** Approx Base64 chunk size for remote/Web uploads (~256 KiB decoded). */
+    const val UploadChunkBytes: Int = 256 * 1024
+
+    /** Compose layout guard for legacy huge inline user messages. */
+    const val TranscriptPreviewMaxChars: Int = 4_096
+
+    /** Fast path: if Kotlin string length exceeds this, UTF-8 must exceed [InlineMaxBytes]. */
+    const val InlineMaxCharsFastPath: Int = InlineMaxBytes.toInt()
+}
+
+/**
+ * True when [text] should become a managed text attachment instead of living in a TextField.
+ * Uses char-length as a fast reject, then line count, then UTF-8 byte length.
+ */
+fun shouldAttachLargeText(text: String): Boolean {
+    if (text.isEmpty()) return false
+    if (text.length > ChatAttachmentLimits.InlineMaxCharsFastPath) return true
+    val lineCount = countTextLines(text)
+    if (lineCount > ChatAttachmentLimits.InlineMaxLines) return true
+    return utf8ByteCount(text) > ChatAttachmentLimits.InlineMaxBytes
+}
+
+/** Line count matching common text-file conventions (empty → 0; otherwise newlines + 1). */
+fun countTextLines(text: String): Long {
+    if (text.isEmpty()) return 0L
+    var lines = 1L
+    for (ch in text) {
+        if (ch == '\n') lines++
+    }
+    return lines
+}
+
+/** Exact UTF-8 byte length of [text]. */
+fun utf8ByteCount(text: String): Long = text.encodeToByteArray().size.toLong()
+
+/** Human-readable size for chips and transcript rows. */
+fun formatAttachmentByteCount(bytes: Long): String = when {
+    bytes < 1024L -> "$bytes B"
+    bytes < 1024L * 1024 -> "${bytes / 1024L} KB"
+    bytes < 1024L * 1024 * 1024 -> {
+        val tenths = (bytes * 10) / (1024L * 1024)
+        "${tenths / 10}.${tenths % 10} MB"
+    }
+    else -> {
+        val hundredths = (bytes * 100) / (1024L * 1024 * 1024)
+        "${hundredths / 100}.${(hundredths % 100).toString().padStart(2, '0')} GB"
+    }
+}
+
+/** Compact chip / row subtitle: size and optional line count. */
+fun AgentAttachment.metadataLabel(): String = buildString {
+    append(formatAttachmentByteCount(byteCount))
+    lineCount?.takeIf { it > 0 }?.let { append(" · "); append(it); append(" lines") }
+}
+
+/**
+ * Builds a short provider-facing hint so the agent inspects the file with bounded reads.
+ * Never embeds attachment bodies.
+ */
+fun promptWithAttachmentHints(text: String, attachments: List<AgentAttachment>): String {
+    if (attachments.isEmpty()) return text
+    val body = text.trim()
+    val instruction = buildString {
+        if (body.isNotEmpty()) {
+            append(body)
+            append("\n\n")
+        } else {
+            append(
+                "The user attached managed text file(s) with no additional prose. " +
+                    "Inspect them with bounded reads/searches (never assume the full file fits in context).\n\n",
+            )
+        }
+        append("Managed text attachment")
+        if (attachments.size != 1) append('s')
+        append(" (read incrementally with offset/limit or search — do not load entire files into one turn):\n")
+        attachments.forEach { attachment ->
+            val path = attachment.relativePath?.takeIf { it.isNotBlank() }
+                ?: "(pending materialization; id=${attachment.id})"
+            append("- ").append(attachment.displayName).append(": ").append(path)
+            append(" (").append(formatAttachmentByteCount(attachment.byteCount))
+            attachment.lineCount?.let { append(", ").append(it).append(" lines") }
+            append(", sha256=").append(attachment.sha256).append(")\n")
+        }
+    }.trimEnd()
+    return instruction
+}
+
+/** Compose-safe preview for legacy huge inline user messages. */
+fun boundedUserMessagePreview(text: String, maxChars: Int = ChatAttachmentLimits.TranscriptPreviewMaxChars): String {
+    if (text.length <= maxChars) return text
+    val omitted = text.length - maxChars
+    return text.take(maxChars) +
+        "\n\n… [message truncated for display: $omitted more characters — use Copy to access the full text]"
+}
+
+/** True when the composer can send with only attachments (no prose / images / skills). */
+fun hasSendableAttachments(attachments: List<AgentAttachment>): Boolean =
+    attachments.any { it.kind == AgentAttachmentKind.Text && it.byteCount > 0 }

--- a/domain/src/commonMain/kotlin/app/andy/model/AgentModels.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/AgentModels.kt
@@ -504,6 +504,8 @@ data class AgentQueuedFollowUp(
     val skills: List<AgentSkill> = emptyList(),
     /** Managed evidence bundle ids (§4) attached to this follow-up, if any. */
     val contextBundleIds: List<String> = emptyList(),
+    /** Managed text attachments for this follow-up (descriptors only; never bodies). */
+    val attachments: List<AgentAttachment> = emptyList(),
     /** Where this follow-up's contextual action was triggered from, if any. */
     val provenance: AgentContextualProvenance? = null,
 )
@@ -571,6 +573,8 @@ data class AgentTask(
     val openClawNewSession: Boolean = true,
     /** Local images supplied with the original task prompt. */
     val imagePaths: List<String> = emptyList(),
+    /** Managed text attachments for the original prompt (descriptors only; never bodies). */
+    val attachments: List<AgentAttachment> = emptyList(),
     /** Local skills selected while composing the original prompt. */
     val skills: List<AgentSkill> = emptyList(),
     /** A durable objective Andy keeps alongside the provider session. */
@@ -784,6 +788,8 @@ data class AgentTaskDraft(
     val fastMode: Boolean = false,
     val openClawNewSession: Boolean = true,
     val imagePaths: List<String> = emptyList(),
+    /** Managed text attachments staged for launch (descriptors only; never bodies). */
+    val attachments: List<AgentAttachment> = emptyList(),
     val skills: List<AgentSkill> = emptyList(),
     val goal: String? = null,
     val maxBudgetUsd: Double? = null,
@@ -1053,6 +1059,17 @@ data class AgentChangeSummary(val files: List<AgentFileChange>) {
 data class AgentThreadChangeSnapshot(
     val summary: AgentChangeSummary,
     val diffs: Map<String, AgentFileDiff>,
+    /**
+     * False when this snapshot came off disk summary-only and [diffs] is therefore empty because
+     * it was never read, not because the chat changed nothing. Loading every stored diff at
+     * startup costs ~80MB of heap, so the store hydrates [summary] eagerly and leaves [diffs] to
+     * an explicit fetch (`AgentRunService.completedDiffs`).
+     *
+     * Persistence keys off this: an unhydrated snapshot is saved through a statement that splices
+     * the stored diffs back, so a save can never blank them. Anything built in-memory from a live
+     * working tree is hydrated by definition, which is why this defaults to true.
+     */
+    val diffsHydrated: Boolean = true,
 )
 
 enum class DiffLineKind { Context, Addition, Deletion }
@@ -1211,6 +1228,10 @@ fun AgentTaskDraft.fallbackTitle(): String = when {
         val first = localPathFileName(imagePaths.first())
         if (imagePaths.size == 1) first else "$first (+${imagePaths.size - 1})"
     }
+    attachments.isNotEmpty() -> {
+        val first = attachments.first().displayName
+        if (attachments.size == 1) first else "$first (+${attachments.size - 1})"
+    }
     else -> ""
 }
 
@@ -1310,12 +1331,15 @@ fun promptWithLocalEvidencePathsHint(text: String, hint: String?): String =
     if (hint.isNullOrBlank()) text else text + hint
 
 fun AgentTask.promptForCli(): String = promptWithImageHints(
-    promptWithLocalEvidencePathsHint(
-        promptWithEvidenceHint(
-            composeAgentPrompt(continuationPrompt ?: prompt, skills, id, planMode, goal),
-            contextBundleIds,
+    promptWithAttachmentHints(
+        promptWithLocalEvidencePathsHint(
+            promptWithEvidenceHint(
+                composeAgentPrompt(continuationPrompt ?: prompt, skills, id, planMode, goal),
+                contextBundleIds,
+            ),
+            evidenceLocalPathsHint,
         ),
-        evidenceLocalPathsHint,
+        attachments,
     ),
     imagePaths,
 )
@@ -1324,8 +1348,12 @@ fun AgentTask.followUpPromptForCli(
     text: String,
     imagePaths: List<String>,
     skills: List<AgentSkill> = this.skills,
+    attachments: List<AgentAttachment> = emptyList(),
 ): String = promptWithImageHints(
-    composeAgentPrompt(text, skills, id, planMode, goal),
+    promptWithAttachmentHints(
+        composeAgentPrompt(text, skills, id, planMode, goal),
+        attachments,
+    ),
     imagePaths,
 )
 
@@ -1343,8 +1371,12 @@ fun AgentTask.followUpCliPayload(
     text: String,
     imagePaths: List<String>,
     skills: List<AgentSkill> = emptyList(),
+    attachments: List<AgentAttachment> = emptyList(),
 ): FollowUpCliPayload {
-    val composed = composeAgentPrompt(text, skills, id, planMode, goal)
+    val composed = promptWithAttachmentHints(
+        composeAgentPrompt(text, skills, id, planMode, goal),
+        attachments,
+    )
     return when (agent) {
         AgentKind.Codex -> FollowUpCliPayload(
             prompt = composed,
@@ -1361,8 +1393,12 @@ fun AgentTask.followUpPromptForLiveTerminal(
     text: String,
     imagePaths: List<String>,
     skills: List<AgentSkill> = emptyList(),
+    attachments: List<AgentAttachment> = emptyList(),
 ): String = promptWithInlineImageHints(
-    composeAgentPrompt(text, skills, id, planMode, goal),
+    promptWithAttachmentHints(
+        composeAgentPrompt(text, skills, id, planMode, goal),
+        attachments,
+    ),
     imagePaths,
 )
 
@@ -1414,6 +1450,8 @@ sealed interface AgentEvent {
         val skills: List<AgentSkill> = emptyList(),
         /** Local image paths attached with this message, shown as thumbnails in the bubble. */
         val imagePaths: List<String> = emptyList(),
+        /** Managed text attachments shown as compact rows (descriptors only). */
+        val attachments: List<AgentAttachment> = emptyList(),
     ) : AgentEvent
     data class ToolCall(
         override val atMillis: Long,
@@ -1507,6 +1545,16 @@ sealed interface AgentEvent {
     /** Fallback for stdout lines the adapter could not parse; nothing is dropped. */
     data class Raw(override val atMillis: Long, val line: String) : AgentEvent
 }
+
+/** One Cmd+K / search hit from project chat transcript body text. */
+data class TranscriptSearchHit(
+    val taskId: String,
+    val projectId: String?,
+    val title: String,
+    val projectName: String?,
+    val snippet: String,
+    val atMillis: Long,
+)
 
 /**
  * Wall time from the current turn's user message (or [startedAtMillis]) to [finishedAtMillis].

--- a/domain/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
+++ b/domain/src/commonMain/kotlin/app/andy/model/WorkspaceModels.kt
@@ -33,6 +33,18 @@ enum class EditorSyntaxTheme(val id: String, val label: String) {
     }
 }
 
+/**
+ * A project seen on a saved SSH remote during the last scan, cached so the merged Projects list
+ * has something to draw before (or without) a fresh `ssh`. Runbook actions and notes are not
+ * cached — those load for real once that host is connected.
+ */
+@Serializable
+data class CachedRemoteProject(
+    val id: String,
+    val name: String,
+    val contextDir: String = "",
+)
+
 @Serializable
 data class WorkspaceState(
     val selectedSdkPath: String? = null,
@@ -203,6 +215,22 @@ data class WorkspaceState(
      * optional passwords live in the OS keychain (`Andy SSH`), not in this file.
      */
     val savedSshTargets: List<String> = emptyList(),
+    /**
+     * Friendly display names keyed by SSH target (`user@host` / config Host). Shown in the
+     * sidebar Host list; blank / missing falls back to the raw target string.
+     */
+    val sshTargetAliases: Map<String, String> = emptyMap(),
+    /**
+     * When true, the Projects list also shows projects that live on saved SSH remotes, badged
+     * with their host. Opening one connects to that host first. Off by default — it costs a
+     * background `ssh` read of each saved host's `~/.andy/actions.toml`.
+     */
+    val mergeRemoteProjects: Boolean = false,
+    /**
+     * Last successful remote project scan keyed by SSH target, so the merged list paints
+     * immediately at launch instead of waiting on SSH. Display fields only.
+     */
+    val remoteProjectCache: Map<String, List<CachedRemoteProject>> = emptyMap(),
     /**
      * Physical iOS CMIO `uniqueID` keyed by device UDID, remembered across reconnects so the
      * native screen-capture lookup can skip re-resolving it from the CoreMediaIO device list

--- a/domain/src/commonMain/kotlin/app/andy/service/ChatAttachmentService.kt
+++ b/domain/src/commonMain/kotlin/app/andy/service/ChatAttachmentService.kt
@@ -1,0 +1,140 @@
+package app.andy.service
+
+import app.andy.model.AgentAttachment
+import app.andy.model.ChatAttachmentLimits
+
+/**
+ * Stages large pasted / uploaded text as managed disk-backed attachments.
+ * Descriptors are safe to persist; bodies live only on disk under Andy-managed roots.
+ */
+interface ChatAttachmentService {
+    /**
+     * Writes [text] to a staging file (buffered, hashed in one pass) and returns a descriptor.
+     * Rejects payloads over [ChatAttachmentLimits.MaxAttachmentBytes] or when the draft budget
+     * would exceed [ChatAttachmentLimits.MaxStagedBytesPerDraft].
+     */
+    suspend fun stageText(
+        text: String,
+        displayName: String = "pasted.txt",
+        draftKey: String? = null,
+    ): Result<AgentAttachment>
+
+    /** Removes a staged attachment that was never bound to a task (composer discard). */
+    suspend fun discardStaged(attachmentId: String): Boolean
+
+    /**
+     * Makes [attachments] readable under `<cwd>/.andy/<taskId>/attachments/`, preferring a
+     * hard link when possible. Returns descriptors with [AgentAttachment.relativePath] set.
+     */
+    suspend fun materializeForTask(
+        taskId: String,
+        cwd: String?,
+        attachments: List<AgentAttachment>,
+    ): List<AgentAttachment>
+
+    /** Deletes staged files owned by [draftKey] (abandoned composer). */
+    suspend fun discardDraft(draftKey: String)
+
+    /** Best-effort cleanup of abandoned staging uploads older than [maxAgeMillis]. */
+    suspend fun expireAbandonedStaging(maxAgeMillis: Long = 24L * 60 * 60 * 1000)
+
+    /** Bounded authenticated upload: begin a new staging session. */
+    suspend fun beginUpload(
+        displayName: String,
+        byteCount: Long,
+        sha256: String,
+        mediaType: String = "text/plain; charset=utf-8",
+        draftKey: String? = null,
+    ): Result<ChatAttachmentUploadSession>
+
+    /** Appends a Base64 chunk; [sequence] must be monotonic from 0. */
+    suspend fun appendUploadChunk(
+        uploadId: String,
+        sequence: Int,
+        base64Chunk: String,
+    ): Result<Unit>
+
+    /** Verifies size/hash and finalizes into a staged [AgentAttachment]. */
+    suspend fun commitUpload(uploadId: String): Result<AgentAttachment>
+
+    /** Cancels an in-progress upload and deletes partial bytes. */
+    suspend fun cancelUpload(uploadId: String): Boolean
+
+    /**
+     * Reads up to [maxBytes] from a locally staged attachment body starting at [offset].
+     * Used by the GUI→daemon remote upload path so large bodies never enter a single RPC.
+     * Returns null when the staged file is missing; empty array at/after EOF.
+     */
+    suspend fun readStagedChunk(attachmentId: String, offset: Long, maxBytes: Int): ByteArray?
+
+    /**
+     * When a final provider prompt exceeds the inline budget, spills it to the task attachment
+     * directory and returns a short path hint. Otherwise returns [prompt] unchanged.
+     */
+    suspend fun spilloverPromptIfNeeded(
+        taskId: String,
+        cwd: String?,
+        prompt: String,
+    ): String
+}
+
+data class ChatAttachmentUploadSession(
+    val uploadId: String,
+    val displayName: String,
+    val expectedBytes: Long,
+    val expectedSha256: String,
+)
+
+object UnavailableChatAttachmentService : ChatAttachmentService {
+    override suspend fun stageText(
+        text: String,
+        displayName: String,
+        draftKey: String?,
+    ): Result<AgentAttachment> = Result.failure(
+        UnsupportedOperationException("Managed text attachments are unavailable on this platform."),
+    )
+
+    override suspend fun discardStaged(attachmentId: String): Boolean = false
+
+    override suspend fun materializeForTask(
+        taskId: String,
+        cwd: String?,
+        attachments: List<AgentAttachment>,
+    ): List<AgentAttachment> = attachments
+
+    override suspend fun discardDraft(draftKey: String) = Unit
+
+    override suspend fun expireAbandonedStaging(maxAgeMillis: Long) = Unit
+
+    override suspend fun beginUpload(
+        displayName: String,
+        byteCount: Long,
+        sha256: String,
+        mediaType: String,
+        draftKey: String?,
+    ): Result<ChatAttachmentUploadSession> = Result.failure(
+        UnsupportedOperationException("Managed text attachments are unavailable on this platform."),
+    )
+
+    override suspend fun appendUploadChunk(
+        uploadId: String,
+        sequence: Int,
+        base64Chunk: String,
+    ): Result<Unit> = Result.failure(
+        UnsupportedOperationException("Managed text attachments are unavailable on this platform."),
+    )
+
+    override suspend fun commitUpload(uploadId: String): Result<AgentAttachment> = Result.failure(
+        UnsupportedOperationException("Managed text attachments are unavailable on this platform."),
+    )
+
+    override suspend fun cancelUpload(uploadId: String): Boolean = false
+
+    override suspend fun readStagedChunk(attachmentId: String, offset: Long, maxBytes: Int): ByteArray? = null
+
+    override suspend fun spilloverPromptIfNeeded(
+        taskId: String,
+        cwd: String?,
+        prompt: String,
+    ): String = prompt
+}

--- a/domain/src/commonMain/kotlin/app/andy/service/RemoteSession.kt
+++ b/domain/src/commonMain/kotlin/app/andy/service/RemoteSession.kt
@@ -1,5 +1,6 @@
 package app.andy.service
 
+import app.andy.model.ActionProject
 import app.andy.model.ActionsConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,6 +30,8 @@ data class RemoteSessionState(
     val error: String? = null,
     /** Non-secret saved SSH targets from workspace prefs (passwords optional via OS keychain). */
     val savedTargets: List<String> = emptyList(),
+    /** Friendly display names keyed by SSH target; blank / missing falls back to the raw target. */
+    val targetAliases: Map<String, String> = emptyMap(),
     /**
      * Probed once per successful connect — Screen Sharing / VNC / screenshot tools on the
      * remote host. `null` while local or still connecting.
@@ -36,7 +39,40 @@ data class RemoteSessionState(
     val hostCapabilities: RemoteHostCapabilities? = null,
 ) {
     val isRemote: Boolean get() = status == RemoteSessionStatus.Connected
+
+    /** Sidebar / header label for [target], preferring a user-set alias when present. */
+    fun displayNameFor(target: String): String =
+        targetAliases[target]?.takeIf { it.isNotBlank() } ?: target
 }
+
+/** Outcome of the background `~/.andy/actions.toml` read for one saved SSH target. */
+enum class RemoteProjectScanStatus {
+    /** Never scanned this session — anything listed came from the workspace cache. */
+    Cached,
+    Scanning,
+    Ok,
+    /**
+     * No usable project list: host is down, refused a non-interactive `ssh` (needs a password
+     * Andy won't prompt for during a background scan), or its `actions.toml` failed to parse.
+     * `RemoteTargetProjects.error` carries the reason for the row tooltip.
+     */
+    Unavailable,
+}
+
+/**
+ * Projects found on a saved SSH remote that is *not* the active host, for the merged Projects
+ * list. These are display-only: opening one connects to [target] first, after which its real
+ * config arrives through [RemoteSessionService.remoteActionsConfig].
+ */
+data class RemoteTargetProjects(
+    val target: String,
+    val status: RemoteProjectScanStatus = RemoteProjectScanStatus.Cached,
+    val projects: List<ActionProject> = emptyList(),
+    val error: String? = null,
+)
+
+private val NoSavedTargetProjects: StateFlow<Map<String, RemoteTargetProjects>> =
+    MutableStateFlow(emptyMap<String, RemoteTargetProjects>()).asStateFlow()
 
 /**
  * Desktop SSH remote control plane: tunnel `andyd.sock` (+ tmux) to another machine and
@@ -44,6 +80,23 @@ data class RemoteSessionState(
  */
 interface RemoteSessionService {
     val state: StateFlow<RemoteSessionState>
+
+    /**
+     * Projects on saved SSH targets other than the connected one, keyed by target — the merge
+     * source for the Projects list when `WorkspaceState.mergeRemoteProjects` is on. Empty while
+     * the setting is off; the active host is never included (its projects are already the list).
+     */
+    val savedTargetProjects: StateFlow<Map<String, RemoteTargetProjects>>
+        get() = NoSavedTargetProjects
+
+    /**
+     * Re-read `~/.andy/actions.toml` on every saved target. No-op while the merge setting is off.
+     * Scans are non-interactive — a host that would need a password is reported
+     * [RemoteProjectScanStatus.Unreachable] rather than prompting.
+     *
+     * @param force bypasses the min-interval throttle that de-dupes UI-triggered refreshes.
+     */
+    suspend fun refreshSavedTargetProjects(force: Boolean = false) = Unit
 
     /**
      * Remote `~/.andy/actions.toml` projects while connected; `null` means use the local
@@ -69,6 +122,11 @@ interface RemoteSessionService {
     suspend fun reconnect(rememberPassword: Boolean = false): Result<Unit>
     suspend fun addSavedTarget(target: String)
     suspend fun removeSavedTarget(target: String)
+    /**
+     * Set or clear the sidebar display alias for a saved SSH [target]. Blank [alias] removes
+     * the override so the raw target shows again.
+     */
+    suspend fun renameSavedTargetAlias(target: String, alias: String)
     /** Persist project edits to the remote host's `~/.andy/actions.toml` while remoted. */
     suspend fun saveRemoteActionsConfig(config: ActionsConfig): Result<Unit>
 
@@ -110,6 +168,8 @@ object UnavailableRemoteSessionService : RemoteSessionService {
     override suspend fun addSavedTarget(target: String) = Unit
 
     override suspend fun removeSavedTarget(target: String) = Unit
+
+    override suspend fun renameSavedTargetAlias(target: String, alias: String) = Unit
 
     override suspend fun saveRemoteActionsConfig(config: ActionsConfig): Result<Unit> =
         Result.failure(IllegalStateException("SSH remote requires Andy Desktop on macOS or Linux."))

--- a/domain/src/commonMain/kotlin/app/andy/service/Services.kt
+++ b/domain/src/commonMain/kotlin/app/andy/service/Services.kt
@@ -692,6 +692,8 @@ interface AgentRunService {
         contextBundleIds: List<String> = emptyList(),
         /** Where this turn's contextual action came from (§5); recorded on the task when it has none yet. */
         provenance: AgentContextualProvenance? = null,
+        /** Managed text attachments (descriptors only). */
+        attachments: List<AgentAttachment> = emptyList(),
     )
     /** Reopens a stored provider session so the live interactive terminal UI comes back. */
     fun reattachSession(taskId: String)
@@ -754,7 +756,45 @@ interface AgentRunService {
         contextBundleIds: List<String> = emptyList(),
         /** Where this follow-up's contextual action came from (§5). */
         provenance: AgentContextualProvenance? = null,
+        /** Managed text attachments (descriptors only). */
+        attachments: List<AgentAttachment> = emptyList(),
     )
+
+    /**
+     * Materializes (or remotely uploads) [attachments] then starts [resume]. Suspends until
+     * attachments are ready or fails — the provider turn continues asynchronously.
+     * Callers that clear a composer draft must await this and keep the draft on failure.
+     */
+    suspend fun resumePrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String> = emptyList(),
+        skills: List<AgentSkill> = emptyList(),
+        contextBundleIds: List<String> = emptyList(),
+        provenance: AgentContextualProvenance? = null,
+        attachments: List<AgentAttachment> = emptyList(),
+    ): Result<Unit> {
+        resume(taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments)
+        return Result.success(Unit)
+    }
+
+    /**
+     * Like [queueFollowUp], but suspends until attachments are materialized/uploaded (or fails)
+     * before treating the send as successful for composer draft clearing.
+     */
+    suspend fun queueFollowUpPrepared(
+        taskId: String,
+        followUp: String,
+        imagePaths: List<String> = emptyList(),
+        skills: List<AgentSkill> = emptyList(),
+        contextBundleIds: List<String> = emptyList(),
+        provenance: AgentContextualProvenance? = null,
+        attachments: List<AgentAttachment> = emptyList(),
+    ): Result<Unit> {
+        queueFollowUp(taskId, followUp, imagePaths, skills, contextBundleIds, provenance, attachments)
+        return Result.success(Unit)
+    }
+
     /** Removes an unsent follow-up at [queueIndex]. */
     fun removeQueuedFollowUp(taskId: String, queueIndex: Int)
     /** Sends the queued follow-up at [queueIndex] when the chat is idle. */
@@ -790,6 +830,12 @@ interface AgentRunService {
      * the PTY buffer is the transcript. Kept for call-site compatibility during migration.
      */
     fun events(taskId: String): StateFlow<List<AgentEvent>>
+    /**
+     * Streams transcript-body matches for [query] (user/assistant text and tool titles).
+     * Emits progressively as the FTS index and any cold-task backfill find hits.
+     * Empty / short queries yield [emptyFlow].
+     */
+    fun searchTranscripts(query: String): Flow<TranscriptSearchHit> = emptyFlow()
     fun interactiveResumeCommand(taskId: String): String?
     /**
      * Provider label when this exact conversation can continue in its desktop app.
@@ -1324,6 +1370,7 @@ data class AndyServices(
     val crashInspector: CrashInspectorService = UnavailableCrashInspectorService,
     val heapDump: HeapDumpService = UnavailableHeapDumpService,
     val evidence: InvestigationEvidenceService = UnavailableInvestigationEvidenceService,
+    val chatAttachments: ChatAttachmentService = UnavailableChatAttachmentService,
     val workspaceStore: WorkspaceStore,
     val updates: AppUpdateService,
     val runtimeBundle: RuntimeBundleService = UnavailableRuntimeBundleService,

--- a/domain/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
+++ b/domain/src/commonMain/kotlin/app/andy/service/UnavailableServices.kt
@@ -371,6 +371,7 @@ object UnavailableAgentRunService : AgentRunService {
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
     ) = Unit
 
     override fun reattachSession(taskId: String) = Unit
@@ -385,6 +386,7 @@ object UnavailableAgentRunService : AgentRunService {
         skills: List<AgentSkill>,
         contextBundleIds: List<String>,
         provenance: AgentContextualProvenance?,
+        attachments: List<AgentAttachment>,
     ) = Unit
     override fun removeQueuedFollowUp(taskId: String, queueIndex: Int) = Unit
     override fun sendQueuedFollowUp(taskId: String, queueIndex: Int) = Unit

--- a/domain/src/commonTest/kotlin/app/andy/model/AgentAttachmentModelsTest.kt
+++ b/domain/src/commonTest/kotlin/app/andy/model/AgentAttachmentModelsTest.kt
@@ -1,0 +1,83 @@
+package app.andy.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AgentAttachmentModelsTest {
+    @Test
+    fun shouldAttachWhenOverByteBudget() {
+        val text = "x".repeat(ChatAttachmentLimits.InlineMaxBytes.toInt() + 1)
+        assertTrue(shouldAttachLargeText(text))
+    }
+
+    @Test
+    fun shouldAttachWhenOverLineBudget() {
+        val text = (1..(ChatAttachmentLimits.InlineMaxLines.toInt() + 1)).joinToString("\n") { "line" }
+        assertTrue(shouldAttachLargeText(text))
+        assertTrue(utf8ByteCount(text) < ChatAttachmentLimits.InlineMaxBytes)
+    }
+
+    @Test
+    fun smallAsciiPasteStaysInline() {
+        assertFalse(shouldAttachLargeText("hello world"))
+        assertFalse(shouldAttachLargeText(""))
+    }
+
+    @Test
+    fun unicodeByteCountExceedsCharLength() {
+        val text = "你".repeat(30_000) // 3 bytes each in UTF-8
+        assertTrue(utf8ByteCount(text) > text.length)
+        assertTrue(shouldAttachLargeText(text))
+    }
+
+    @Test
+    fun promptHintsNeverEmbedBody() {
+        val body = "SECRET_BODY_" + "x".repeat(1000)
+        val attachment = AgentAttachment(
+            id = "att-1",
+            displayName = "pasted.txt",
+            byteCount = body.length.toLong(),
+            lineCount = 1,
+            sha256 = "a".repeat(64),
+            relativePath = ".andy/task/attachments/pasted.txt",
+        )
+        val prompt = promptWithAttachmentHints("Please inspect", listOf(attachment))
+        assertTrue(prompt.contains("Please inspect"))
+        assertTrue(prompt.contains(".andy/task/attachments/pasted.txt"))
+        assertTrue(prompt.contains(attachment.sha256))
+        assertFalse(prompt.contains("SECRET_BODY_"))
+        assertTrue(prompt.length < 2_000)
+    }
+
+    @Test
+    fun attachmentOnlyPromptSynthesizesInstruction() {
+        val attachment = AgentAttachment(
+            id = "att-2",
+            displayName = "dump.txt",
+            byteCount = 100,
+            lineCount = 4,
+            sha256 = "b".repeat(64),
+            relativePath = ".andy/t/attachments/dump.txt",
+        )
+        val prompt = promptWithAttachmentHints("", listOf(attachment))
+        assertTrue(prompt.contains("no additional prose"))
+        assertTrue(prompt.contains("dump.txt"))
+    }
+
+    @Test
+    fun boundedPreviewKeepsComposeLayoutSafe() {
+        val huge = "y".repeat(20_000)
+        val preview = boundedUserMessagePreview(huge, maxChars = 100)
+        assertTrue(preview.length < 300)
+        assertTrue(preview.contains("truncated"))
+        assertEquals(100, preview.indexOf('\n').let { if (it < 0) preview.length else it }.coerceAtMost(100))
+    }
+
+    @Test
+    fun formatAttachmentByteCountReadable() {
+        assertEquals("100 B", formatAttachmentByteCount(100))
+        assertEquals("8.0 MB", formatAttachmentByteCount(8L * 1024 * 1024))
+    }
+}

--- a/domain/src/commonTest/kotlin/app/andy/model/FollowUpCliPayloadTest.kt
+++ b/domain/src/commonTest/kotlin/app/andy/model/FollowUpCliPayloadTest.kt
@@ -39,14 +39,23 @@ class FollowUpCliPayloadTest {
     }
 
     @Test
-    fun liveTerminalPromptKeepsAttachedImagesInline() {
-        val task = task(AgentKind.ClaudeCode)
-        val prompt = task.followUpPromptForLiveTerminal(
-            text = "fix this bug",
-            imagePaths = listOf("/tmp/screenshot.png"),
+    fun followUpPromptIncludesAttachmentHintsWithoutBodies() {
+        val attachment = AgentAttachment(
+            id = "att-1",
+            displayName = "dump.txt",
+            byteCount = 8_000_000,
+            lineCount = 90_000,
+            sha256 = "c".repeat(64),
+            relativePath = ".andy/task-1/attachments/dump.txt",
         )
-        assertTrue(prompt.contains("fix this bug"))
-        assertTrue(prompt.contains("/tmp/screenshot.png"))
-        assertTrue(!prompt.contains("\n\nAttached image file"))
+        val payload = task(AgentKind.ClaudeCode).followUpCliPayload(
+            text = "summarize the dump",
+            imagePaths = emptyList(),
+            attachments = listOf(attachment),
+        )
+        assertTrue(payload.prompt.contains("summarize the dump"))
+        assertTrue(payload.prompt.contains(".andy/task-1/attachments/dump.txt"))
+        assertTrue(payload.prompt.contains(attachment.sha256))
+        assertTrue(payload.prompt.length < 4_000)
     }
 }

--- a/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -1108,6 +1108,9 @@ private fun ProjectCockpit(
             services.agentRuns.searchTranscripts(query)
                 .mapNotNull { hit ->
                     if (hit.taskId in excludeChatIds) return@mapNotNull null
+                    // This palette can only open project-scoped chats; a top-level Agents chat
+                    // (null projectId) would render but do nothing on select.
+                    if (hit.projectId == null) return@mapNotNull null
                     val supporting = listOfNotNull(hit.projectName, hit.snippet)
                         .joinToString(" · ")
                         .ifBlank { null }

--- a/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
+++ b/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/ActionsScreen.kt
@@ -125,6 +125,7 @@ import app.andy.domain.visibleChatSessions
 import app.andy.pickDirectory
 import app.andy.rememberCopyText
 import app.andy.service.AndyServices
+import app.andy.service.RemoteSessionStatus
 import app.andy.ui.components.Button
 import app.andy.ui.components.CommandPalette
 import app.andy.ui.components.CommandPaletteItem
@@ -134,6 +135,7 @@ import app.andy.ui.components.LabeledField
 import app.andy.ui.components.OutlinedButton
 import app.andy.ui.components.TextField
 import app.andy.ui.components.Toolbar
+import app.andy.ui.components.Tooltip
 import app.andy.ui.components.WorkspaceCanvas
 import app.andy.ui.components.WorkspaceEmptyCanvas
 import app.andy.ui.components.WorkspaceRail
@@ -153,6 +155,7 @@ import app.andy.ui.agents.isChatRelaunching
 import app.andy.ui.agents.isSessionWorking
 import app.andy.ui.components.StatusTag
 import app.andy.ui.components.RetainedDestination
+import app.andy.ui.components.SuppressHeavyweightSurfacesWhileOpen
 import app.andy.ui.theme.AndyColors
 import app.andy.ui.theme.AndyLayout
 import app.andy.ui.theme.AndySpace
@@ -171,6 +174,8 @@ import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
 import app.andy.ui.theme.andyTokens
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 
@@ -201,10 +206,19 @@ private enum class ProjectCanvas(val label: String) {
 private const val RecentSessionsPerProject = 5
 private const val ShowMoreSessionsIncrement = 20
 
+/**
+ * How long the outgoing project list is held after a host switch reports success. Only a release
+ * valve — the destination config normally arrives in well under a second and ends the switch.
+ */
+private const val HostSwitchReleaseMillis = 8_000L
+/** Slow enough not to flash on a warm host that reconnects instantly. */
+private const val HostSwitchFadeInMillis = 220
+private const val HostSwitchFadeOutMillis = 160
+
 @Composable
 private fun ProjectCockpit(
     services: AndyServices,
-    config: ActionsConfig,
+    incomingConfig: ActionsConfig,
     onConfigChange: (ActionsConfig) -> Unit,
     agentTasks: List<AgentTask>,
     preferredProjectId: String?,
@@ -226,6 +240,9 @@ private fun ProjectCockpit(
     val outdatedCliUpdates by services.cliUpdates.outdated.collectAsState()
     val updatingCliKinds by services.cliUpdates.updating.collectAsState()
     val workflowProjects by services.projectWorkflows.projects.collectAsState()
+    val remoteSession by services.remoteSession.state.collectAsState()
+    val savedTargetProjects by services.remoteSession.savedTargetProjects.collectAsState()
+    val mergeRemoteProjects = workspaceState.mergeRemoteProjects
     var selectedProjectId by remember { mutableStateOf<String?>(null) }
     var selectedTaskId by remember { mutableStateOf<String?>(null) }
     var selectedWorkflowTaskId by remember { mutableStateOf<String?>(null) }
@@ -262,6 +279,31 @@ private fun ProjectCockpit(
     var buildEditor by remember { mutableStateOf<BuildEditorSeed?>(null) }
     var profilesOpen by remember { mutableStateOf(false) }
     var pendingConfirmation by remember { mutableStateOf<PendingConfirmation?>(null) }
+    /** Host being switched to on behalf of a merged "other host" project row. */
+    var switchingToHost by remember { mutableStateOf<ProjectHost?>(null) }
+    /** Project to select once the newly attached host's actions.toml arrives. */
+    var pendingRemoteProjectId by remember { mutableStateOf<String?>(null) }
+    var switchingHostLabel by remember { mutableStateOf("") }
+    /**
+     * A host switch tears the old backend down before the new config arrives, so for a moment
+     * `incomingConfig` is the *local* list. Rendering that would flash a third project list —
+     * and steal the selection — between the one the user left and the one they asked for, so the
+     * outgoing list is held on screen until the destination is ready.
+     */
+    // Also covers a switch started from the Local/Remote sidebar switcher, which flashes the same
+    // way — the backend swap is identical, only the entry point differs.
+    val switchingHosts = switchingToHost != null ||
+        pendingRemoteProjectId != null ||
+        remoteSession.status == RemoteSessionStatus.Connecting
+    var heldConfig by remember { mutableStateOf(incomingConfig) }
+    LaunchedEffect(incomingConfig, switchingHosts) {
+        if (!switchingHosts) {
+            heldConfig = incomingConfig
+            // Stale label would mislabel the next sidebar-initiated switch.
+            switchingHostLabel = ""
+        }
+    }
+    val config = if (switchingHosts) heldConfig else incomingConfig
     val transcriptScrollMemory = remember { TranscriptScrollMemory() }
     val followUpDraftMemory = remember { ChatFollowUpDraftMemory() }
     var expandedActionId by remember { mutableStateOf<String?>(null) }
@@ -278,6 +320,37 @@ private fun ProjectCockpit(
     fun selectProject(projectId: String, rememberAsPreferred: Boolean = true) {
         selectedProjectId = projectId
         if (rememberAsPreferred) onPreferredProjectChange(projectId)
+    }
+
+    /**
+     * Opens a project that lives on another host: attach Andy there first (connecting to a
+     * previously used host is usually instant — it stays warm), then select the project once its
+     * config lands.
+     */
+    fun openOtherHostProject(row: OtherHostProjectRow) {
+        if (switchingHosts) return
+        scope.launch {
+            switchingHostLabel = row.hostLabel
+            switchingToHost = row.host
+            val result = when (val host = row.host) {
+                ProjectHost.Local -> {
+                    services.remoteSession.disconnect()
+                    Result.success(Unit)
+                }
+                is ProjectHost.Ssh -> services.remoteSession.connect(host.target)
+            }
+            switchingToHost = null
+            if (result.isSuccess) {
+                pendingRemoteProjectId = row.project.id
+            } else {
+                pendingConfirmation = PendingConfirmation(
+                    title = "Could not connect to ${row.hostLabel}",
+                    message = result.exceptionOrNull()?.message
+                        ?: "SSH connect failed. Check the host from the Local/Remote switcher.",
+                    confirmLabel = "OK",
+                ) {}
+            }
+        }
     }
 
     fun ensureWorkflowProjectLoaded() {
@@ -325,11 +398,36 @@ private fun ProjectCockpit(
 
     LaunchedEffect(workspaceReady, config.projects, preferredProjectId) {
         if (!workspaceReady) return@LaunchedEffect
+        // A host switch has its own destination in mind; letting this fall back to the preferred
+        // project first would render one frame of the wrong project before that lands.
+        if (pendingRemoteProjectId != null) return@LaunchedEffect
         val projectIds = config.projects.map { it.id }
         if (selectedProjectId !in projectIds) {
             selectedProjectId = preferredProjectId?.takeIf { it in projectIds }
                 ?: config.projects.firstOrNull()?.id
         }
+    }
+    // Watches the incoming config, not the held one: this is what ends the switch. Runs after the
+    // selection effect above so a just-attached host lands on the project the user actually
+    // clicked, not on the preferred/first one that effect would restore.
+    LaunchedEffect(incomingConfig.projects, pendingRemoteProjectId) {
+        val pending = pendingRemoteProjectId ?: return@LaunchedEffect
+        if (incomingConfig.projects.none { it.id == pending }) return@LaunchedEffect
+        selectProject(pending)
+        selectedTaskId = null
+        selectedWorkflowTaskId = null
+        canvas = ProjectCanvas.Chat
+        pendingRemoteProjectId = null
+    }
+    // Safety valve: if the destination never lists that project (its actions.toml changed, or the
+    // config never lands), release the held list rather than leaving the UI frozen mid-switch.
+    LaunchedEffect(pendingRemoteProjectId) {
+        if (pendingRemoteProjectId == null) return@LaunchedEffect
+        delay(HostSwitchReleaseMillis)
+        pendingRemoteProjectId = null
+    }
+    LaunchedEffect(active, mergeRemoteProjects) {
+        if (active && mergeRemoteProjects) services.remoteSession.refreshSavedTargetProjects()
     }
     LaunchedEffect(requestedAgentTaskId, requestedProjectId, agentTasks) {
         val taskId = requestedAgentTaskId ?: return@LaunchedEffect
@@ -425,7 +523,53 @@ private fun ProjectCockpit(
     val sidebarEntries = remember(config.projects) {
         config.projects.map { ProjectSidebarEntry(it) }
     }
-    val commandPaletteItems = remember(config.projects, projectChatLists) {
+    val activeRemoteTarget = remoteSession.target?.takeIf { remoteSession.isRemote }
+    // While remoted the main list is the remote host's, so this machine's own projects become
+    // "elsewhere" and have to be read separately to stay in the merged view.
+    var localProjectsWhileRemote by remember { mutableStateOf<List<ActionProject>>(emptyList()) }
+    LaunchedEffect(mergeRemoteProjects, activeRemoteTarget) {
+        localProjectsWhileRemote = if (mergeRemoteProjects && activeRemoteTarget != null) {
+            runCatching { services.actionConfig.load().projects }.getOrDefault(emptyList())
+        } else {
+            emptyList()
+        }
+    }
+    val computedRemoteRows = remember(
+        mergeRemoteProjects,
+        savedTargetProjects,
+        activeRemoteTarget,
+        remoteSession.targetAliases,
+        localProjectsWhileRemote,
+    ) {
+        otherHostProjectRows(
+            enabled = mergeRemoteProjects,
+            savedTargetProjects = savedTargetProjects,
+            activeTarget = activeRemoteTarget,
+            localProjects = localProjectsWhileRemote,
+            displayNameFor = remoteSession::displayNameFor,
+        )
+    }
+    val computedUnreachableHosts = remember(mergeRemoteProjects, savedTargetProjects, activeRemoteTarget, remoteSession.targetAliases) {
+        unreachableRemoteHosts(
+            enabled = mergeRemoteProjects,
+            savedTargetProjects = savedTargetProjects,
+            activeTarget = activeRemoteTarget,
+            displayNameFor = remoteSession::displayNameFor,
+        )
+    }
+    // These follow the live session, which flips to the destination before its project list
+    // arrives — held alongside [config] so the sidebar moves once, not twice.
+    var heldRemoteRows by remember { mutableStateOf(computedRemoteRows) }
+    var heldUnreachableHosts by remember { mutableStateOf(computedUnreachableHosts) }
+    LaunchedEffect(computedRemoteRows, computedUnreachableHosts, switchingHosts) {
+        if (!switchingHosts) {
+            heldRemoteRows = computedRemoteRows
+            heldUnreachableHosts = computedUnreachableHosts
+        }
+    }
+    val remoteProjectRows = if (switchingHosts) heldRemoteRows else computedRemoteRows
+    val unreachableHosts = if (switchingHosts) heldUnreachableHosts else computedUnreachableHosts
+    val commandPaletteItems = remember(config.projects, projectChatLists, remoteProjectRows) {
         buildList {
             config.projects.forEach { project ->
                 add(
@@ -452,6 +596,21 @@ private fun ProjectCockpit(
                         ),
                     )
                 }
+            }
+            // Listed after everything local so a same-named project on this host still ranks first.
+            remoteProjectRows.forEach { row ->
+                add(
+                    CommandPaletteItem(
+                        id = "remote-project:${row.key}",
+                        label = row.project.name,
+                        group = "Projects on other hosts",
+                        supporting = row.hostLabel,
+                        keywords = listOfNotNull(
+                            row.project.contextDir,
+                            (row.host as? ProjectHost.Ssh)?.target,
+                        ),
+                    ),
+                )
             }
         }
     }
@@ -637,6 +796,24 @@ private fun ProjectCockpit(
                                     canvas = ProjectCanvas.Chat
                                 },
                                 onEditProject = { editingProject = EditingProject(item) },
+                            )
+                        }
+                        if (remoteProjectRows.isNotEmpty() || unreachableHosts.isNotEmpty()) {
+                            item(key = "remote-projects-header") {
+                                ChatInboxSectionLabel("On other hosts")
+                            }
+                        }
+                        items(remoteProjectRows, key = { row -> row.key }) { row ->
+                            OtherHostProjectSidebarRow(
+                                row = row,
+                                connecting = switchingToHost == row.host,
+                                onClick = { openOtherHostProject(row) },
+                            )
+                        }
+                        items(unreachableHosts, key = { host -> "remote-host:${host.target}" }) { host ->
+                            RemoteHostUnavailableRow(
+                                hostLabel = remoteSession.displayNameFor(host.target),
+                                error = host.error,
                             )
                         }
                     }
@@ -896,6 +1073,19 @@ private fun ProjectCockpit(
                 }
             }
         }
+        // Covers the moment the backend detaches and reattaches: the held list stays behind this,
+        // so the switch reads as one deliberate transition instead of two list flashes.
+        HostSwitchOverlay(
+            // Only while Projects is on screen: this screen stays composed in the background, and
+            // the overlay drops interop surfaces app-wide — including another page's mirror.
+            visible = switchingHosts && active,
+            // Blank for a sidebar-initiated switch, where the session already names the target.
+            hostLabel = switchingHostLabel.ifBlank {
+                remoteSession.target?.let(remoteSession::displayNameFor) ?: "another host"
+            },
+            leavingForLocal = switchingToHost == ProjectHost.Local,
+            modifier = Modifier.matchParentSize(),
+        )
         if (outdatedCliUpdates.isNotEmpty()) {
             CliUpdateSnackbarStack(
                 items = outdatedCliUpdates,
@@ -912,10 +1102,29 @@ private fun ProjectCockpit(
         isOpen = commandPaletteOpen,
         onOpenChange = { commandPaletteOpen = it },
         items = commandPaletteItems,
-        placeholder = "Search projects and chats",
+        placeholder = "Search projects, chats, and transcripts",
         title = "Jump to",
+        asyncSearch = { query, excludeChatIds ->
+            services.agentRuns.searchTranscripts(query)
+                .mapNotNull { hit ->
+                    if (hit.taskId in excludeChatIds) return@mapNotNull null
+                    val supporting = listOfNotNull(hit.projectName, hit.snippet)
+                        .joinToString(" · ")
+                        .ifBlank { null }
+                    CommandPaletteItem(
+                        id = "chat:${hit.taskId}",
+                        label = hit.title.ifBlank { "Untitled chat" },
+                        group = "Transcripts",
+                        supporting = supporting,
+                    )
+                }
+        },
         onSelect = { item ->
             when {
+                item.id.startsWith("remote-project:") -> {
+                    val key = item.id.removePrefix("remote-project:")
+                    remoteProjectRows.firstOrNull { it.key == key }?.let(::openOtherHostProject)
+                }
                 item.id.startsWith("project:") -> {
                     val projectId = item.id.removePrefix("project:")
                     selectProject(projectId)
@@ -1108,7 +1317,7 @@ fun ActionsScreen(
     } else {
         ProjectCockpit(
             services = services,
-            config = config,
+            incomingConfig = config,
             onConfigChange = onConfigChange,
             agentTasks = agentTasks,
             preferredProjectId = preferredProjectId,
@@ -1273,6 +1482,146 @@ private fun ProjectFolderGlyph(
         TextSecondary.copy(alpha = 0.78f),
         modifier.size(16.dp),
     )
+}
+
+/**
+ * Scrim shown while Andy detaches from one host and attaches to another. It also swallows input:
+ * chats, terminals and runbooks behind it belong to the host being left, so clicking them during
+ * the swap would act on a backend that is already going away.
+ */
+@Composable
+private fun HostSwitchOverlay(
+    visible: Boolean,
+    hostLabel: String,
+    leavingForLocal: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(animationSpec = tween(HostSwitchFadeInMillis)),
+        exit = fadeOut(animationSpec = tween(HostSwitchFadeOutMillis)),
+        modifier = modifier,
+    ) {
+        // Terminals and mirrors are Swing/Metal interop hosts that paint above ordinary Compose
+        // content — without this they would show through the scrim, still rendering the backend
+        // that is being torn down.
+        SuppressHeavyweightSurfacesWhileOpen()
+        val blocker = remember { MutableInteractionSource() }
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(AndyColors.WindowBg.copy(alpha = 0.82f))
+                .clickable(interactionSource = blocker, indication = null) {},
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(AndySpace.Space3),
+            ) {
+                ProjectActivityIndicator(22.dp)
+                Text(
+                    if (leavingForLocal) "Switching to $hostLabel" else "Connecting to $hostLabel",
+                    color = TextPrimary,
+                    fontFamily = DisplayFont,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 15.sp,
+                )
+                Text(
+                    "Moving chats, terminals, and devices to this host.",
+                    color = TextSecondary,
+                    fontFamily = MonoFont,
+                    fontSize = 11.sp,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Projects list row for a project on a host other than the active one. The glyph + host name mark
+ * where it lives; clicking switches Andy there, after which it becomes an ordinary project row.
+ */
+@Composable
+private fun OtherHostProjectSidebarRow(
+    row: OtherHostProjectRow,
+    connecting: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val hovered by interactionSource.collectIsHoveredAsState()
+    // Stale rows came from the last successful scan — dim them so they read as "was here".
+    val fade = if (row.stale) 0.55f else 1f
+    val isLocal = row.host == ProjectHost.Local
+    val tooltip = when {
+        connecting && isLocal -> "Disconnecting from the remote host…"
+        connecting -> "Connecting to ${row.hostLabel}…"
+        row.stale -> "Last seen on ${row.hostLabel} — ${row.error ?: "host unreachable"}"
+        isLocal -> "${row.project.contextDir.ifBlank { row.project.name }} on ${row.hostLabel} — " +
+            "opens it by leaving the remote host"
+        else -> "${row.project.contextDir.ifBlank { row.project.name }} on ${row.hostLabel} — opens over SSH"
+    }
+    Tooltip(tooltip, Modifier.fillMaxWidth()) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clip(AndyShape.Row)
+                .background(if (hovered) AndyColors.SurfaceSelected.copy(alpha = 0.5f) else Color.Transparent)
+                .hoverable(interactionSource)
+                .clickable(enabled = !connecting, onClick = onClick)
+                .padding(horizontal = AndySpace.Space2, vertical = AndySpace.Space1),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+        ) {
+            LucideIcon(
+                if (isLocal) Lucide.Monitor else Lucide.Server,
+                TextSecondary.copy(alpha = 0.78f * fade),
+                Modifier.size(16.dp),
+            )
+            Column(Modifier.weight(1f)) {
+                Text(
+                    row.project.name,
+                    color = TextSecondary.copy(alpha = fade),
+                    fontFamily = DisplayFont,
+                    fontSize = 13.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    row.hostLabel,
+                    color = TextSecondary.copy(alpha = 0.6f * fade),
+                    fontFamily = MonoFont,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (connecting) ProjectActivityIndicator(14.dp)
+        }
+    }
+}
+
+/** A saved host that answered with nothing — reported so its projects don't just disappear. */
+@Composable
+private fun RemoteHostUnavailableRow(hostLabel: String, error: String?) {
+    Tooltip(error ?: "Host did not respond to a background scan", Modifier.fillMaxWidth()) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = AndySpace.Space2, vertical = AndySpace.Space1),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+        ) {
+            LucideIcon(Lucide.Server, TextSecondary.copy(alpha = 0.4f), Modifier.size(16.dp))
+            Text(
+                "$hostLabel unavailable",
+                color = TextSecondary.copy(alpha = 0.5f),
+                fontFamily = DisplayFont,
+                fontSize = 12.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
 }
 
 private data class ProjectSidebarEntry(
@@ -1542,6 +1891,7 @@ private fun ProjectSessionRow(
     onDelete: () -> Unit,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
+    val copyText = rememberCopyText()
     Box(Modifier.fillMaxWidth()) {
         ChatSessionSidebarRow(
             task = task,
@@ -1603,6 +1953,13 @@ private fun ProjectSessionRow(
                     onArchive()
                 },
                 enabled = archiveLabel == "Unarchive" || !task.isActive,
+            )
+            DropdownMenuItem(
+                text = { Text("Copy chat ID", color = TextPrimary, fontFamily = MonoFont, fontSize = 12.sp) },
+                onClick = {
+                    menuExpanded = false
+                    copyText(task.id)
+                },
             )
             DropdownMenuItem(
                 text = { Text("Delete", color = Red, fontFamily = MonoFont, fontSize = 12.sp) },

--- a/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/MergedRemoteProjects.kt
+++ b/feature/actions/src/commonMain/kotlin/app/andy/ui/actions/MergedRemoteProjects.kt
@@ -1,0 +1,110 @@
+package app.andy.ui.actions
+
+import app.andy.model.ActionProject
+import app.andy.service.RemoteProjectScanStatus
+import app.andy.service.RemoteTargetProjects
+
+/** Where a project lives, relative to the host currently driving the Projects list. */
+sealed interface ProjectHost {
+    /** This machine. Only appears as an "other" host while Andy is SSH-remoted. */
+    data object Local : ProjectHost
+    data class Ssh(val target: String) : ProjectHost
+}
+
+/**
+ * A project that lives on a host other than the one currently driving the Projects list.
+ *
+ * These rows are display-only — chats, runbooks and worktrees all come from whichever host the
+ * agent backend is attached to, so opening one switches Andy to [host] first and the project then
+ * reappears as an ordinary entry once that host's `actions.toml` becomes the list.
+ */
+data class OtherHostProjectRow(
+    val host: ProjectHost,
+    val hostLabel: String,
+    val project: ActionProject,
+    val status: RemoteProjectScanStatus,
+    val error: String? = null,
+) {
+    /**
+     * List key. Project ids are only unique within one host — two machines with the same project
+     * dir produce the same id — so the host has to be part of the key.
+     */
+    val key: String get() = when (host) {
+        ProjectHost.Local -> "local::${project.id}"
+        is ProjectHost.Ssh -> "${host.target}::${project.id}"
+    }
+
+    /** Last scan could not reach the host; [project] is what it looked like beforehand. */
+    val stale: Boolean get() = status == RemoteProjectScanStatus.Unavailable
+}
+
+/**
+ * Rows to append to the Projects list, host-grouped and alphabetical within a host.
+ *
+ * @param enabled `WorkspaceState.mergeRemoteProjects`; off means no extra rows at all.
+ * @param activeTarget SSH target currently connected, whose projects are already the main list.
+ * @param localProjects this machine's projects, which are only "elsewhere" while remoted — pass
+ *   them empty when Andy is local, or they would duplicate the main list.
+ * @param displayNameFor alias lookup, so rows read "m116" rather than "joe@192.168.4.29".
+ */
+fun otherHostProjectRows(
+    enabled: Boolean,
+    savedTargetProjects: Map<String, RemoteTargetProjects>,
+    activeTarget: String?,
+    localProjects: List<ActionProject> = emptyList(),
+    localLabel: String = "This computer",
+    displayNameFor: (String) -> String,
+): List<OtherHostProjectRow> {
+    if (!enabled) return emptyList()
+    val local = if (activeTarget == null) {
+        emptyList()
+    } else {
+        localProjects.sortedBy { it.name.lowercase() }.map { project ->
+            OtherHostProjectRow(
+                host = ProjectHost.Local,
+                hostLabel = localLabel,
+                project = project,
+                status = RemoteProjectScanStatus.Ok,
+            )
+        }
+    }
+    val remote = savedTargetProjects.values
+        .asSequence()
+        .filter { it.target != activeTarget }
+        .sortedBy { displayNameFor(it.target).lowercase() }
+        .flatMap { host ->
+            host.projects
+                .sortedBy { it.name.lowercase() }
+                .map { project ->
+                    OtherHostProjectRow(
+                        host = ProjectHost.Ssh(host.target),
+                        hostLabel = displayNameFor(host.target),
+                        project = project,
+                        status = host.status,
+                        error = host.error,
+                    )
+                }
+        }
+    // Home first — getting back to this machine is the most common hop.
+    return local + remote
+}
+
+/**
+ * Hosts that produced no rows but are still worth reporting — an unreachable laptop with nothing
+ * cached would otherwise vanish silently, leaving the user wondering where its projects went.
+ */
+fun unreachableRemoteHosts(
+    enabled: Boolean,
+    savedTargetProjects: Map<String, RemoteTargetProjects>,
+    activeTarget: String?,
+    displayNameFor: (String) -> String,
+): List<RemoteTargetProjects> {
+    if (!enabled) return emptyList()
+    return savedTargetProjects.values
+        .filter {
+            it.target != activeTarget &&
+                it.projects.isEmpty() &&
+                it.status == RemoteProjectScanStatus.Unavailable
+        }
+        .sortedBy { displayNameFor(it.target).lowercase() }
+}

--- a/feature/actions/src/desktopTest/kotlin/app/andy/ui/actions/MergedRemoteProjectsTest.kt
+++ b/feature/actions/src/desktopTest/kotlin/app/andy/ui/actions/MergedRemoteProjectsTest.kt
@@ -1,0 +1,225 @@
+package app.andy.ui.actions
+
+import app.andy.model.ActionProject
+import app.andy.service.RemoteProjectScanStatus
+import app.andy.service.RemoteTargetProjects
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MergedRemoteProjectsTest {
+    private fun project(id: String, name: String = id, dir: String = "/Code/$id") =
+        ActionProject(id = id, name = name, contextDir = dir)
+
+    private val aliases = mapOf("joe@10.0.0.7" to "studio-mini")
+    private val displayName: (String) -> String = { target -> aliases[target] ?: target }
+
+    private val scanned = mapOf(
+        "joe@10.0.0.7" to RemoteTargetProjects(
+            target = "joe@10.0.0.7",
+            status = RemoteProjectScanStatus.Ok,
+            projects = listOf(project("site", "Site"), project("andy", "Andy")),
+        ),
+        "joe@builder" to RemoteTargetProjects(
+            target = "joe@builder",
+            status = RemoteProjectScanStatus.Ok,
+            projects = listOf(project("tools", "Tools")),
+        ),
+    )
+
+    @Test
+    fun settingOffHidesEveryRemoteRow() {
+        val rows = otherHostProjectRows(
+            enabled = false,
+            savedTargetProjects = scanned,
+            activeTarget = null,
+            displayNameFor = displayName,
+        )
+
+        assertTrue(rows.isEmpty())
+    }
+
+    @Test
+    fun groupsByHostAliasThenSortsProjectsByName() {
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = scanned,
+            activeTarget = null,
+            displayNameFor = displayName,
+        )
+
+        // "joe@builder" sorts before the aliased "studio-mini"; names sort within each host.
+        assertEquals(
+            listOf("Tools" to "joe@builder", "Andy" to "studio-mini", "Site" to "studio-mini"),
+            rows.map { it.project.name to it.hostLabel },
+        )
+    }
+
+    @Test
+    fun connectedHostIsNotDuplicatedAsARemoteRow() {
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = scanned,
+            activeTarget = "joe@10.0.0.7",
+            displayNameFor = displayName,
+        )
+
+        assertEquals(listOf("joe@builder"), rows.map { (it.host as ProjectHost.Ssh).target }.distinct())
+    }
+
+    @Test
+    fun keyNamespacesProjectIdByHostSoCollisionsDoNotMerge() {
+        val sameIdOnBothHosts = mapOf(
+            "joe@a" to RemoteTargetProjects("joe@a", RemoteProjectScanStatus.Ok, listOf(project("andy"))),
+            "joe@b" to RemoteTargetProjects("joe@b", RemoteProjectScanStatus.Ok, listOf(project("andy"))),
+        )
+
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = sameIdOnBothHosts,
+            activeTarget = null,
+            displayNameFor = { it },
+        )
+
+        assertEquals(listOf("joe@a::andy", "joe@b::andy"), rows.map { it.key })
+        assertEquals(2, rows.map { it.key }.toSet().size)
+    }
+
+    @Test
+    fun unavailableHostKeepsItsRowsButMarksThemStale() {
+        val asleep = mapOf(
+            "joe@builder" to RemoteTargetProjects(
+                target = "joe@builder",
+                status = RemoteProjectScanStatus.Unavailable,
+                projects = listOf(project("tools", "Tools")),
+                error = "host is asleep",
+            ),
+        )
+
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = asleep,
+            activeTarget = null,
+            displayNameFor = displayName,
+        )
+
+        assertEquals(1, rows.size)
+        assertTrue(rows.single().stale)
+        assertEquals("host is asleep", rows.single().error)
+    }
+
+    @Test
+    fun freshRowsAreNotStale() {
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = scanned,
+            activeTarget = null,
+            displayNameFor = displayName,
+        )
+
+        assertTrue(rows.none { it.stale })
+    }
+
+    @Test
+    fun cachedRowsRenderWhileTheFirstScanIsStillRunning() {
+        val cached = mapOf(
+            "joe@builder" to RemoteTargetProjects(
+                target = "joe@builder",
+                status = RemoteProjectScanStatus.Cached,
+                projects = listOf(project("tools", "Tools")),
+            ),
+        )
+
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = cached,
+            activeTarget = null,
+            displayNameFor = displayName,
+        )
+
+        assertEquals(listOf("Tools"), rows.map { it.project.name })
+        assertFalse(rows.single().stale)
+    }
+
+    @Test
+    fun onlyEmptyUnavailableHostsAreReportedSeparately() {
+        val hosts = mapOf(
+            "joe@empty" to RemoteTargetProjects(
+                target = "joe@empty",
+                status = RemoteProjectScanStatus.Unavailable,
+                error = "Permission denied (publickey).",
+            ),
+            // Has cached rows of its own, so it is already visible in the list.
+            "joe@stale" to RemoteTargetProjects(
+                target = "joe@stale",
+                status = RemoteProjectScanStatus.Unavailable,
+                projects = listOf(project("tools", "Tools")),
+            ),
+            // Reachable with genuinely zero projects — nothing to report.
+            "joe@blank" to RemoteTargetProjects("joe@blank", RemoteProjectScanStatus.Ok),
+        )
+
+        val reported = unreachableRemoteHosts(
+            enabled = true,
+            savedTargetProjects = hosts,
+            activeTarget = null,
+            displayNameFor = displayName,
+        )
+
+        assertEquals(listOf("joe@empty"), reported.map { it.target })
+    }
+
+    @Test
+    fun whileRemotedThisComputersProjectsJoinTheListFirst() {
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = scanned,
+            activeTarget = "joe@10.0.0.7",
+            localProjects = listOf(project("home", "Home"), project("alpha", "Alpha")),
+            displayNameFor = displayName,
+        )
+
+        assertEquals(
+            listOf("Alpha", "Home", "Tools"),
+            rows.map { it.project.name },
+        )
+        assertEquals(
+            listOf(ProjectHost.Local, ProjectHost.Local, ProjectHost.Ssh("joe@builder")),
+            rows.map { it.host },
+        )
+        assertEquals(listOf("local::alpha", "local::home"), rows.take(2).map { it.key })
+    }
+
+    @Test
+    fun localProjectsAreNotDuplicatedWhileAndyIsLocal() {
+        // Local projects already *are* the main list when no remote is attached.
+        val rows = otherHostProjectRows(
+            enabled = true,
+            savedTargetProjects = emptyMap(),
+            activeTarget = null,
+            localProjects = listOf(project("home", "Home")),
+            displayNameFor = displayName,
+        )
+
+        assertTrue(rows.isEmpty())
+    }
+
+    @Test
+    fun unreachableHostReportingRespectsTheSettingAndActiveHost() {
+        val hosts = mapOf(
+            "joe@empty" to RemoteTargetProjects(
+                target = "joe@empty",
+                status = RemoteProjectScanStatus.Unavailable,
+                error = "timed out",
+            ),
+        )
+
+        assertTrue(
+            unreachableRemoteHosts(false, hosts, activeTarget = null, displayNameFor = displayName).isEmpty(),
+        )
+        assertTrue(
+            unreachableRemoteHosts(true, hosts, activeTarget = "joe@empty", displayNameFor = displayName).isEmpty(),
+        )
+    }
+}

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskComposer.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isShiftPressed
@@ -67,7 +68,10 @@ import app.andy.model.AgentProviderDefaults
 import app.andy.model.AgentReasoningEffort
 import app.andy.model.AgentSandboxMode
 import app.andy.model.AgentSkill
+import app.andy.model.AgentAttachment
 import app.andy.model.AgentTaskDraft
+import app.andy.model.hasSendableAttachments
+import app.andy.model.metadataLabel
 import app.andy.model.withImportedVendorSession
 import app.andy.model.WorktreeBaseOption
 import app.andy.model.GitBranchInfo
@@ -85,6 +89,7 @@ import app.andy.model.resolvePersistedTaskGoal
 import app.andy.model.toAutonomy
 import app.andy.model.withAlignedPermissions
 import app.andy.onImageFilesDropped
+import app.andy.readPlainText
 import app.andy.rememberCopyText
 import app.andy.service.AndyServices
 import app.andy.ui.components.ChatComposerLayout
@@ -93,6 +98,7 @@ import app.andy.ui.components.ComposerModelChip
 import app.andy.ui.components.ComposerPermissionsChip
 import app.andy.ui.components.ComposerProviderChip
 import app.andy.ui.components.VoiceDictationButtonStyle
+import app.andy.ui.components.ChatTextAttachmentPreviewDialog
 import app.andy.ui.components.chatComposerDrawerItemsFromPaths
 import app.andy.ui.components.ChatSendButton
 import app.andy.ui.components.ChatVoiceDictationButton
@@ -108,7 +114,7 @@ import app.andy.ui.components.FieldChromeStyle
 import app.andy.ui.components.attachChatImages
 import app.andy.ui.components.attachImagesFromPicker
 import app.andy.ui.components.insertTextAtCursor
-import app.andy.ui.components.onChatImagePaste
+import app.andy.ui.components.onChatComposerPaste
 import app.andy.ui.components.fieldColors
 import app.andy.ui.theme.Cyan
 import app.andy.ui.theme.AndyColors
@@ -122,6 +128,7 @@ import app.andy.ui.theme.TextSecondary
 import app.andy.ui.theme.Yellow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 @Composable
 fun AgentTaskComposerPane(
@@ -145,9 +152,18 @@ fun AgentTaskComposerPane(
         if (!dictationActive) importingThread = false
     }
     CollectChatComposerInbox(active = dictationActive) { item ->
-        val (text, images) = applyChatComposerAttachment(form.state.promptValue, form.state.imagePaths, item)
-        form.state.promptValue = text
-        form.state.imagePaths = images
+        val applied = applyChatComposerAttachment(
+            currentText = form.state.promptValue,
+            currentImages = form.state.imagePaths,
+            currentAttachments = form.state.attachments,
+            item = item,
+        )
+        form.state.promptValue = applied.text
+        form.state.imagePaths = applied.images
+        form.state.attachments = applied.attachments
+        applied.largeTextToStage?.let { text ->
+            form.stageLargePaste(text)
+        }
     }
     LaunchedEffect(projectContext?.id, initialPrompt) {
         if (form.state.promptValue.text.isBlank() && !initialPrompt.isNullOrBlank()) {
@@ -322,6 +338,10 @@ private class AgentTaskComposerFormState(
     var promptValue by mutableStateOf(TextFieldValue(""))
     var skillMenuDismissed by mutableStateOf(false)
     var imagePaths by mutableStateOf<List<String>>(emptyList())
+    var attachments by mutableStateOf<List<AgentAttachment>>(emptyList())
+    var pendingAttachmentPastes by mutableIntStateOf(0)
+    var attachmentPasteError by mutableStateOf<String?>(null)
+    val attachmentDraftKey: String = "new-chat-${Random.nextLong().toString(16)}${Random.nextLong().toString(16)}"
     var imageDragActive by mutableStateOf(false)
     var agent by mutableStateOf(initialAgent)
     var localRuntime by mutableStateOf<LocalAgentRuntime?>(null)
@@ -362,6 +382,9 @@ private class AgentTaskComposerFormState(
     fun clearPrompt() {
         promptValue = TextFieldValue("")
         imagePaths = emptyList()
+        attachments = emptyList()
+        pendingAttachmentPastes = 0
+        attachmentPasteError = null
         skillMenuDismissed = false
         // Off for every new chat: carrying it over would silently make the next ordinary chat
         // vanish on close, and nothing was persisted to get it back.
@@ -474,7 +497,7 @@ private fun rememberAgentTaskComposerForm(
             (state.usesCustomModel && state.customModel.isNotBlank()) ||
                 (!state.usesCustomModel && !state.modelId.isNullOrBlank())
             ))
-    val canSubmit = (state.prompt.isNotBlank() || state.imagePaths.isNotEmpty()) &&
+    val canSubmit = (state.prompt.isNotBlank() || state.imagePaths.isNotEmpty() || hasSendableAttachments(state.attachments)) &&
         (!state.usesCustomModel || state.customModel.isNotBlank()) &&
         (state.budgetText.isBlank() || validBudget != null) &&
         selectedCliAvailable &&
@@ -639,6 +662,7 @@ private class AgentTaskComposerForm(
             fastMode = if (state.usesCustomModel) false else state.fastMode,
             openClawNewSession = state.openClawNewSession,
             imagePaths = state.imagePaths,
+            attachments = state.attachments,
             skills = selectedSkills,
             goal = state.prompt.resolvePersistedTaskGoal(supportsGoal),
             maxBudgetUsd = state.budgetText.toMaxBudgetUsd(),
@@ -684,6 +708,28 @@ private class AgentTaskComposerForm(
 
     fun selectMentionAt(index: Int) {
         mentionResults.getOrNull(index)?.let(::selectFileMention)
+    }
+
+    fun stageLargePaste(text: String) {
+        state.pendingAttachmentPastes++
+        state.attachmentPasteError = null
+        scope.launch {
+            val result = services.chatAttachments.stageText(
+                text = text,
+                draftKey = state.attachmentDraftKey,
+            )
+            state.pendingAttachmentPastes = (state.pendingAttachmentPastes - 1).coerceAtLeast(0)
+            result.onSuccess { attachment ->
+                state.attachments = state.attachments + attachment
+            }.onFailure { error ->
+                state.attachmentPasteError = error.message ?: "Failed to stage attachment"
+            }
+        }
+    }
+
+    fun removeAttachment(attachment: AgentAttachment) {
+        state.attachments = state.attachments.filterNot { it.id == attachment.id }
+        scope.launch { services.chatAttachments.discardStaged(attachment.id) }
     }
 }
 
@@ -743,6 +789,8 @@ private fun AgentChatComposer(
     onSubmit: () -> Unit,
 ) {
     val state = form.state
+    val clipboard = LocalClipboard.current
+    var previewAttachment by remember { mutableStateOf<AgentAttachment?>(null) }
     var agentMenuExpanded by remember { mutableStateOf(false) }
     var modelMenuExpanded by remember { mutableStateOf(false) }
     var effortMenuExpanded by remember { mutableStateOf(false) }
@@ -790,6 +838,19 @@ private fun AgentChatComposer(
         },
         imagePaths = state.imagePaths,
         onRemoveImage = { path -> state.imagePaths = state.imagePaths.filterNot { it == path } },
+        attachments = state.attachments,
+        onRemoveAttachment = form::removeAttachment,
+        onPreviewAttachment = { previewAttachment = it },
+        pendingAttachmentLabels = List(state.pendingAttachmentPastes) { index ->
+            "pasted.txt" to {
+                if (index == 0 && state.pendingAttachmentPastes > 0) {
+                    state.pendingAttachmentPastes = (state.pendingAttachmentPastes - 1).coerceAtLeast(0)
+                }
+            }
+        },
+        attachmentErrors = state.attachmentPasteError?.let { error ->
+            listOf("pasted.txt" to error)
+        }.orEmpty(),
     )
     val modelLabel = when {
         !hasAvailableProvider -> "No provider"
@@ -928,11 +989,20 @@ private fun AgentChatComposer(
                                 if (canSubmit) onSubmit()
                                 true
                             }
-                            .onChatImagePaste(form.scope) { added ->
-                                if (!form.services.remoteSession.isRemote) {
-                                    state.imagePaths = attachChatImages(state.imagePaths, added)
-                                }
-                            },
+                            .onChatComposerPaste(
+                                scope = form.scope,
+                                readClipboardText = { clipboard.readPlainText() },
+                                onImagesAttached = { added ->
+                                    if (!form.services.remoteSession.isRemote) {
+                                        state.imagePaths = attachChatImages(state.imagePaths, added)
+                                    }
+                                },
+                                onSmallTextPaste = { pasted ->
+                                    state.promptValue = insertTextAtCursor(state.promptValue, pasted)
+                                    state.skillMenuDismissed = false
+                                },
+                                onLargeTextPaste = form::stageLargePaste,
+                            ),
                         textStyle = LocalTextStyle.current.copy(
                             color = TextPrimary,
                             fontFamily = DisplayFont,
@@ -948,7 +1018,8 @@ private fun AgentChatComposer(
                                 text = when {
                                     !hasAvailableProvider -> "Install a provider CLI to start a chat"
                                     state.imageDragActive -> "Release to attach images"
-                                    state.imagePaths.isNotEmpty() -> "Add a message, or send the attached images"
+                                    state.imagePaths.isNotEmpty() || state.attachments.isNotEmpty() ->
+                                        "Add a message, or send the attachments"
                                     else -> "Ask me anything…"
                                 },
                                 highlighted = state.imageDragActive,
@@ -1268,11 +1339,25 @@ private fun AgentChatComposer(
                     )
                 }
             },
-            footer = voiceError?.let { err ->
+            footer = if (voiceError != null || state.attachmentPasteError != null) {
                 {
-                    Text(err, color = Rust, fontFamily = MonoFont, fontSize = 11.sp)
+                    voiceError?.let { err ->
+                        Text(err, color = Rust, fontFamily = MonoFont, fontSize = 11.sp)
+                    }
+                    state.attachmentPasteError?.let { err ->
+                        Text(err, color = Rust, fontFamily = MonoFont, fontSize = 11.sp)
+                    }
                 }
+            } else {
+                null
             },
+        )
+    }
+    previewAttachment?.let { attachment ->
+        ChatTextAttachmentPreviewDialog(
+            label = attachment.displayName,
+            subtitle = attachment.metadataLabel(),
+            onDismiss = { previewAttachment = null },
         )
     }
 }

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTaskDetail.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -47,15 +48,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameMillis
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -82,7 +91,10 @@ import app.andy.model.AgentUserInputOrigin
 import app.andy.model.AgentChangeSummary
 import app.andy.model.CONNECTION_STALL_RETRY_PROMPT
 import app.andy.model.IMPLEMENT_PLAN_PROMPT
+import app.andy.model.AgentAttachment
 import app.andy.model.AgentEvent
+import app.andy.model.hasSendableAttachments
+import app.andy.model.metadataLabel
 import app.andy.model.turnWorkedDurationMs
 import app.andy.model.AgentFileDiff
 import app.andy.model.AgentThreadChangeSnapshot
@@ -109,9 +121,11 @@ import app.andy.model.latestPlanHasPendingEntries
 import app.andy.model.looksLikePlanMode
 import app.andy.model.shouldShowConnectionStallBanner
 import app.andy.onImageFilesDropped
+import app.andy.readPlainText
 import app.andy.service.AndyServices
 import app.andy.ui.components.Button
 import app.andy.ui.components.ChatComposerLayout
+import app.andy.ui.components.ChatFindBar
 import app.andy.ui.components.ComposerModelChip
 import app.andy.ui.components.ComposerPermissionsChip
 import app.andy.ui.components.ComposerProviderChip
@@ -138,7 +152,8 @@ import app.andy.ui.components.TextField
 import app.andy.ui.components.attachChatImages
 import app.andy.ui.components.attachImagesFromPicker
 import app.andy.ui.components.insertTextAtCursor
-import app.andy.ui.components.onChatImagePaste
+import app.andy.ui.components.ChatTextAttachmentPreviewDialog
+import app.andy.ui.components.onChatComposerPaste
 import app.andy.ui.components.fieldColors
 import app.andy.ui.components.primaryButtonColors
 import app.andy.ui.theme.AndyColors
@@ -209,6 +224,11 @@ fun AgentTaskDetail(
     var toolSidePane by remember(task.id) { mutableStateOf<AgentToolSidePaneState?>(null) }
     var filePreviewPane by remember(task.id) { mutableStateOf<FileLinkPreviewState?>(null) }
     var toolSidePaneWidth by remember(task.id) { mutableStateOf(420f) }
+    var findVisible by remember(task.id) { mutableStateOf(false) }
+    var findQuery by remember(task.id) { mutableStateOf("") }
+    var findMatchIndex by remember(task.id) { mutableIntStateOf(0) }
+    var findMatchCount by remember(task.id) { mutableIntStateOf(0) }
+    var findFocusNonce by remember(task.id) { mutableIntStateOf(0) }
     var undoError by remember(task.id) { mutableStateOf<String?>(null) }
     var pendingConfirmation by remember(task.id) { mutableStateOf<PendingConfirmation?>(null) }
     val fileLinkRoots = remember(task.worktreePath, task.cwd, task.originDir) {
@@ -217,14 +237,53 @@ fun AgentTaskDetail(
     var followUpImagePaths by remember(task.id) {
         mutableStateOf(followUpDraftMemory?.get(task.id)?.imagePaths ?: emptyList())
     }
+    var followUpAttachments by remember(task.id) {
+        mutableStateOf(followUpDraftMemory?.get(task.id)?.attachments ?: emptyList())
+    }
+    var pendingAttachmentPastes by remember(task.id) { mutableIntStateOf(0) }
+    var attachmentPasteError by remember(task.id) { mutableStateOf<String?>(null) }
+    var previewAttachment by remember(task.id) { mutableStateOf<AgentAttachment?>(null) }
+    val followUpAttachmentDraftKey = remember(task.id) { "follow-up-${task.id}" }
     var followUpImageDragActive by remember(task.id) { mutableStateOf(false) }
-    LaunchedEffect(task.id, followUpValue, followUpImagePaths) {
-        followUpDraftMemory?.save(task.id, ChatFollowUpDraft(followUpValue, followUpImagePaths))
+    val stageFollowUpLargePaste: (String) -> Unit = { text ->
+        pendingAttachmentPastes++
+        attachmentPasteError = null
+        scope.launch {
+            val result = services.chatAttachments.stageText(
+                text = text,
+                draftKey = followUpAttachmentDraftKey,
+            )
+            pendingAttachmentPastes = (pendingAttachmentPastes - 1).coerceAtLeast(0)
+            result.onSuccess { attachment ->
+                followUpAttachments = followUpAttachments + attachment
+            }.onFailure { error ->
+                attachmentPasteError = error.message ?: "Failed to stage attachment"
+            }
+        }
+    }
+    val removeFollowUpAttachment: (AgentAttachment) -> Unit = { attachment ->
+        followUpAttachments = followUpAttachments.filterNot { it.id == attachment.id }
+        scope.launch { services.chatAttachments.discardStaged(attachment.id) }
+    }
+    LaunchedEffect(task.id, followUpValue, followUpImagePaths, followUpAttachments) {
+        followUpDraftMemory?.save(
+            task.id,
+            ChatFollowUpDraft(followUpValue, followUpImagePaths, followUpAttachments),
+        )
     }
     CollectChatComposerInbox(active = dictationActive) { item ->
-        val (text, images) = applyChatComposerAttachment(followUpValue, followUpImagePaths, item)
-        followUpValue = text
-        followUpImagePaths = images
+        val applied = applyChatComposerAttachment(
+            currentText = followUpValue,
+            currentImages = followUpImagePaths,
+            currentAttachments = followUpAttachments,
+            item = item,
+        )
+        followUpValue = applied.text
+        followUpImagePaths = applied.images
+        followUpAttachments = applied.attachments
+        applied.largeTextToStage?.let { text ->
+            stageFollowUpLargePaste(text)
+        }
     }
     var voiceError by remember(task.id) { mutableStateOf<String?>(null) }
     val voiceController = rememberVoiceDictationController(
@@ -242,8 +301,9 @@ fun AgentTaskDetail(
     var goalEditorOpen by remember(task.id) { mutableStateOf(false) }
     var goalEditorText by remember(task.id) { mutableStateOf(task.goal.orEmpty()) }
     val hasStagedImages = followUpImagePaths.isNotEmpty()
-    LaunchedEffect(hasStagedImages) {
-        if (hasStagedImages) scrollToLatestRequest++
+    val hasStagedAttachments = followUpAttachments.isNotEmpty()
+    LaunchedEffect(hasStagedImages, hasStagedAttachments) {
+        if (hasStagedImages || hasStagedAttachments) scrollToLatestRequest++
     }
     val transcriptEvents by services.agentRuns.events(task.id).collectAsState()
     LaunchedEffect(task.id, task.status) {
@@ -281,6 +341,7 @@ fun AgentTaskDetail(
             interactive = terminalSessionActive,
             hasStagedImages = followUpImagePaths.isNotEmpty(),
             canReconnect = canReconnectTerminal,
+            hasStagedAttachments = hasStagedAttachments,
         )
     }
     val turnElapsedEnd = rememberElapsedEndMillis(task.id, task.finishedAtMillis, task)
@@ -298,7 +359,9 @@ fun AgentTaskDetail(
         workedHeadline(durationMs, success = task.status != AgentStatus.Error)
     }
     val followUp = followUpValue.text
-    val canSendFollowUp = followUp.isNotBlank() || followUpImagePaths.isNotEmpty()
+    val canSendFollowUp = followUp.isNotBlank() ||
+        followUpImagePaths.isNotEmpty() ||
+        hasSendableAttachments(followUpAttachments)
     val queueMode = workspaceState.agentMessageDeliveryMode == AgentMessageDeliveryMode.Queue
     val slashCommand = findActiveSlashCommand(followUp)
     val sessionCommands = remember(transcriptEvents) {
@@ -432,42 +495,71 @@ fun AgentTaskDetail(
     fun submitFollowUp() {
         if (!supportsResume || !canSendFollowUp) return
         val willQueue = task.isActive || (queueMode && task.queuedFollowUps.isNotEmpty())
-        fun sendOrQueue(message: String, skills: List<AgentSkill>) {
-            when {
-                queueMode && (task.isActive || task.queuedFollowUps.isNotEmpty()) ->
-                    services.agentRuns.queueFollowUp(task.id, message, followUpImagePaths, skills)
-                task.isActive ->
-                    services.agentRuns.queueFollowUp(task.id, message, followUpImagePaths, skills)
-                else ->
-                    services.agentRuns.resume(task.id, message, followUpImagePaths, skills)
-            }
-        }
+        val imagesSnapshot = followUpImagePaths
+        val attachmentsSnapshot = followUpAttachments
+        val skillsSnapshot = selectedSkills
+
         val goalCommand = if (AgentNativeSlashCommands.supportsGoal(task.agent)) followUp.parseAgentGoalCommand() else null
         val loopGoal = followUp.parseAndyLoopGoal()
-        val sentText = if (goalCommand != null) {
-            services.agentRuns.updateGoal(task.id, goalCommand.goal)
-            val remainder = goalCommand.remainingPrompt
-            if (remainder.isBlank()) {
-                followUpValue = TextFieldValue("")
-                followUpImagePaths = emptyList()
-                return
+        val sentText: String
+        val skillsForSend: List<AgentSkill>
+        when {
+            goalCommand != null -> {
+                services.agentRuns.updateGoal(task.id, goalCommand.goal)
+                val remainder = goalCommand.remainingPrompt
+                if (remainder.isBlank()) {
+                    followUpValue = TextFieldValue("")
+                    followUpImagePaths = emptyList()
+                    followUpAttachments = emptyList()
+                    attachmentPasteError = null
+                    return
+                }
+                sentText = remainder
+                skillsForSend = skillsSnapshot.filter { remainder.referencesSkill(it) }
             }
-            sendOrQueue(remainder, selectedSkills.filter { remainder.referencesSkill(it) })
-            remainder
-        } else {
-            val trimmed = followUp.trim()
-            if (loopGoal != null) {
-                services.agentRuns.updateGoal(task.id, loopGoal)
+            else -> {
+                val trimmed = followUp.trim()
+                if (loopGoal != null) {
+                    services.agentRuns.updateGoal(task.id, loopGoal)
+                }
+                sentText = trimmed
+                skillsForSend = skillsSnapshot
             }
-            sendOrQueue(trimmed, selectedSkills)
-            trimmed
         }
-        // Resume appends the user row synchronously — pass the text so the transcript can
-        // animate that row. Queued sends never hit the transcript, so skip entrance there.
-        pendingSendEntranceText = sentText.takeUnless { willQueue || it.isBlank() }
-        followUpValue = TextFieldValue("")
-        followUpImagePaths = emptyList()
-        scrollToLatestRequest++
+
+        scope.launch {
+            val result = if (willQueue) {
+                services.agentRuns.queueFollowUpPrepared(
+                    task.id,
+                    sentText,
+                    imagesSnapshot,
+                    skillsForSend,
+                    attachments = attachmentsSnapshot,
+                )
+            } else {
+                services.agentRuns.resumePrepared(
+                    task.id,
+                    sentText,
+                    imagesSnapshot,
+                    skillsForSend,
+                    attachments = attachmentsSnapshot,
+                )
+            }
+            if (result.isFailure) {
+                attachmentPasteError = result.exceptionOrNull()?.message
+                    ?: "Failed to prepare text attachment"
+                return@launch
+            }
+            // Resume appends the user row synchronously after materialize — pass the text so
+            // the transcript can animate that row. Queued sends never hit the transcript, so
+            // skip entrance there.
+            pendingSendEntranceText = sentText.takeUnless { willQueue || it.isBlank() }
+            followUpValue = TextFieldValue("")
+            followUpImagePaths = emptyList()
+            followUpAttachments = emptyList()
+            attachmentPasteError = null
+            scrollToLatestRequest++
+        }
     }
 
     LaunchedEffect(task.goal) {
@@ -546,7 +638,81 @@ fun AgentTaskDetail(
             confirmation.onConfirm()
         }
     }
-    Column(modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    LaunchedEffect(findQuery) {
+        findMatchIndex = 0
+    }
+    LaunchedEffect(findMatchCount) {
+        if (findMatchCount == 0) {
+            findMatchIndex = 0
+        } else {
+            findMatchIndex = findMatchIndex.coerceIn(0, findMatchCount - 1)
+        }
+    }
+    val chatFocusRequester = remember(task.id) { FocusRequester() }
+    // Selecting a chat often leaves focus on the inbox list. Claim it here so shortcuts
+    // work without first clicking the composer.
+    LaunchedEffect(task.id, acpTask) {
+        if (!acpTask) return@LaunchedEffect
+        withFrameMillis { }
+        runCatching { chatFocusRequester.requestFocus() }
+    }
+    fun openChatFind() {
+        findVisible = true
+        findFocusNonce++
+    }
+    fun closeChatFind() {
+        findVisible = false
+        findQuery = ""
+        findMatchIndex = 0
+        findMatchCount = 0
+        // Return keyboard focus to the chat pane so Cmd/Ctrl+F keeps working.
+        runCatching { chatFocusRequester.requestFocus() }
+    }
+    fun findNext() {
+        if (findMatchCount <= 0) return
+        findMatchIndex = (findMatchIndex + 1) % findMatchCount
+    }
+    fun findPrevious() {
+        if (findMatchCount <= 0) return
+        findMatchIndex = (findMatchIndex - 1 + findMatchCount) % findMatchCount
+    }
+    Column(
+        modifier
+            .fillMaxSize()
+            .then(
+                if (acpTask && filePreviewPane == null) {
+                    Modifier
+                        .focusRequester(chatFocusRequester)
+                        .focusable()
+                        .onPreviewKeyEvent { event ->
+                            if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                            val primary = event.isMetaPressed || event.isCtrlPressed
+                            when {
+                                primary && event.key == Key.F -> {
+                                    openChatFind()
+                                    true
+                                }
+                                findVisible && event.key == Key.Escape -> {
+                                    closeChatFind()
+                                    true
+                                }
+                                findVisible && primary && !event.isShiftPressed && event.key == Key.G -> {
+                                    findNext()
+                                    true
+                                }
+                                findVisible && primary && event.isShiftPressed && event.key == Key.G -> {
+                                    findPrevious()
+                                    true
+                                }
+                                else -> false
+                            }
+                        }
+                } else {
+                    Modifier
+                },
+            ),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
         val authRecovery = remember(task.errorMessage, task.agent) { task.providerAuthRecoveryOrNull() }
         task.errorMessage?.let { error ->
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
@@ -679,14 +845,32 @@ fun AgentTaskDetail(
                 .fillMaxWidth()
                 .heightIn(
                     min = when {
-                        hasStagedImages -> 120.dp
+                        hasStagedImages || hasStagedAttachments -> 120.dp
                         else -> 280.dp
                     },
                 )
                 .clipToBounds()
                 .onSizeChanged { size ->
                     chatPaneWidth = with(density) { size.width.toDp() }
-                },
+                }
+                .then(
+                    if (acpTask && filePreviewPane == null) {
+                        // Transcript clicks often don't move keyboard focus (list/sidebar keeps
+                        // it). Pull focus into this chat so Cmd/Ctrl+F is heard.
+                        Modifier.pointerInput(task.id) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent(PointerEventPass.Initial)
+                                    if (event.type == PointerEventType.Press) {
+                                        chatFocusRequester.requestFocus()
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        Modifier
+                    },
+                ),
         ) {
             val terminalModifier = remember { Modifier.fillMaxSize() }
             val imagesStagedLatest = rememberUpdatedState(
@@ -710,6 +894,7 @@ fun AgentTaskDetail(
                         agentLabel = task.agent.cliName,
                         originalPrompt = task.prompt.ifBlank { task.title },
                         originalImagePaths = task.imagePaths,
+                        originalAttachments = task.attachments,
                         originalSkills = task.skills,
                         originalPromptAtMillis = task.createdAtMillis,
                         restoreScrollKey = task.id,
@@ -736,6 +921,9 @@ fun AgentTaskDetail(
                         onFileChangesUndo = ::requestUndoFileChanges,
                         knownTasks = knownAgentTasks,
                         currentTaskId = task.id,
+                        findQuery = if (findVisible) findQuery else "",
+                        activeFindMatchIndex = findMatchIndex,
+                        onFindMatchesChanged = { count -> findMatchCount = count },
                         modifier = Modifier.weight(1f).fillMaxHeight(),
                     )
                     if (filePreviewPane != null || toolSidePane != null) {
@@ -795,6 +983,23 @@ fun AgentTaskDetail(
                         .align(Alignment.TopEnd)
                         .padding(top = AndySpace.Space2, end = AndySpace.Space2)
                         .zIndex(2f),
+                )
+            }
+            if (acpTask && findVisible) {
+                ChatFindBar(
+                    query = findQuery,
+                    onQueryChange = { findQuery = it },
+                    matchIndex = findMatchIndex,
+                    matchCount = findMatchCount,
+                    onFindNext = { findNext() },
+                    onFindPrevious = { findPrevious() },
+                    onClose = { closeChatFind() },
+                    focusNonce = findFocusNonce,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .fillMaxWidth()
+                        .padding(horizontal = AndySpace.Space3, vertical = AndySpace.Space2)
+                        .zIndex(3f),
                 )
             }
         }
@@ -962,10 +1167,24 @@ fun AgentTaskDetail(
                     },
                     imagePaths = followUpImagePaths,
                     onRemoveImage = { path -> followUpImagePaths = followUpImagePaths.filterNot { it == path } },
+                    attachments = followUpAttachments,
+                    onRemoveAttachment = removeFollowUpAttachment,
+                    onPreviewAttachment = { previewAttachment = it },
+                    pendingAttachmentLabels = List(pendingAttachmentPastes) { index ->
+                        "pasted.txt" to {
+                            if (index == 0 && pendingAttachmentPastes > 0) {
+                                pendingAttachmentPastes = (pendingAttachmentPastes - 1).coerceAtLeast(0)
+                            }
+                        }
+                    },
+                    attachmentErrors = attachmentPasteError?.let { error ->
+                        listOf("pasted.txt" to error)
+                    }.orEmpty(),
                 )
             } else {
                 emptyList()
             }
+            val clipboard = LocalClipboard.current
             val followUpModelLabel = task.model?.substringAfterLast('/')?.takeIf { it.isNotBlank() } ?: "Auto"
             ChatComposerLayout(
                 modifier = Modifier
@@ -1069,9 +1288,18 @@ fun AgentTaskDetail(
                                     if (canSendFollowUp) submitFollowUp()
                                     true
                                 }
-                                .onChatImagePaste(scope) { added ->
-                                    followUpImagePaths = attachChatImages(followUpImagePaths, added)
-                                },
+                                .onChatComposerPaste(
+                                    scope = scope,
+                                    readClipboardText = { clipboard.readPlainText() },
+                                    onImagesAttached = { added ->
+                                        followUpImagePaths = attachChatImages(followUpImagePaths, added)
+                                    },
+                                    onSmallTextPaste = { pasted ->
+                                        followUpValue = insertTextAtCursor(followUpValue, pasted)
+                                        skillMenuDismissed = false
+                                    },
+                                    onLargeTextPaste = stageFollowUpLargePaste,
+                                ),
                             textStyle = LocalTextStyle.current.copy(
                                 color = TextPrimary,
                                 fontFamily = DisplayFont,
@@ -1086,7 +1314,8 @@ fun AgentTaskDetail(
                                 ComposerPlaceholderHint(
                                     text = when {
                                         followUpImageDragActive -> "Release to attach images"
-                                        followUpImagePaths.isNotEmpty() -> "Add a message, or send the attached images"
+                                        followUpImagePaths.isNotEmpty() || followUpAttachments.isNotEmpty() ->
+                                            "Add a message, or send the attachments"
                                         awaitingPlanConfirmation -> "Refine the plan, or implement above"
                                         else -> "Ask me anything…"
                                     },
@@ -1275,12 +1504,26 @@ fun AgentTaskDetail(
                         }
                     }
                 },
-                footer = voiceError?.let { err ->
+                footer = if (voiceError != null || attachmentPasteError != null) {
                     {
-                        Text(err, color = Rust, fontFamily = MonoFont, fontSize = 11.sp)
+                        voiceError?.let { err ->
+                            Text(err, color = Rust, fontFamily = MonoFont, fontSize = 11.sp)
+                        }
+                        attachmentPasteError?.let { err ->
+                            Text(err, color = Rust, fontFamily = MonoFont, fontSize = 11.sp)
+                        }
                     }
+                } else {
+                    null
                 },
             )
+            previewAttachment?.let { attachment ->
+                ChatTextAttachmentPreviewDialog(
+                    label = attachment.displayName,
+                    subtitle = attachment.metadataLabel(),
+                    onDismiss = { previewAttachment = null },
+                )
+            }
         }
     }
     }

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentTranscript.kt
@@ -49,12 +49,18 @@ import androidx.compose.material3.Text
 import app.andy.ui.components.ChatBubbleGroup
 import app.andy.ui.components.ChatBubbleSender
 import app.andy.ui.components.ChatBubbleVariant
+import app.andy.ui.components.ChatFindHighlight
+import app.andy.ui.components.ChatFindActiveRowWash
+import app.andy.ui.components.ChatFindRowWash
 import app.andy.ui.components.ChatMessageBubble
 import app.andy.ui.components.ChatMessageCopyAction
 import app.andy.ui.components.ChatMessageMetadata
+import app.andy.ui.components.LocalChatFindHighlight
 import app.andy.ui.components.PlatformLazyListScrollbar
 import app.andy.ui.components.TextButton
+import app.andy.ui.components.highlightFindMatches
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -107,7 +113,10 @@ import app.andy.domain.looksLikeFilePath
 import app.andy.domain.parseToolCallFileArguments
 import app.andy.domain.parseToolCallFileContent
 import app.andy.model.AcpToolCallPresentation
+import app.andy.model.AgentAttachment
 import app.andy.model.AgentEvent
+import app.andy.model.boundedUserMessagePreview
+import app.andy.model.metadataLabel
 import app.andy.model.AgentFileDiff
 import app.andy.model.AgentPlanEntry
 import app.andy.model.AgentSpawnPresentation
@@ -235,6 +244,7 @@ fun AgentTranscript(
     activePermissionRequestId: String? = null,
     originalPrompt: String? = null,
     originalImagePaths: List<String> = emptyList(),
+    originalAttachments: List<AgentAttachment> = emptyList(),
     originalSkills: List<AgentSkill> = emptyList(),
     /** Wall time for the launch prompt bubble when it is synthesized (not from [AgentEvent.UserMessage]). */
     originalPromptAtMillis: Long? = null,
@@ -267,6 +277,15 @@ fun AgentTranscript(
     knownTasks: List<AgentTask> = emptyList(),
     /** Current chat id so spawn resolution does not link a row back to itself. */
     currentTaskId: String? = null,
+    /**
+     * In-chat find query. When non-blank, matching rows highlight and
+     * [activeFindMatchIndex] scrolls into view.
+     */
+    findQuery: String = "",
+    /** Index into the match list derived from [findQuery] (clamped by this composable). */
+    activeFindMatchIndex: Int = 0,
+    /** Reports the current match count whenever [findQuery] or transcript content changes. */
+    onFindMatchesChanged: (matchCount: Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val compositionCounter = LocalTranscriptCompositionCounter.current
@@ -295,7 +314,13 @@ fun AgentTranscript(
             .filter { it.id !in alreadyLinked }
         withLinkedChildSpawnItems(base, children)
     }
-    val originalPromptVisible = shouldDisplayOriginalPrompt(events, originalPrompt, originalImagePaths, originalSkills)
+    val originalPromptVisible = shouldDisplayOriginalPrompt(
+        events,
+        originalPrompt,
+        originalImagePaths,
+        originalSkills,
+        originalAttachments,
+    )
     val latestTaskResultItemIndex = displayItems.indexOfLast { item ->
         item is TranscriptDisplayItem.Event && item.event is AgentEvent.TaskResult
     }
@@ -342,6 +367,28 @@ fun AgentTranscript(
     var expandedToolKeys by remember(taskId) { mutableStateOf(setOf<String>()) }
     var expandedToolGroups by remember(taskId) { mutableStateOf(setOf<String>()) }
     var expandedThinkingKeys by remember(taskId) { mutableStateOf(setOf<String>()) }
+    val findMatches = remember(
+        displayItems,
+        findQuery,
+        originalPrompt,
+        originalPromptVisible,
+    ) {
+        findChatMatches(
+            displayItems = displayItems,
+            query = findQuery,
+            originalPrompt = originalPrompt,
+            originalPromptVisible = originalPromptVisible,
+        )
+    }
+    val onFindMatchesChangedLatest = rememberUpdatedState(onFindMatchesChanged)
+    LaunchedEffect(findMatches) {
+        onFindMatchesChangedLatest.value(findMatches.size)
+    }
+    val activeFindMatch = findMatches.getOrNull(
+        activeFindMatchIndex.coerceIn(0, (findMatches.size - 1).coerceAtLeast(0)),
+    ).takeIf { findMatches.isNotEmpty() && findQuery.trim().isNotEmpty() }
+    val findMatchKeys = remember(findMatches) { findMatches.map { it.itemKey }.toSet() }
+    val findExpandKeys = remember(activeFindMatch) { chatFindExpandKeys(activeFindMatch) }
     fun setActivityExpanded(
         key: String,
         expanded: Boolean,
@@ -358,6 +405,11 @@ fun AgentTranscript(
             },
         )
     }
+    fun activityExpanded(
+        key: String,
+        overrides: Set<String>,
+        autoExpand: Boolean,
+    ): Boolean = key in findExpandKeys || transcriptActivityExpanded(key, overrides, autoExpand)
     // Desktop wheel/trackpad often never sets isScrollInProgress. Emit ticks without Compose
     // state so each wheel event does not recompose the whole transcript. Keep a single slot and
     // DROP_OLDEST so a fast fling cannot queue dozens of settle waits.
@@ -466,6 +518,21 @@ fun AgentTranscript(
                 anchorKey = listState.firstVisibleAnchorKey(),
             )
         }.distinctUntilChanged().collect { memory.save(id, it) }
+    }
+    LaunchedEffect(activeFindMatch, rowKeys, scrollInitialized, findExpandKeys) {
+        val match = activeFindMatch ?: return@LaunchedEffect
+        if (!scrollInitialized) return@LaunchedEffect
+        stickToBottom = false
+        // Let force-expanded thinking/tool content compose before scrolling so the hit
+        // isn't still behind AnimatedVisibility.
+        if (findExpandKeys.isNotEmpty()) {
+            withFrameMillis { }
+            withFrameMillis { }
+        }
+        val listIndex = rowKeys.indexOf(match.itemKey).takeIf { it >= 0 } ?: return@LaunchedEffect
+        listState.runProgrammaticScroll(programmaticScroll) {
+            scrollToItem(listIndex.coerceIn(0, (layoutInfo.totalItemsCount - 1).coerceAtLeast(0)))
+        }
     }
     DisposableEffect(taskId, listState, scrollInitialized, stickToBottom) {
         onDispose {
@@ -652,46 +719,64 @@ fun AgentTranscript(
                 }
                 if (originalPromptVisible) {
                     item(key = "original-prompt", contentType = "message") {
-                        SelectionContainer {
-                            val originalTimestamp = originalPromptAtMillis
-                                ?.takeIf { it > 0L }
-                                ?.let(::formatDisplayTime)
-                            val originalCopyText = originalPrompt?.takeIf { it.isNotBlank() }
-                            ChatMessageBubble(
-                                sender = ChatBubbleSender.User,
-                                testTag = "user-message-bubble",
-                                metadata = if (originalTimestamp != null || originalCopyText != null) {
-                                    {
-                                        ChatMessageMetadata(
-                                            timestamp = originalTimestamp,
-                                            footer = originalCopyText?.let { prompt ->
-                                                { ChatMessageCopyAction(prompt) }
-                                            },
-                                        )
-                                    }
-                                } else {
-                                    null
-                                },
+                        val promptFind = findQuery.trim().takeIf { it.isNotEmpty() }?.let { query ->
+                            ChatFindHighlight(
+                                query = query,
+                                activeRange = activeFindMatch
+                                    ?.takeIf { it.itemKey == "original-prompt" }
+                                    ?.range,
+                            )
+                        }
+                        val promptWash = when {
+                            activeFindMatch?.itemKey == "original-prompt" -> ChatFindActiveRowWash
+                            "original-prompt" in findMatchKeys -> ChatFindRowWash
+                            else -> Color.Transparent
+                        }
+                        CompositionLocalProvider(LocalChatFindHighlight provides promptFind) {
+                            SelectionContainer(
+                                Modifier.background(promptWash),
                             ) {
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    originalPrompt?.takeIf { it.isNotBlank() }?.let { prompt ->
-                                        if (!isSkillOnlyMessage(prompt, originalSkills)) {
-                                            ChatUserText(prompt)
+                                val originalTimestamp = originalPromptAtMillis
+                                    ?.takeIf { it > 0L }
+                                    ?.let(::formatDisplayTime)
+                                val originalCopyText = originalPrompt?.takeIf { it.isNotBlank() }
+                                ChatMessageBubble(
+                                    sender = ChatBubbleSender.User,
+                                    testTag = "user-message-bubble",
+                                    metadata = if (originalTimestamp != null || originalCopyText != null) {
+                                        {
+                                            ChatMessageMetadata(
+                                                timestamp = originalTimestamp,
+                                                footer = originalCopyText?.let { prompt ->
+                                                    { ChatMessageCopyAction(prompt) }
+                                                },
+                                            )
                                         }
-                                    }
-                                    ChatAttachedImages(originalImagePaths)
-                                    if (originalSkills.isNotEmpty()) {
-                                        DisableSelection {
-                                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                                originalSkills.forEach { skill ->
-                                                    Text(
-                                                        "/${skill.name}",
-                                                        color = Cyan,
-                                                        fontFamily = MonoFont,
-                                                        fontSize = 11.sp,
-                                                        textDecoration = TextDecoration.Underline,
-                                                        modifier = Modifier.clickable { onSkillOpen(skill) },
-                                                    )
+                                    } else {
+                                        null
+                                    },
+                                ) {
+                                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        originalPrompt?.takeIf { it.isNotBlank() }?.let { prompt ->
+                                            if (!isSkillOnlyMessage(prompt, originalSkills)) {
+                                                ChatUserText(boundedUserMessagePreview(prompt))
+                                            }
+                                        }
+                                        ChatAttachedTextAttachments(originalAttachments)
+                                        ChatAttachedImages(originalImagePaths)
+                                        if (originalSkills.isNotEmpty()) {
+                                            DisableSelection {
+                                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                                    originalSkills.forEach { skill ->
+                                                        Text(
+                                                            "/${skill.name}",
+                                                            color = Cyan,
+                                                            fontFamily = MonoFont,
+                                                            fontSize = 11.sp,
+                                                            textDecoration = TextDecoration.Underline,
+                                                            modifier = Modifier.clickable { onSkillOpen(skill) },
+                                                        )
+                                                    }
                                                 }
                                             }
                                         }
@@ -717,119 +802,143 @@ fun AgentTranscript(
                     val isUserMessage = item is TranscriptDisplayItem.Event &&
                         item.event is AgentEvent.UserMessage &&
                         !(item.event as AgentEvent.UserMessage).text.isSilentConnectionRecoveryPrompt()
-                    SelectionContainer(
-                        modifier = Modifier
-                            .then(
-                                if (isUserMessage) {
-                                    Modifier.userMessageSendEnter(
-                                        play = itemKey == sendEntranceKey,
-                                        onFinished = {
-                                            if (sendEntranceKey == itemKey) sendEntranceKey = null
-                                        },
-                                    )
-                                } else {
-                                    Modifier
-                                },
-                            )
-                            .testTag("transcript-row-$itemKey"),
-                    ) {
-                        when (item) {
-                            is TranscriptDisplayItem.Event -> {
-                                val bubbleGroup = transcriptChatBubbleGroup(displayItems, itemIndex)
-                                TranscriptEvent(
-                                event = item.event,
-                                eventKey = transcriptEventKey(item.index, item.event),
-                                bubbleGroup = bubbleGroup,
-                                streamPlainText = isActive &&
-                                    item.event is AgentEvent.AssistantText &&
-                                    (item.event as AgentEvent.AssistantText).isStreamDelta,
-                                toolExpanded = transcriptActivityExpanded(
-                                    transcriptEventKey(item.index, item.event),
-                                    expandedToolKeys,
-                                    autoExpandToolSections,
-                                ),
-                                thinkingExpanded = transcriptActivityExpanded(
-                                    transcriptEventKey(item.index, item.event),
-                                    expandedThinkingKeys,
-                                    autoExpandThinkingSections,
-                                ),
-                                agentLabel = agentLabel,
-                                completedContent = if (itemIndex == latestTaskResultItemIndex) completedContent else null,
-                                awaitingPlanConfirmation = awaitingPlanConfirmation &&
-                                    itemIndex == latestPlanUpdateItemIndex,
-                                activePermissionRequestId = activePermissionRequestId,
-                                onToolExpandedChange = { key, expanded ->
-                                    setActivityExpanded(
-                                        key,
-                                        expanded,
+                    val rowFind = findQuery.trim().takeIf { it.isNotEmpty() }?.let { query ->
+                        val activeOnThisRow = activeFindMatch?.takeIf { match ->
+                            match.itemKey == itemKey &&
+                                (match.nestedEventKey == null || match.nestedEventKey == itemKey)
+                        }
+                        ChatFindHighlight(
+                            query = query,
+                            activeRange = activeOnThisRow?.range,
+                        )
+                    }
+                    val rowWash = when {
+                        activeFindMatch?.itemKey == itemKey -> ChatFindActiveRowWash
+                        itemKey in findMatchKeys -> ChatFindRowWash
+                        else -> Color.Transparent
+                    }
+                    CompositionLocalProvider(LocalChatFindHighlight provides rowFind) {
+                        SelectionContainer(
+                            modifier = Modifier
+                                .background(rowWash)
+                                .then(
+                                    if (isUserMessage) {
+                                        Modifier.userMessageSendEnter(
+                                            play = itemKey == sendEntranceKey,
+                                            onFinished = {
+                                                if (sendEntranceKey == itemKey) sendEntranceKey = null
+                                            },
+                                        )
+                                    } else {
+                                        Modifier
+                                    },
+                                )
+                                .testTag("transcript-row-$itemKey"),
+                        ) {
+                            when (item) {
+                                is TranscriptDisplayItem.Event -> {
+                                    val eventKey = transcriptEventKey(item.index, item.event)
+                                    val bubbleGroup = transcriptChatBubbleGroup(displayItems, itemIndex)
+                                    TranscriptEvent(
+                                    event = item.event,
+                                    eventKey = eventKey,
+                                    bubbleGroup = bubbleGroup,
+                                    streamPlainText = isActive &&
+                                        item.event is AgentEvent.AssistantText &&
+                                        (item.event as AgentEvent.AssistantText).isStreamDelta,
+                                    toolExpanded = activityExpanded(
+                                        eventKey,
                                         expandedToolKeys,
                                         autoExpandToolSections,
-                                    ) { expandedToolKeys = it }
-                                },
-                                onThinkingExpandedChange = { key, expanded ->
-                                    setActivityExpanded(
-                                        key,
-                                        expanded,
+                                    ),
+                                    thinkingExpanded = activityExpanded(
+                                        eventKey,
                                         expandedThinkingKeys,
                                         autoExpandThinkingSections,
-                                    ) { expandedThinkingKeys = it }
-                                },
-                                onSkillOpen = onSkillOpen,
-                                onToolFileOpen = onToolFileOpen,
-                                onFileChangesReview = onFileChangesReview,
-                                onFileChangesUndo = onFileChangesUndo,
-                                knownTasks = knownTasks,
-                                currentTaskId = currentTaskId,
-                                autoExpandThinkingSections = autoExpandThinkingSections,
-                                autoExpandToolSections = autoExpandToolSections,
-                            )
-                            }
-                            is TranscriptDisplayItem.ToolCalls -> CompactToolCallsBlock(
-                                events = item.events,
-                                startIndex = item.startIndex,
-                                expanded = transcriptActivityExpanded(
-                                    transcriptDisplayItemKey(item),
-                                    expandedToolGroups,
-                                    autoExpandToolSections,
-                                ),
-                                onExpandedChange = { expanded ->
-                                    val key = transcriptDisplayItemKey(item)
-                                    setActivityExpanded(
-                                        key,
-                                        expanded,
+                                    ),
+                                    forceExpandInstant = eventKey in findExpandKeys,
+                                    agentLabel = agentLabel,
+                                    completedContent = if (itemIndex == latestTaskResultItemIndex) completedContent else null,
+                                    awaitingPlanConfirmation = awaitingPlanConfirmation &&
+                                        itemIndex == latestPlanUpdateItemIndex,
+                                    activePermissionRequestId = activePermissionRequestId,
+                                    onToolExpandedChange = { key, expanded ->
+                                        setActivityExpanded(
+                                            key,
+                                            expanded,
+                                            expandedToolKeys,
+                                            autoExpandToolSections,
+                                        ) { expandedToolKeys = it }
+                                    },
+                                    onThinkingExpandedChange = { key, expanded ->
+                                        setActivityExpanded(
+                                            key,
+                                            expanded,
+                                            expandedThinkingKeys,
+                                            autoExpandThinkingSections,
+                                        ) { expandedThinkingKeys = it }
+                                    },
+                                    onSkillOpen = onSkillOpen,
+                                    onToolFileOpen = onToolFileOpen,
+                                    onFileChangesReview = onFileChangesReview,
+                                    onFileChangesUndo = onFileChangesUndo,
+                                    knownTasks = knownTasks,
+                                    currentTaskId = currentTaskId,
+                                    autoExpandThinkingSections = autoExpandThinkingSections,
+                                    autoExpandToolSections = autoExpandToolSections,
+                                )
+                                }
+                                is TranscriptDisplayItem.ToolCalls -> CompactToolCallsBlock(
+                                    events = item.events,
+                                    startIndex = item.startIndex,
+                                    expanded = activityExpanded(
+                                        transcriptDisplayItemKey(item),
                                         expandedToolGroups,
                                         autoExpandToolSections,
-                                    ) { expandedToolGroups = it }
-                                },
-                                expandedToolKeys = expandedToolKeys,
-                                expandedThinkingKeys = expandedThinkingKeys,
-                                autoExpandThinkingSections = autoExpandThinkingSections,
-                                autoExpandToolSections = autoExpandToolSections,
-                                onToolExpandedChange = { key, expanded ->
-                                    setActivityExpanded(
-                                        key,
-                                        expanded,
-                                        expandedToolKeys,
-                                        autoExpandToolSections,
-                                    ) { expandedToolKeys = it }
-                                },
-                                onThinkingExpandedChange = { key, expanded ->
-                                    setActivityExpanded(
-                                        key,
-                                        expanded,
-                                        expandedThinkingKeys,
-                                        autoExpandThinkingSections,
-                                    ) { expandedThinkingKeys = it }
-                                },
-                                onToolFileOpen = onToolFileOpen,
-                                knownTasks = knownTasks,
-                                currentTaskId = currentTaskId,
-                            )
-                            is TranscriptDisplayItem.ChildSpawns -> LinkedChildChatsBlock(
-                                children = item.tasks,
-                                knownTasks = knownTasks,
-                                currentTaskId = currentTaskId,
-                            )
+                                    ),
+                                    forceExpandInstant = itemKey in findExpandKeys,
+                                    onExpandedChange = { expanded ->
+                                        val key = transcriptDisplayItemKey(item)
+                                        setActivityExpanded(
+                                            key,
+                                            expanded,
+                                            expandedToolGroups,
+                                            autoExpandToolSections,
+                                        ) { expandedToolGroups = it }
+                                    },
+                                    expandedToolKeys = expandedToolKeys,
+                                    expandedThinkingKeys = expandedThinkingKeys,
+                                    findExpandKeys = findExpandKeys,
+                                    findQuery = findQuery,
+                                    activeFindMatch = activeFindMatch?.takeIf { it.itemKey == itemKey },
+                                    autoExpandThinkingSections = autoExpandThinkingSections,
+                                    autoExpandToolSections = autoExpandToolSections,
+                                    onToolExpandedChange = { key, expanded ->
+                                        setActivityExpanded(
+                                            key,
+                                            expanded,
+                                            expandedToolKeys,
+                                            autoExpandToolSections,
+                                        ) { expandedToolKeys = it }
+                                    },
+                                    onThinkingExpandedChange = { key, expanded ->
+                                        setActivityExpanded(
+                                            key,
+                                            expanded,
+                                            expandedThinkingKeys,
+                                            autoExpandThinkingSections,
+                                        ) { expandedThinkingKeys = it }
+                                    },
+                                    onToolFileOpen = onToolFileOpen,
+                                    knownTasks = knownTasks,
+                                    currentTaskId = currentTaskId,
+                                )
+                                is TranscriptDisplayItem.ChildSpawns -> LinkedChildChatsBlock(
+                                    children = item.tasks,
+                                    knownTasks = knownTasks,
+                                    currentTaskId = currentTaskId,
+                                )
+                            }
                         }
                     }
                 }
@@ -941,12 +1050,18 @@ fun shouldDisplayOriginalPrompt(
     originalPrompt: String?,
     originalImagePaths: List<String>,
     originalSkills: List<AgentSkill> = emptyList(),
+    originalAttachments: List<AgentAttachment> = emptyList(),
 ): Boolean {
     val prompt = originalPrompt?.trim().orEmpty()
     val recordedInTranscript = events.filterIsInstance<AgentEvent.UserMessage>().any { event ->
-        userMessageMatchesOriginalPrompt(event, prompt, originalImagePaths, originalSkills)
+        userMessageMatchesOriginalPrompt(event, prompt, originalImagePaths, originalSkills, originalAttachments)
     }
-    return !recordedInTranscript && (prompt.isNotBlank() || originalImagePaths.isNotEmpty() || originalSkills.isNotEmpty())
+    return !recordedInTranscript && (
+        prompt.isNotBlank() ||
+            originalImagePaths.isNotEmpty() ||
+            originalSkills.isNotEmpty() ||
+            originalAttachments.isNotEmpty()
+        )
 }
 
 /** Launch turns are stored for the CLI with image hints while [originalPrompt] stays user-facing. */
@@ -955,6 +1070,7 @@ internal fun userMessageMatchesOriginalPrompt(
     prompt: String,
     imagePaths: List<String>,
     skills: List<AgentSkill> = emptyList(),
+    attachments: List<AgentAttachment> = emptyList(),
 ): Boolean {
     val text = event.text.trim()
     val resolvedSkills = skills.ifEmpty { event.skills }
@@ -964,7 +1080,9 @@ internal fun userMessageMatchesOriginalPrompt(
         prompt.isNotBlank() && resolvedSkills.isNotEmpty() && text == promptWithSkillHints(prompt, resolvedSkills) -> true
         prompt.isNotBlank() && resolvedSkills.isNotEmpty() &&
             stripCliSkillHints(text) == prompt && event.skills.map { it.path } == resolvedSkills.map { it.path } -> true
-        prompt.isBlank() && imagePaths.isNotEmpty() && event.imagePaths == imagePaths -> true
+        prompt.isBlank() && imagePaths.isNotEmpty() && event.imagePaths == imagePaths &&
+            attachments.isEmpty() && event.attachments.isEmpty() -> true
+        prompt.isBlank() && attachments.isNotEmpty() && event.attachments.map { it.id } == attachments.map { it.id } -> true
         else -> false
     }
 }
@@ -972,7 +1090,14 @@ internal fun userMessageMatchesOriginalPrompt(
 /** User-facing transcript text; strips CLI-only skill hints and redundant slash-only prose. */
 internal fun userMessageDisplayText(event: AgentEvent.UserMessage): String {
     val stripped = stripCliSkillHints(event.text).trim()
-    return if (isSkillOnlyMessage(stripped, event.skills)) "" else stripped
+    val prose = if (isSkillOnlyMessage(stripped, event.skills)) "" else stripped
+    return if (prose.isBlank()) prose else boundedUserMessagePreview(prose)
+}
+
+/** Full user prose for copy actions — never bounded for display layout. */
+internal fun userMessageCopyText(event: AgentEvent.UserMessage): String? {
+    val stripped = stripCliSkillHints(event.text).trim()
+    return stripped.takeIf { it.isNotBlank() && !isSkillOnlyMessage(stripped, event.skills) }
 }
 
 /** True when the transcript viewport is pinned to the live edge (end of the forward list). */
@@ -1148,6 +1273,8 @@ private fun TranscriptEvent(
     currentTaskId: String? = null,
     autoExpandThinkingSections: Boolean = false,
     autoExpandToolSections: Boolean = false,
+    /** Find navigation: expand without AnimatedVisibility so the hit is visible immediately. */
+    forceExpandInstant: Boolean = false,
 ) {
     when (event) {
         is AgentEvent.SessionStarted -> Unit
@@ -1164,8 +1291,13 @@ private fun TranscriptEvent(
                 // While tokens are still arriving, render plain text. Full GFM reparse on every
                 // delta thrash-measures the row and makes detached scroll compensation flicker.
                 if (streamPlainText) {
+                    val find = LocalChatFindHighlight.current
                     Text(
-                        text = visibleText,
+                        text = if (find?.isActive == true) {
+                            highlightFindMatches(visibleText, find.query, find.activeRange)
+                        } else {
+                            AnnotatedString(visibleText)
+                        },
                         color = TextPrimary,
                         fontSize = 14.sp,
                         lineHeight = 21.sp,
@@ -1180,12 +1312,12 @@ private fun TranscriptEvent(
             text = event.text,
             expanded = thinkingExpanded,
             onExpandedChange = { expanded -> onThinkingExpandedChange(eventKey, expanded) },
-            animateExpansion = !autoExpandThinkingSections,
+            animateExpansion = !forceExpandInstant && !autoExpandThinkingSections,
         )
         is AgentEvent.UserMessage -> {
             if (event.text.isSilentConnectionRecoveryPrompt()) return
             val displayText = userMessageDisplayText(event)
-            val copyText = displayText.takeIf { it.isNotBlank() }
+            val copyText = userMessageCopyText(event)
                 ?: event.skills.takeIf { it.isNotEmpty() }?.joinToString(" ") { "/${it.name}" }
             val timestamp = event.atMillis.takeIf { it > 0L }?.let(::formatDisplayTime)
             ChatMessageBubble(
@@ -1207,6 +1339,7 @@ private fun TranscriptEvent(
                     if (displayText.isNotBlank()) {
                         ChatUserText(displayText)
                     }
+                    ChatAttachedTextAttachments(event.attachments)
                     ChatAttachedImages(event.imagePaths)
                     if (event.skills.isNotEmpty()) {
                         DisableSelection {
@@ -1234,7 +1367,7 @@ private fun TranscriptEvent(
                 ),
                 expanded = toolExpanded,
                 onExpandedChange = { expanded -> onToolExpandedChange(eventKey, expanded) },
-                animateExpansion = !autoExpandToolSections,
+                animateExpansion = !forceExpandInstant && !autoExpandToolSections,
                 knownTasks = knownTasks,
                 currentTaskId = currentTaskId,
             )
@@ -1242,7 +1375,7 @@ private fun TranscriptEvent(
             ToolBlock(
                 expanded = toolExpanded,
                 onExpandedChange = { expanded -> onToolExpandedChange(eventKey, expanded) },
-                animateExpansion = !autoExpandToolSections,
+                animateExpansion = !forceExpandInstant && !autoExpandToolSections,
                 marker = "▸",
                 name = event.toolName,
                 summary = event.summary,
@@ -1259,7 +1392,7 @@ private fun TranscriptEvent(
             ToolBlock(
                 expanded = toolExpanded,
                 onExpandedChange = { expanded -> onToolExpandedChange(eventKey, expanded) },
-                animateExpansion = !autoExpandToolSections,
+                animateExpansion = !forceExpandInstant && !autoExpandToolSections,
                 marker = if (event.isError) "✗" else "✓",
                 name = event.toolName,
                 summary = event.summary,
@@ -1511,8 +1644,13 @@ private fun ThinkingStep(
 
 @Composable
 private fun ChatUserText(text: String) {
+    val find = LocalChatFindHighlight.current
     Text(
-        text,
+        text = if (find?.isActive == true) {
+            highlightFindMatches(text, find.query, find.activeRange)
+        } else {
+            AnnotatedString(text)
+        },
         color = TextPrimary,
         fontFamily = DisplayFont,
         fontSize = 14.sp,
@@ -1588,6 +1726,51 @@ private fun AgentCompletion(
             }
         }
         if (event.success) completedContent?.invoke()
+    }
+}
+
+@Composable
+fun ChatAttachedTextAttachments(
+    attachments: List<AgentAttachment>,
+    modifier: Modifier = Modifier,
+) {
+    if (attachments.isEmpty()) return
+    Column(
+        modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        attachments.forEach { attachment ->
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(AndyRadius.Control))
+                    .background(AndyColors.Neutral900.copy(alpha = AndyOverlay.Medium))
+                    .border(1.dp, PaneDividerTint, RoundedCornerShape(AndyRadius.Control))
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                LucideIcon(Lucide.FileText, TextSecondary.copy(alpha = 0.85f), Modifier.size(14.dp))
+                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                    Text(
+                        attachment.displayName,
+                        color = TextPrimary,
+                        fontFamily = DisplayFont,
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        attachment.metadataLabel(),
+                        color = TextSecondary,
+                        fontFamily = MonoFont,
+                        fontSize = 10.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -1857,6 +2040,9 @@ private fun CompactToolCallsBlock(
     onExpandedChange: (Boolean) -> Unit,
     expandedToolKeys: Set<String>,
     expandedThinkingKeys: Set<String>,
+    findExpandKeys: Set<String> = emptySet(),
+    findQuery: String = "",
+    activeFindMatch: ChatFindMatch? = null,
     autoExpandThinkingSections: Boolean,
     autoExpandToolSections: Boolean,
     onToolExpandedChange: (String, Boolean) -> Unit,
@@ -1864,6 +2050,7 @@ private fun CompactToolCallsBlock(
     onToolFileOpen: (ToolCallFileContent) -> Unit,
     knownTasks: List<AgentTask> = emptyList(),
     currentTaskId: String? = null,
+    forceExpandInstant: Boolean = false,
 ) {
     // isAgentSpawn runs several regex passes over each event's summary/detail. Classifying
     // once per composition (memoized on `events`) instead of on every recomposition — e.g.
@@ -1894,7 +2081,7 @@ private fun CompactToolCallsBlock(
             sources = classification.spawnSources,
             expanded = expanded,
             onExpandedChange = onExpandedChange,
-            animateExpansion = !autoExpandToolSections,
+            animateExpansion = !forceExpandInstant && !autoExpandToolSections,
             knownTasks = knownTasks,
             currentTaskId = currentTaskId,
         )
@@ -1902,12 +2089,13 @@ private fun CompactToolCallsBlock(
     }
 
     val headlineColor = if (classification.hasError) Red.copy(alpha = 0.9f) else TextSecondary
+    val findQueryTrimmed = findQuery.trim()
 
     TranscriptExpandableRow(
         headline = classification.headline,
         expanded = expanded,
         onExpandedChange = onExpandedChange,
-        animateExpansion = !autoExpandToolSections,
+        animateExpansion = !forceExpandInstant && !autoExpandToolSections,
         headlineColor = headlineColor,
         indent = TranscriptAsideIndent,
     ) {
@@ -1918,56 +2106,74 @@ private fun CompactToolCallsBlock(
             events.forEachIndexed { offset, event ->
                 val eventKey = transcriptEventKey(startIndex + offset, event)
                 val isSpawn = classification.spawnFlags[offset]
-                when (event) {
-                    is AgentEvent.Thinking -> ThinkingStep(
-                        text = event.text,
-                        expanded = transcriptActivityExpanded(eventKey, expandedThinkingKeys, autoExpandThinkingSections),
-                        onExpandedChange = { value -> onThinkingExpandedChange(eventKey, value) },
-                        animateExpansion = !autoExpandThinkingSections,
+                val nestedExpanded = eventKey in findExpandKeys || when (event) {
+                    is AgentEvent.Thinking ->
+                        transcriptActivityExpanded(eventKey, expandedThinkingKeys, autoExpandThinkingSections)
+                    is AgentEvent.ToolCall, is AgentEvent.ToolResult ->
+                        transcriptActivityExpanded(eventKey, expandedToolKeys, autoExpandToolSections)
+                    else -> false
+                }
+                val nestedInstant = eventKey in findExpandKeys
+                val nestedFind = findQueryTrimmed.takeIf { it.isNotEmpty() }?.let { query ->
+                    ChatFindHighlight(
+                        query = query,
+                        activeRange = activeFindMatch
+                            ?.takeIf { it.nestedEventKey == eventKey }
+                            ?.range,
                     )
-                    is AgentEvent.ToolCall -> if (isSpawn) {
-                        val source = AgentSpawnPresentation.spawnSources(listOf(event)).singleOrNull()
-                            ?: AgentSpawnPresentation.SpawnSource(event.toolName, event.summary, event.detail)
-                        SpawnedAgentLine(
-                            spawn = AgentSpawnPresentation.parse(source.toolName, source.summary, source.detail),
-                            indent = TranscriptAsideContentIndent,
-                            knownTasks = knownTasks,
-                            currentTaskId = currentTaskId,
+                }
+                CompositionLocalProvider(LocalChatFindHighlight provides nestedFind) {
+                    when (event) {
+                        is AgentEvent.Thinking -> ThinkingStep(
+                            text = event.text,
+                            expanded = nestedExpanded,
+                            onExpandedChange = { value -> onThinkingExpandedChange(eventKey, value) },
+                            animateExpansion = !nestedInstant && !autoExpandThinkingSections,
                         )
-                    } else {
-                        ToolBlock(
-                            expanded = transcriptActivityExpanded(eventKey, expandedToolKeys, autoExpandToolSections),
-                            onExpandedChange = { value -> onToolExpandedChange(eventKey, value) },
-                            animateExpansion = !autoExpandToolSections,
-                            marker = "▸",
-                            name = event.toolName,
-                            summary = event.summary,
-                            detail = event.detail,
-                            kind = event.kind,
-                            locations = event.locations,
-                            images = event.images,
-                            color = TextSecondary,
-                            forceVisible = event.state == AgentToolState.Failed,
-                            indent = TranscriptAsideContentIndent,
-                            onToolFileOpen = onToolFileOpen,
-                        )
+                        is AgentEvent.ToolCall -> if (isSpawn) {
+                            val source = AgentSpawnPresentation.spawnSources(listOf(event)).singleOrNull()
+                                ?: AgentSpawnPresentation.SpawnSource(event.toolName, event.summary, event.detail)
+                            SpawnedAgentLine(
+                                spawn = AgentSpawnPresentation.parse(source.toolName, source.summary, source.detail),
+                                indent = TranscriptAsideContentIndent,
+                                knownTasks = knownTasks,
+                                currentTaskId = currentTaskId,
+                            )
+                        } else {
+                            ToolBlock(
+                                expanded = nestedExpanded,
+                                onExpandedChange = { value -> onToolExpandedChange(eventKey, value) },
+                                animateExpansion = !nestedInstant && !autoExpandToolSections,
+                                marker = "▸",
+                                name = event.toolName,
+                                summary = event.summary,
+                                detail = event.detail,
+                                kind = event.kind,
+                                locations = event.locations,
+                                images = event.images,
+                                color = TextSecondary,
+                                forceVisible = event.state == AgentToolState.Failed,
+                                indent = TranscriptAsideContentIndent,
+                                onToolFileOpen = onToolFileOpen,
+                            )
+                        }
+                        is AgentEvent.ToolResult -> if (event.isError || !isSpawn) {
+                            ToolBlock(
+                                expanded = nestedExpanded,
+                                onExpandedChange = { value -> onToolExpandedChange(eventKey, value) },
+                                animateExpansion = !nestedInstant && !autoExpandToolSections,
+                                marker = if (event.isError) "✗" else "✓",
+                                name = event.toolName,
+                                summary = event.summary,
+                                detail = event.detail,
+                                color = if (event.isError) Red else TextSecondary,
+                                forceVisible = event.isError,
+                                indent = TranscriptAsideContentIndent,
+                                onToolFileOpen = onToolFileOpen,
+                            )
+                        }
+                        else -> Unit
                     }
-                    is AgentEvent.ToolResult -> if (event.isError || !isSpawn) {
-                        ToolBlock(
-                            expanded = transcriptActivityExpanded(eventKey, expandedToolKeys, autoExpandToolSections),
-                            onExpandedChange = { value -> onToolExpandedChange(eventKey, value) },
-                            animateExpansion = !autoExpandToolSections,
-                            marker = if (event.isError) "✗" else "✓",
-                            name = event.toolName,
-                            summary = event.summary,
-                            detail = event.detail,
-                            color = if (event.isError) Red else TextSecondary,
-                            forceVisible = event.isError,
-                            indent = TranscriptAsideContentIndent,
-                            onToolFileOpen = onToolFileOpen,
-                        )
-                    }
-                    else -> Unit
                 }
             }
         }

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentUi.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/AgentUi.kt
@@ -493,7 +493,8 @@ fun showsChatFollowUpComposer(
     interactive: Boolean,
     hasStagedImages: Boolean,
     canReconnect: Boolean = false,
-): Boolean = (!interactive && !canReconnect) || hasStagedImages
+    hasStagedAttachments: Boolean = false,
+): Boolean = (!interactive && !canReconnect) || hasStagedImages || hasStagedAttachments
 
 /** True while the card timer should keep ticking with wall clock. */
 fun isElapsedLive(task: AgentTask): Boolean =

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ChatComposerInbox.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ChatComposerInbox.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import app.andy.model.AgentAttachment
+import app.andy.model.shouldAttachLargeText
 import app.andy.ui.components.attachChatImages
 import app.andy.ui.components.insertTextAtCursor
 
@@ -16,6 +18,7 @@ import app.andy.ui.components.insertTextAtCursor
 data class ChatComposerAttachment(
     val imagePaths: List<String> = emptyList(),
     val text: String = "",
+    val attachments: List<AgentAttachment> = emptyList(),
 )
 
 class ChatComposerInbox {
@@ -23,7 +26,7 @@ class ChatComposerInbox {
     private val pending = ArrayDeque<ChatComposerAttachment>()
 
     fun offer(item: ChatComposerAttachment) {
-        if (item.imagePaths.isEmpty() && item.text.isBlank()) return
+        if (item.imagePaths.isEmpty() && item.text.isBlank() && item.attachments.isEmpty()) return
         val sink = sinks.lastOrNull()
         if (sink != null) {
             sink(item)
@@ -61,15 +64,34 @@ fun CollectChatComposerInbox(
     }
 }
 
+data class ChatComposerApplyResult(
+    val text: TextFieldValue,
+    val images: List<String>,
+    val attachments: List<AgentAttachment>,
+    /** Large pasted prose that must be staged asynchronously by the composer. */
+    val largeTextToStage: String? = null,
+)
+
 fun applyChatComposerAttachment(
     currentText: TextFieldValue,
     currentImages: List<String>,
+    currentAttachments: List<AgentAttachment> = emptyList(),
     item: ChatComposerAttachment,
-): Pair<TextFieldValue, List<String>> {
+): ChatComposerApplyResult {
     val images = attachChatImages(currentImages, item.imagePaths)
+    val attachments = currentAttachments + item.attachments
     val addition = item.text.trim()
-    if (addition.isEmpty()) return currentText to images
+    if (addition.isEmpty()) {
+        return ChatComposerApplyResult(currentText, images, attachments)
+    }
+    if (shouldAttachLargeText(addition)) {
+        return ChatComposerApplyResult(currentText, images, attachments, largeTextToStage = addition)
+    }
     val separator = if (currentText.text.isBlank()) "" else "\n\n"
     val atEnd = currentText.copy(selection = TextRange(currentText.text.length))
-    return insertTextAtCursor(atEnd, separator + addition) to images
+    return ChatComposerApplyResult(
+        text = insertTextAtCursor(atEnd, separator + addition),
+        images = images,
+        attachments = attachments,
+    )
 }

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ChatFind.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ChatFind.kt
@@ -1,0 +1,188 @@
+package app.andy.ui.agents
+
+import app.andy.model.AgentEvent
+import app.andy.model.TranscriptDisplayItem
+import app.andy.model.boundedUserMessagePreview
+import app.andy.model.isSilentConnectionRecoveryPrompt
+import app.andy.model.stripDecisionCheckpointMarkup
+import app.andy.model.stripTrailingConnectionStallError
+import app.andy.ui.components.findLiteralRanges
+
+/** One substring hit inside a transcript row. */
+data class ChatFindMatch(
+    val itemKey: String,
+    val start: Int,
+    val end: Int,
+    /**
+     * Activity key inside a [TranscriptDisplayItem.ToolCalls] group (or the event key itself
+     * for a standalone thinking/tool row). Used to expand and scope text highlights.
+     */
+    val nestedEventKey: String? = null,
+    val nestedExpandKind: ChatFindExpandKind? = null,
+) {
+    val range: IntRange get() = start until end
+}
+
+enum class ChatFindExpandKind {
+    Thinking,
+    Tool,
+    ToolGroup,
+}
+
+/**
+ * Case-insensitive literal find over ACP transcript display rows.
+ *
+ * Searchable content: user messages, assistant text, thinking, tool title/summary/detail,
+ * and task results. Collapsed asides stay reachable — navigation expands them.
+ */
+fun findChatMatches(
+    displayItems: List<TranscriptDisplayItem>,
+    query: String,
+    originalPrompt: String? = null,
+    originalPromptVisible: Boolean = false,
+): List<ChatFindMatch> {
+    val needle = query.trim()
+    if (needle.isEmpty()) return emptyList()
+    val out = ArrayList<ChatFindMatch>()
+    if (originalPromptVisible) {
+        val prompt = originalPrompt?.takeIf { it.isNotBlank() }?.let(::boundedUserMessagePreview)
+        if (!prompt.isNullOrEmpty()) {
+            appendMatches(out, itemKey = "original-prompt", haystack = prompt, needle = needle)
+        }
+    }
+    for (item in displayItems) {
+        when (item) {
+            is TranscriptDisplayItem.Event -> {
+                val text = chatFindSearchableText(item.event) ?: continue
+                val eventKey = transcriptEventKey(item.index, item.event)
+                val kind = chatFindExpandKind(item.event)
+                appendMatches(
+                    out,
+                    itemKey = transcriptDisplayItemKey(item),
+                    haystack = text,
+                    needle = needle,
+                    nestedEventKey = eventKey.takeIf { kind != null },
+                    nestedExpandKind = kind,
+                )
+            }
+            is TranscriptDisplayItem.ToolCalls -> {
+                val groupKey = transcriptDisplayItemKey(item)
+                item.events.forEachIndexed { offset, event ->
+                    val text = chatFindSearchableText(event) ?: return@forEachIndexed
+                    val eventKey = transcriptEventKey(item.startIndex + offset, event)
+                    val kind = chatFindExpandKind(event) ?: return@forEachIndexed
+                    appendMatches(
+                        out,
+                        itemKey = groupKey,
+                        haystack = text,
+                        needle = needle,
+                        nestedEventKey = eventKey,
+                        nestedExpandKind = kind,
+                    )
+                }
+            }
+            is TranscriptDisplayItem.ChildSpawns -> {
+                val text = chatFindSearchableText(item) ?: continue
+                appendMatches(out, itemKey = transcriptDisplayItemKey(item), haystack = text, needle = needle)
+            }
+        }
+    }
+    return out
+}
+
+/** Keys that should be force-expanded (no animation) for the active find hit. */
+fun chatFindExpandKeys(match: ChatFindMatch?): Set<String> {
+    if (match == null) return emptySet()
+    val keys = linkedSetOf<String>()
+    when (match.nestedExpandKind) {
+        ChatFindExpandKind.ToolGroup -> keys += match.itemKey
+        ChatFindExpandKind.Thinking, ChatFindExpandKind.Tool -> {
+            // Nested hit inside a collapsed activity group: open the group and the row.
+            if (match.itemKey.startsWith("tool-group-")) {
+                keys += match.itemKey
+            }
+            match.nestedEventKey?.let { keys += it }
+        }
+        null -> Unit
+    }
+    return keys
+}
+
+fun chatFindSearchableText(item: TranscriptDisplayItem): String? = when (item) {
+    is TranscriptDisplayItem.Event -> chatFindSearchableText(item.event)
+    is TranscriptDisplayItem.ToolCalls -> {
+        val parts = item.events.mapNotNull(::chatFindSearchableText)
+        parts.takeIf { it.isNotEmpty() }?.joinToString("\n")
+    }
+    is TranscriptDisplayItem.ChildSpawns -> {
+        item.tasks.mapNotNull { task ->
+            sequenceOf(task.title, task.prompt)
+                .map { it.trim() }
+                .firstOrNull { it.isNotEmpty() }
+        }.takeIf { it.isNotEmpty() }?.joinToString("\n")
+    }
+}
+
+fun chatFindSearchableText(event: AgentEvent): String? = when (event) {
+    is AgentEvent.UserMessage -> {
+        if (event.text.isSilentConnectionRecoveryPrompt()) {
+            null
+        } else {
+            userMessageDisplayText(event).takeIf { it.isNotBlank() }
+        }
+    }
+    is AgentEvent.AssistantText -> {
+        val visible = stripDecisionCheckpointMarkup(
+            event.text.stripTrailingConnectionStallError(),
+        )
+        visible.takeIf { it.isNotBlank() }
+    }
+    is AgentEvent.Thinking -> event.text.takeIf { it.isNotBlank() }
+    is AgentEvent.ToolCall -> toolFindText(event.toolName, event.summary, event.detail)
+    is AgentEvent.ToolResult -> toolFindText(event.toolName, event.summary, event.detail)
+    is AgentEvent.TaskResult -> event.finalText?.takeIf { it.isNotBlank() }
+    else -> null
+}
+
+private fun chatFindExpandKind(event: AgentEvent): ChatFindExpandKind? = when (event) {
+    is AgentEvent.Thinking -> ChatFindExpandKind.Thinking
+    is AgentEvent.ToolCall, is AgentEvent.ToolResult -> ChatFindExpandKind.Tool
+    else -> null
+}
+
+private fun toolFindText(toolName: String?, summary: String, detail: String = summary): String? {
+    val title = toolName.orEmpty().trim()
+    val body = summary.trim()
+    val extra = detail.trim().takeUnless { it.isEmpty() || it == body }.orEmpty()
+    val combined = buildString {
+        if (title.isNotEmpty()) append(title)
+        if (body.isNotEmpty()) {
+            if (isNotEmpty()) append(' ')
+            append(body)
+        }
+        if (extra.isNotEmpty()) {
+            if (isNotEmpty()) append('\n')
+            append(extra)
+        }
+    }
+    return combined.takeIf { it.isNotBlank() }
+}
+
+private fun appendMatches(
+    out: MutableList<ChatFindMatch>,
+    itemKey: String,
+    haystack: String,
+    needle: String,
+    nestedEventKey: String? = null,
+    nestedExpandKind: ChatFindExpandKind? = null,
+) {
+    for (range in findLiteralRanges(haystack, needle)) {
+        out += ChatFindMatch(
+            itemKey = itemKey,
+            start = range.first,
+            end = range.last + 1,
+            nestedEventKey = nestedEventKey,
+            nestedExpandKind = nestedExpandKind,
+        )
+    }
+}

--- a/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ChatFollowUpDraftMemory.kt
+++ b/feature/agents/src/commonMain/kotlin/app/andy/ui/agents/ChatFollowUpDraftMemory.kt
@@ -1,10 +1,12 @@
 package app.andy.ui.agents
 
 import androidx.compose.ui.text.input.TextFieldValue
+import app.andy.model.AgentAttachment
 
 data class ChatFollowUpDraft(
     val text: TextFieldValue = TextFieldValue(""),
     val imagePaths: List<String> = emptyList(),
+    val attachments: List<AgentAttachment> = emptyList(),
 )
 
 /** In-memory follow-up composer drafts keyed by chat id. Survives switching chats without retaining full panes. */
@@ -14,7 +16,7 @@ class ChatFollowUpDraftMemory {
     fun get(taskId: String): ChatFollowUpDraft? = drafts[taskId]
 
     fun save(taskId: String, draft: ChatFollowUpDraft) {
-        if (draft.text.text.isBlank() && draft.imagePaths.isEmpty()) {
+        if (draft.text.text.isBlank() && draft.imagePaths.isEmpty() && draft.attachments.isEmpty()) {
             drafts.remove(taskId)
         } else {
             drafts[taskId] = draft

--- a/feature/agents/src/commonTest/kotlin/app/andy/BrowserElementAnnotationTest.kt
+++ b/feature/agents/src/commonTest/kotlin/app/andy/BrowserElementAnnotationTest.kt
@@ -61,7 +61,7 @@ class BrowserElementAnnotationTest {
 
     @Test
     fun applyAttachmentAppendsTextAndMergesImages() {
-        val (text, images) = applyChatComposerAttachment(
+        val applied = applyChatComposerAttachment(
             currentText = TextFieldValue("existing", TextRange(0)),
             currentImages = listOf("/tmp/a.png"),
             item = ChatComposerAttachment(
@@ -69,7 +69,7 @@ class BrowserElementAnnotationTest {
                 text = "note",
             ),
         )
-        assertEquals("existing\n\nnote", text.text)
-        assertEquals(listOf("/tmp/a.png", "/tmp/b.png"), images)
+        assertEquals("existing\n\nnote", applied.text.text)
+        assertEquals(listOf("/tmp/a.png", "/tmp/b.png"), applied.images)
     }
 }

--- a/feature/agents/src/commonTest/kotlin/app/andy/ui/agents/ChatFindTest.kt
+++ b/feature/agents/src/commonTest/kotlin/app/andy/ui/agents/ChatFindTest.kt
@@ -1,0 +1,93 @@
+package app.andy.ui.agents
+
+import app.andy.model.AgentEvent
+import app.andy.model.CONNECTION_STALL_RETRY_PROMPT
+import app.andy.model.transcriptDisplayItems
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChatFindTest {
+    @Test
+    fun findsMatchesAcrossUserAssistantAndThinking() {
+        val events = listOf(
+            AgentEvent.UserMessage(1L, "search for token"),
+            AgentEvent.Thinking(2L, "consider Token reuse"),
+            AgentEvent.AssistantText(3L, "No token here"),
+        )
+        val items = transcriptDisplayItems(events, keepThinkingOnTimeline = true)
+        val matches = findChatMatches(items, "token")
+        assertEquals(3, matches.size)
+        assertTrue(matches.all { it.itemKey.isNotBlank() })
+        val thinking = matches.single { it.nestedExpandKind == ChatFindExpandKind.Thinking }
+        assertEquals(ChatFindExpandKind.Thinking, thinking.nestedExpandKind)
+        assertEquals(setOf(thinking.nestedEventKey), chatFindExpandKeys(thinking).filter { it == thinking.nestedEventKey }.toSet())
+        assertTrue(thinking.nestedEventKey in chatFindExpandKeys(thinking))
+    }
+
+    @Test
+    fun includesOriginalPromptWhenVisible() {
+        val matches = findChatMatches(
+            displayItems = emptyList(),
+            query = "hello",
+            originalPrompt = "say hello world",
+            originalPromptVisible = true,
+        )
+        assertEquals(1, matches.size)
+        assertEquals("original-prompt", matches.single().itemKey)
+        assertEquals(4, matches.single().start)
+    }
+
+    @Test
+    fun skipsSilentRecoveryAndBlankQuery() {
+        val events = listOf(
+            AgentEvent.UserMessage(1L, CONNECTION_STALL_RETRY_PROMPT),
+            AgentEvent.AssistantText(2L, "visible"),
+        )
+        val items = transcriptDisplayItems(events)
+        assertTrue(findChatMatches(items, "  ").isEmpty())
+        assertTrue(findChatMatches(items, "CONNECTION").isEmpty())
+        assertEquals(1, findChatMatches(items, "visible").size)
+    }
+
+    @Test
+    fun searchesToolTitleSummaryAndDetail() {
+        val events = listOf(
+            AgentEvent.ToolCall(
+                atMillis = 1L,
+                toolName = "Read",
+                summary = "ChatFind.kt",
+                detail = "line with uniqueNeedle inside",
+            ),
+        )
+        val items = transcriptDisplayItems(events)
+        val matches = findChatMatches(items, "uniqueNeedle")
+        assertEquals(1, matches.size)
+        assertEquals(ChatFindExpandKind.Tool, matches.single().nestedExpandKind)
+        assertTrue(matches.single().nestedEventKey in chatFindExpandKeys(matches.single()))
+    }
+
+    @Test
+    fun collapsedToolGroupMatchExpandsGroupAndNestedRow() {
+        val events = listOf(
+            AgentEvent.UserMessage(1L, "go"),
+            AgentEvent.Thinking(2L, "plan with secretPhrase"),
+            AgentEvent.ToolCall(3L, toolName = "Read", summary = "a.kt"),
+            AgentEvent.AssistantText(4L, "done"),
+        )
+        val items = transcriptDisplayItems(
+            events,
+            collapseActivityBetweenMessages = true,
+            keepThinkingOnTimeline = false,
+        )
+        val group = items.filterIsInstance<app.andy.model.TranscriptDisplayItem.ToolCalls>().single()
+        val matches = findChatMatches(items, "secretPhrase")
+        assertEquals(1, matches.size)
+        val match = matches.single()
+        assertEquals(transcriptDisplayItemKey(group), match.itemKey)
+        assertEquals(ChatFindExpandKind.Thinking, match.nestedExpandKind)
+        val expand = chatFindExpandKeys(match)
+        assertTrue(match.itemKey in expand, "group should expand")
+        assertTrue(match.nestedEventKey in expand, "nested thinking should expand")
+    }
+}

--- a/feature/agents/src/commonTest/kotlin/app/andy/ui/agents/ChatFollowUpDraftMemoryTest.kt
+++ b/feature/agents/src/commonTest/kotlin/app/andy/ui/agents/ChatFollowUpDraftMemoryTest.kt
@@ -1,6 +1,7 @@
 package app.andy.ui.agents
 
 import androidx.compose.ui.text.input.TextFieldValue
+import app.andy.model.AgentAttachment
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -21,6 +22,20 @@ class ChatFollowUpDraftMemoryTest {
         memory.save("task-a", ChatFollowUpDraft(TextFieldValue("typing")))
         memory.save("task-a", ChatFollowUpDraft(TextFieldValue("")))
         assertNull(memory.get("task-a"))
+    }
+
+    @Test
+    fun retainsDraftWithAttachmentsOnly() {
+        val memory = ChatFollowUpDraftMemory()
+        val attachment = AgentAttachment(
+            id = "att-1",
+            displayName = "pasted.txt",
+            byteCount = 100,
+            lineCount = 5,
+            sha256 = "a".repeat(64),
+        )
+        memory.save("task-a", ChatFollowUpDraft(attachments = listOf(attachment)))
+        assertEquals(listOf(attachment), memory.get("task-a")?.attachments)
     }
 
     @Test

--- a/feature/live/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
+++ b/feature/live/src/commonMain/kotlin/app/andy/ui/live/LiveScreen.kt
@@ -745,10 +745,7 @@ fun LiveScreen(
                             session = dhuSession,
                             readiness = dhuReadiness,
                             onRetry = {
-                                val target = androidAutoForSerial ?: serial
-                                if (target != null) {
-                                    scope.launch { services.dhu.start(target) }
-                                }
+                                scope.launch { services.dhu.start(androidAutoForSerial) }
                             },
                             onStop = { onAndroidAutoSerialChange(null) },
                         )

--- a/feature/settings/src/commonMain/kotlin/app/andy/ui/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/app/andy/ui/settings/SettingsScreen.kt
@@ -118,12 +118,15 @@ import app.andy.service.NetworkLoginCodeRefreshLeadMillis
 import app.andy.service.networkLoginCodeCountdownLabel
 import app.andy.service.OrchestrationPreferencesService
 import app.andy.service.ProxyService
+import app.andy.service.RemoteProjectScanStatus
+import app.andy.service.RemoteSessionService
 import app.andy.service.RetentionSweepResult
 import app.andy.service.RuntimeBundleService
 import app.andy.service.RuntimeBundleSnapshot
 import app.andy.service.RuntimeBundleState
 import app.andy.service.UnavailableAgentRetentionService
 import app.andy.service.UnavailableOrchestrationPreferencesService
+import app.andy.service.UnavailableRemoteSessionService
 import app.andy.service.UnavailableRuntimeBundleService
 import app.andy.service.UnavailableUpdateService
 import app.andy.service.UnavailableVoiceSetupService
@@ -231,11 +234,20 @@ fun SettingsScreen(
     ) {
         when (category) {
             DesktopSettingsCategory.Appearance -> AppearancePanel(workspaceState, onUpdateWorkspace)
-            DesktopSettingsCategory.Navigation -> NavigationPanel(
-                workspace = workspaceState,
-                update = onUpdateWorkspace,
-                destinations = services.capabilities.destinations,
-            )
+            DesktopSettingsCategory.Navigation -> {
+                NavigationPanel(
+                    workspace = workspaceState,
+                    update = onUpdateWorkspace,
+                    destinations = services.capabilities.destinations,
+                )
+                if (services.remoteSession !is UnavailableRemoteSessionService) {
+                    RemoteProjectsPanel(
+                        workspaceState = workspaceState,
+                        onUpdateWorkspace = onUpdateWorkspace,
+                        remoteSession = services.remoteSession,
+                    )
+                }
+            }
             DesktopSettingsCategory.Live -> LivePanel(workspaceState, onUpdateWorkspace)
             DesktopSettingsCategory.Agents -> {
                 if (services.orchestrationPreferences !is UnavailableOrchestrationPreferencesService) {
@@ -3002,6 +3014,68 @@ private fun PluginsPanel(services: AndyServices) {
                     fontSize = 12.sp,
                     fontFamily = MonoFont,
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RemoteProjectsPanel(
+    workspaceState: WorkspaceState,
+    onUpdateWorkspace: ((WorkspaceState) -> WorkspaceState) -> Unit,
+    remoteSession: RemoteSessionService,
+) {
+    val scope = rememberCoroutineScope()
+    val session by remoteSession.state.collectAsState()
+    val scanned by remoteSession.savedTargetProjects.collectAsState()
+    val enabled = workspaceState.mergeRemoteProjects
+    val scanning = scanned.values.any { it.status == RemoteProjectScanStatus.Scanning }
+    val projectCount = scanned.values.sumOf { it.projects.size }
+    val unavailable = scanned.values.filter { it.status == RemoteProjectScanStatus.Unavailable }
+
+    SettingsGroup(
+        title = "Projects from other hosts",
+        description = "Show every host's projects in one list, badged with where they live. " +
+            "Opening one switches Andy to that host first — including back to this computer " +
+            "while you are connected to a remote.",
+    ) {
+        SettingsToggleRow(
+            label = "Show projects from saved SSH hosts",
+            checked = enabled,
+            description = "Reads each saved host's ~/.andy/actions.toml in the background, reusing a live " +
+                "connection or the password saved in your keychain. Scans never open a prompt — a host " +
+                "Andy has no credentials for is listed as unavailable until you connect to it once.",
+            onCheckedChange = { checked ->
+                onUpdateWorkspace { it.copy(mergeRemoteProjects = checked) }
+            },
+        )
+        if (enabled) {
+            Text(
+                when {
+                    session.savedTargets.isEmpty() ->
+                        "No saved SSH hosts yet — add one from the Local/Remote switcher at the bottom of the sidebar."
+                    scanning -> "Scanning ${session.savedTargets.size} host(s)…"
+                    else -> "$projectCount project(s) from ${scanned.size} host(s)."
+                },
+                color = TextSecondary,
+                fontFamily = MonoFont,
+                fontSize = 12.sp,
+            )
+            unavailable.forEach { host ->
+                Text(
+                    "${session.displayNameFor(host.target)}: ${host.error ?: "unavailable"}",
+                    color = Rust,
+                    fontFamily = MonoFont,
+                    fontSize = 11.sp,
+                    lineHeight = 15.sp,
+                )
+            }
+            Button(
+                onClick = { scope.launch { remoteSession.refreshSavedTargetProjects(force = true) } },
+                enabled = !scanning && session.savedTargets.isNotEmpty(),
+                colors = primaryButtonColors(),
+            ) {
+                Text(if (scanning) "Scanning…" else "Rescan hosts")
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ okhttp = "4.12.0"
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMaterial3" }
+compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose" }
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose" }
@@ -81,6 +82,7 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor"
 ktor-server-sse = { module = "io.ktor:ktor-server-sse", version.ref = "ktor" }
 ktor-server-double-receive = { module = "io.ktor:ktor-server-double-receive", version.ref = "ktor" }
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
+ktor-server-compression = { module = "io.ktor:ktor-server-compression", version.ref = "ktor" }
 ktor-server-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 roborazzi-compose-desktop = { module = "io.github.takahirom.roborazzi:roborazzi-compose-desktop", version.ref = "roborazzi" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }

--- a/native/andy-voice/jni/andy_voice_jni.m
+++ b/native/andy-voice/jni/andy_voice_jni.m
@@ -1,4 +1,5 @@
 #include <jni.h>
+#include <stdint.h>
 #import <AVFoundation/AVFoundation.h>
 #import <Carbon/Carbon.h>
 #import <Foundation/Foundation.h>
@@ -17,10 +18,12 @@
 static JavaVM *g_jvm = NULL;
 static jclass g_bridge_class = NULL; // GlobalRef to MacOsGlobalHotKeyBridge
 static jmethodID g_hotkey_method = NULL; // static void dispatchHotKeyPressed()
-static jmethodID g_hotkey_failed_method = NULL; // static void dispatchRegisterFailed(int)
+static jmethodID g_hotkey_failed_method = NULL; // static void dispatchRegisterFailed(int, int)
 static EventHandlerRef g_hotkey_handler = NULL;
 static EventHotKeyRef g_hotkey_ref = NULL;
 static UInt32 g_hotkey_id = 1;
+/** Bumped on every register/unregister request; async work bails when stale. */
+static volatile int32_t g_hotkey_generation = 0;
 
 static void run_on_main_sync(void (^block)(void)) {
     if ([NSThread isMainThread]) {
@@ -171,7 +174,15 @@ static void andy_hotkey_invoke_java(void) {
 static void andy_hotkey_release_bridge(void) {
     if (g_bridge_class != NULL && g_jvm != NULL) {
         JNIEnv *mainEnv = NULL;
-        if ((*g_jvm)->GetEnv(g_jvm, (void **)&mainEnv, JNI_VERSION_1_8) == JNI_OK && mainEnv != NULL) {
+        jint getEnv = (*g_jvm)->GetEnv(g_jvm, (void **)&mainEnv, JNI_VERSION_1_8);
+        if (getEnv == JNI_EDETACHED) {
+            if ((*g_jvm)->AttachCurrentThread(g_jvm, (void **)&mainEnv, NULL) != JNI_OK) {
+                mainEnv = NULL;
+            }
+        } else if (getEnv != JNI_OK) {
+            mainEnv = NULL;
+        }
+        if (mainEnv != NULL) {
             (*mainEnv)->DeleteGlobalRef(mainEnv, g_bridge_class);
         }
     }
@@ -184,11 +195,16 @@ static void andy_hotkey_release_bridge(void) {
  * Registration now completes asynchronously, so OSStatus failures are pushed back to Kotlin
  * instead of returned. Takes explicit refs so the caller can report before tearing them down.
  */
-static void andy_hotkey_report_failure(jclass bridgeClass, jmethodID failedMethod, jint status) {
+static void andy_hotkey_report_failure(
+    jclass bridgeClass,
+    jmethodID failedMethod,
+    jint handle,
+    jint status
+) {
     if (g_jvm == NULL || bridgeClass == NULL || failedMethod == NULL) return;
     JNIEnv *env = NULL;
     if ((*g_jvm)->GetEnv(g_jvm, (void **)&env, JNI_VERSION_1_8) != JNI_OK || env == NULL) return;
-    (*env)->CallStaticVoidMethod(env, bridgeClass, failedMethod, status);
+    (*env)->CallStaticVoidMethod(env, bridgeClass, failedMethod, handle, status);
     if ((*env)->ExceptionCheck(env)) {
         (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);
@@ -271,7 +287,7 @@ Java_app_andy_desktop_service_voice_MacOsGlobalHotKeyBridge_nativeRegisterHotKey
         env,
         localClass,
         "dispatchRegisterFailed",
-        "(I)V"
+        "(II)V"
     );
     if (failedMethod == NULL) {
         NSLog(@"andy-voice: GetStaticMethodID dispatchRegisterFailed failed");
@@ -281,7 +297,10 @@ Java_app_andy_desktop_service_voice_MacOsGlobalHotKeyBridge_nativeRegisterHotKey
     if (globalClass == NULL) return -1;
 
     // Allocated up front so the handle can be returned without waiting on the main queue.
+    // Generation invalidates any in-flight async Reg/Unreg so a late Reg cannot reinstall
+    // after Kotlin already asked to unregister (or registered a newer combo).
     jint handle = (jint)__atomic_fetch_add(&g_hotkey_id, 1, __ATOMIC_RELAXED);
+    int32_t generation = __atomic_add_fetch(&g_hotkey_generation, 1, __ATOMIC_SEQ_CST);
     jobject retainedClass = globalClass;
     jmethodID retainedMethod = method;
     jmethodID retainedFailedMethod = failedMethod;
@@ -289,6 +308,20 @@ Java_app_andy_desktop_service_voice_MacOsGlobalHotKeyBridge_nativeRegisterHotKey
     jint mods = carbonModifiers;
 
     run_on_main_async(^{
+        if (generation != g_hotkey_generation) {
+            // Stale — drop the GlobalRef we would have installed.
+            if (g_jvm != NULL && retainedClass != NULL) {
+                JNIEnv *dropEnv = NULL;
+                if ((*g_jvm)->GetEnv(g_jvm, (void **)&dropEnv, JNI_VERSION_1_8) == JNI_OK &&
+                    dropEnv != NULL) {
+                    (*dropEnv)->DeleteGlobalRef(dropEnv, retainedClass);
+                } else if ((*g_jvm)->AttachCurrentThread(g_jvm, (void **)&dropEnv, NULL) == JNI_OK &&
+                           dropEnv != NULL) {
+                    (*dropEnv)->DeleteGlobalRef(dropEnv, retainedClass);
+                }
+            }
+            return;
+        }
         if (g_hotkey_ref != NULL) {
             UnregisterEventHotKey(g_hotkey_ref);
             g_hotkey_ref = NULL;
@@ -301,7 +334,7 @@ Java_app_andy_desktop_service_voice_MacOsGlobalHotKeyBridge_nativeRegisterHotKey
 
         OSStatus handlerStatus = ensure_hotkey_handler();
         if (handlerStatus != noErr) {
-            andy_hotkey_report_failure(g_bridge_class, g_hotkey_failed_method, -1);
+            andy_hotkey_report_failure(g_bridge_class, g_hotkey_failed_method, handle, -1);
             andy_hotkey_release_bridge();
             return;
         }
@@ -318,17 +351,27 @@ Java_app_andy_desktop_service_voice_MacOsGlobalHotKeyBridge_nativeRegisterHotKey
             &g_hotkey_ref
         );
         NSLog(
-            @"andy-voice: RegisterEventHotKey status=%d key=0x%X mods=0x%X id=%u",
+            @"andy-voice: RegisterEventHotKey status=%d key=0x%X mods=0x%X id=%u gen=%d",
             (int)status,
             (unsigned)vKey,
             (unsigned)mods,
-            (unsigned)hotKeyId.id
+            (unsigned)hotKeyId.id,
+            (int)generation
         );
+        if (generation != g_hotkey_generation) {
+            // Unregister won the race after we registered — tear down immediately.
+            if (g_hotkey_ref != NULL) {
+                UnregisterEventHotKey(g_hotkey_ref);
+                g_hotkey_ref = NULL;
+            }
+            andy_hotkey_release_bridge();
+            return;
+        }
         if (status != noErr) {
             g_hotkey_ref = NULL;
             // Encode OSStatus as negative so Kotlin can surface it (avoid colliding with -1).
             jint reported = status > 0 ? -(jint)status : (status == 0 ? -1 : (jint)status);
-            andy_hotkey_report_failure(g_bridge_class, g_hotkey_failed_method, reported);
+            andy_hotkey_report_failure(g_bridge_class, g_hotkey_failed_method, handle, reported);
             andy_hotkey_release_bridge();
         }
     });
@@ -344,7 +387,9 @@ Java_app_andy_desktop_service_voice_MacOsGlobalHotKeyBridge_nativeUnregisterHotK
     (void)env;
     (void)cls;
     (void)handle;
+    int32_t generation = __atomic_add_fetch(&g_hotkey_generation, 1, __ATOMIC_SEQ_CST);
     run_on_main_async(^{
+        (void)generation;
         if (g_hotkey_ref != NULL) {
             UnregisterEventHotKey(g_hotkey_ref);
             g_hotkey_ref = NULL;

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatComposerChrome.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatComposerChrome.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.andy.loadImageBitmap
+import app.andy.model.AgentAttachment
+import app.andy.model.metadataLabel
 import app.andy.ui.theme.AndyColors
 import app.andy.ui.theme.AndyLayout
 import app.andy.ui.theme.AndyOverlay
@@ -71,6 +73,11 @@ data class ChatComposerDrawerItem(
     val onRemove: () -> Unit,
     /** When set, the drawer renders a thumbnail preview instead of a text-only chip. */
     val imagePath: String? = null,
+    /** Secondary line — e.g. `8.3 MB · 90768 lines` for text attachments. */
+    val subtitle: String? = null,
+    val pending: Boolean = false,
+    val error: String? = null,
+    val onClick: (() -> Unit)? = null,
 )
 
 /**
@@ -201,17 +208,23 @@ private fun ChatComposerAttachmentItems(
         itemVerticalAlignment = Alignment.CenterVertically,
     ) {
         items.forEach { item ->
-            if (item.imagePath != null) {
-                ChatComposerDrawerImageChip(
-                    label = item.label,
-                    imagePath = item.imagePath,
-                    onRemove = item.onRemove,
-                )
-            } else {
-                ChatComposerDrawerChip(
-                    label = item.label,
-                    onRemove = item.onRemove,
-                )
+            when {
+                item.imagePath != null -> {
+                    ChatComposerDrawerImageChip(
+                        label = item.label,
+                        imagePath = item.imagePath,
+                        onRemove = item.onRemove,
+                    )
+                }
+                item.subtitle != null || item.pending || item.error != null || item.onClick != null -> {
+                    ChatComposerDrawerTextAttachmentChip(item = item)
+                }
+                else -> {
+                    ChatComposerDrawerChip(
+                        label = item.label,
+                        onRemove = item.onRemove,
+                    )
+                }
             }
         }
     }
@@ -361,6 +374,145 @@ private fun ChatComposerImagePreviewDialog(
                 color = TextSecondary.copy(alpha = 0.8f),
                 fontFamily = MonoFont,
                 fontSize = 11.sp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChatComposerDrawerTextAttachmentChip(
+    item: ChatComposerDrawerItem,
+    modifier: Modifier = Modifier,
+) {
+    var previewOpen by remember(item.id) { mutableStateOf(false) }
+    val chipShape = RoundedCornerShape(AndyRadius.Interactive)
+    val subtitle = when {
+        item.pending -> "Staging…"
+        item.error != null -> item.error
+        else -> item.subtitle
+    }
+    val subtitleColor = when {
+        item.error != null -> Red.copy(alpha = 0.9f)
+        item.pending -> TextSecondary.copy(alpha = 0.75f)
+        else -> TextSecondary.copy(alpha = 0.78f)
+    }
+    Row(
+        modifier
+            .clip(chipShape)
+            .background(AndyColors.Neutral800, chipShape)
+            .border(1.dp, PaneDividerTint, chipShape)
+            .then(
+                if (item.onClick != null && !item.pending) {
+                    Modifier
+                        .pointerHoverIcon(PointerIcon.Hand)
+                        .clickable { item.onClick?.invoke() ?: run { previewOpen = true } }
+                } else {
+                    Modifier
+                },
+            )
+            .padding(start = AndySpace.Space2, end = AndySpace.Space1, top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Column(
+            Modifier.widthIn(max = 220.dp),
+            verticalArrangement = Arrangement.spacedBy(1.dp),
+        ) {
+            Text(
+                item.label,
+                color = TextPrimary.copy(alpha = if (item.pending) 0.65f else 0.88f),
+                fontFamily = DisplayFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            subtitle?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    it,
+                    color = subtitleColor,
+                    fontFamily = MonoFont,
+                    fontSize = 10.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        IconButton(
+            onClick = item.onRemove,
+            modifier = Modifier.size(AndyLayout.ControlHeightSm),
+            contentDescription = "Remove ${item.label}",
+        ) {
+            LucideIcon(Lucide.X, TextSecondary.copy(alpha = 0.75f), Modifier.size(10.dp))
+        }
+    }
+    if (previewOpen) {
+        ChatTextAttachmentPreviewDialog(
+            label = item.label,
+            subtitle = item.subtitle,
+            onDismiss = { previewOpen = false },
+        )
+    }
+}
+
+@Composable
+fun ChatTextAttachmentPreviewDialog(
+    label: String,
+    subtitle: String?,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier
+                .widthIn(max = 520.dp)
+                .background(
+                    AndyColors.Neutral900.copy(alpha = AndyOverlay.Strong),
+                    RoundedCornerShape(AndyRadius.Control),
+                )
+                .border(1.dp, PaneDividerTint, RoundedCornerShape(AndyRadius.Control))
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+        ) {
+            Text(
+                label.ifBlank { "attachment" },
+                color = TextPrimary,
+                fontFamily = DisplayFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            subtitle?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    it,
+                    color = TextSecondary,
+                    fontFamily = MonoFont,
+                    fontSize = 12.sp,
+                )
+            }
+            Text(
+                "Sent as a managed text file — the agent reads it incrementally from disk.",
+                color = TextSecondary.copy(alpha = 0.85f),
+                fontFamily = DisplayFont,
+                fontSize = 12.sp,
+                lineHeight = 17.sp,
+            )
+            Text(
+                "click to close",
+                color = TextSecondary.copy(alpha = 0.8f),
+                fontFamily = MonoFont,
+                fontSize = 11.sp,
+                modifier = Modifier
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .clickable(onClick = onDismiss),
             )
         }
     }
@@ -640,9 +792,65 @@ fun chatComposerDrawerItemsFromPaths(
     skillLabels: List<Pair<String, () -> Unit>>,
     imagePaths: List<String>,
     onRemoveImage: (String) -> Unit,
+    attachments: List<AgentAttachment> = emptyList(),
+    onRemoveAttachment: (AgentAttachment) -> Unit = {},
+    onPreviewAttachment: (AgentAttachment) -> Unit = {},
+    pendingAttachmentLabels: List<Pair<String, () -> Unit>> = emptyList(),
+    attachmentErrors: List<Pair<String, String>> = emptyList(),
+): List<ChatComposerDrawerItem> = chatComposerDrawerItems(
+    skillLabels = skillLabels,
+    imagePaths = imagePaths,
+    onRemoveImage = onRemoveImage,
+    attachments = attachments,
+    onRemoveAttachment = onRemoveAttachment,
+    onPreviewAttachment = onPreviewAttachment,
+    pendingAttachmentLabels = pendingAttachmentLabels,
+    attachmentErrors = attachmentErrors,
+)
+
+fun chatComposerDrawerItems(
+    skillLabels: List<Pair<String, () -> Unit>>,
+    imagePaths: List<String>,
+    onRemoveImage: (String) -> Unit,
+    attachments: List<AgentAttachment> = emptyList(),
+    onRemoveAttachment: (AgentAttachment) -> Unit = {},
+    onPreviewAttachment: (AgentAttachment) -> Unit = {},
+    pendingAttachmentLabels: List<Pair<String, () -> Unit>> = emptyList(),
+    attachmentErrors: List<Pair<String, String>> = emptyList(),
 ): List<ChatComposerDrawerItem> = buildList {
     skillLabels.forEach { (label, onRemove) ->
         add(ChatComposerDrawerItem(id = "skill:$label", label = label, onRemove = onRemove))
+    }
+    attachments.forEach { attachment ->
+        add(
+            ChatComposerDrawerItem(
+                id = "attachment:${attachment.id}",
+                label = attachment.displayName,
+                subtitle = attachment.metadataLabel(),
+                onRemove = { onRemoveAttachment(attachment) },
+                onClick = { onPreviewAttachment(attachment) },
+            ),
+        )
+    }
+    pendingAttachmentLabels.forEachIndexed { index, (label, onRemove) ->
+        add(
+            ChatComposerDrawerItem(
+                id = "attachment-pending:$index:$label",
+                label = label,
+                pending = true,
+                onRemove = onRemove,
+            ),
+        )
+    }
+    attachmentErrors.forEachIndexed { index, (label, error) ->
+        add(
+            ChatComposerDrawerItem(
+                id = "attachment-error:$index:$label",
+                label = label,
+                error = error,
+                onRemove = {},
+            ),
+        )
     }
     imagePaths.forEach { path ->
         val name = path.substringAfterLast('/').substringAfterLast('\\')

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatFindBar.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatFindBar.kt
@@ -1,0 +1,150 @@
+package app.andy.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.andy.ui.theme.AndyColors
+import app.andy.ui.theme.AndyRadius
+import app.andy.ui.theme.AndySpace
+import app.andy.ui.theme.DisplayFont
+import app.andy.ui.theme.MonoFont
+import app.andy.ui.theme.TextPrimary
+import app.andy.ui.theme.TextSecondary
+import androidx.compose.foundation.shape.RoundedCornerShape
+
+/**
+ * Floating in-chat find bar. Caller owns query/match index and keyboard chords that open it.
+ */
+@Composable
+fun ChatFindBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    matchIndex: Int,
+    matchCount: Int,
+    onFindNext: () -> Unit,
+    onFindPrevious: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    /** Bump to re-request focus (e.g. Cmd+F while the bar is already open). */
+    focusNonce: Int = 0,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(focusNonce) {
+        runCatching { focusRequester.requestFocus() }
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(AndyColors.SurfaceRaised, RoundedCornerShape(AndyRadius.Control))
+            .border(1.dp, AndyColors.BorderEmphasized, RoundedCornerShape(AndyRadius.Control))
+            .padding(horizontal = AndySpace.Space2, vertical = AndySpace.Space2)
+            .testTag("chat-find-bar"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+    ) {
+        LucideIcon(Lucide.Search, TextSecondary, Modifier.size(14.dp))
+        TextField(
+            value = query,
+            onValueChange = onQueryChange,
+            modifier = Modifier
+                .weight(1f)
+                .widthIn(min = 120.dp)
+                .focusRequester(focusRequester)
+                .onPreviewKeyEvent { event ->
+                    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    when {
+                        event.key == Key.Escape -> {
+                            onClose()
+                            true
+                        }
+                        event.key == Key.Enter || event.key == Key.NumPadEnter -> {
+                            if (event.isShiftPressed) onFindPrevious() else onFindNext()
+                            true
+                        }
+                        event.key == Key.DirectionDown -> {
+                            onFindNext()
+                            true
+                        }
+                        event.key == Key.DirectionUp -> {
+                            onFindPrevious()
+                            true
+                        }
+                        else -> false
+                    }
+                },
+            singleLine = true,
+            textStyle = androidx.compose.ui.text.TextStyle(
+                fontFamily = DisplayFont,
+                fontSize = 13.sp,
+                color = TextPrimary,
+            ),
+            placeholder = {
+                Text("Find in chat", color = TextSecondary, fontFamily = DisplayFont, fontSize = 13.sp)
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { onFindNext() }),
+        )
+        Text(
+            text = when {
+                query.isBlank() -> ""
+                matchCount == 0 -> "No results"
+                else -> "${(matchIndex + 1).coerceAtLeast(1)} of $matchCount"
+            },
+            color = if (query.isNotBlank() && matchCount == 0) AndyColors.Warning else TextSecondary,
+            fontFamily = MonoFont,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.widthIn(min = 64.dp),
+        )
+        IconButton(
+            onClick = onFindPrevious,
+            enabled = matchCount > 0,
+            contentDescription = "Previous match",
+            modifier = Modifier.size(28.dp),
+        ) {
+            LucideIcon(Lucide.ChevronUp, if (matchCount > 0) TextPrimary else TextSecondary, Modifier.size(14.dp))
+        }
+        IconButton(
+            onClick = onFindNext,
+            enabled = matchCount > 0,
+            contentDescription = "Next match",
+            modifier = Modifier.size(28.dp),
+        ) {
+            LucideIcon(Lucide.ChevronDown, if (matchCount > 0) TextPrimary else TextSecondary, Modifier.size(14.dp))
+        }
+        IconButton(
+            onClick = onClose,
+            contentDescription = "Close find",
+            modifier = Modifier.size(28.dp),
+        ) {
+            LucideIcon(Lucide.X, TextSecondary, Modifier.size(14.dp))
+        }
+    }
+}

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatFindHighlight.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatFindHighlight.kt
@@ -1,0 +1,106 @@
+package app.andy.ui.components
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+
+/**
+ * In-chat find highlight ambient. Provided per transcript row so markdown/plain text can
+ * paint match backgrounds without threading the query through every bubble API.
+ */
+@Immutable
+data class ChatFindHighlight(
+    val query: String,
+    /** Range into this row's searchable/source text for the active hit, if any. */
+    val activeRange: IntRange? = null,
+) {
+    val trimmedQuery: String get() = query.trim()
+    val isActive: Boolean get() = trimmedQuery.isNotEmpty()
+}
+
+val LocalChatFindHighlight = staticCompositionLocalOf<ChatFindHighlight?> { null }
+
+val ChatFindMatchBackground: Color = Color(0x66E2A400)
+val ChatFindActiveMatchBackground: Color = Color(0xCCFBCE03)
+val ChatFindActiveMatchForeground: Color = Color(0xFF1A1408)
+val ChatFindRowWash: Color = Color(0x22E2A400)
+val ChatFindActiveRowWash: Color = Color(0x33FBCE03)
+
+/** All non-overlapping, case-insensitive occurrences of [needle] in [haystack]. */
+fun findLiteralRanges(haystack: String, needle: String): List<IntRange> {
+    val query = needle.trim()
+    if (query.isEmpty() || haystack.isEmpty()) return emptyList()
+    val ranges = ArrayList<IntRange>()
+    var start = 0
+    while (start <= haystack.length - query.length) {
+        val idx = haystack.indexOf(query, startIndex = start, ignoreCase = true)
+        if (idx < 0) break
+        ranges += idx until (idx + query.length)
+        start = idx + query.length
+    }
+    return ranges
+}
+
+/**
+ * Build an [AnnotatedString] with find-match backgrounds. When [activeRange] overlaps a hit
+ * (relative to [text]), that span uses the stronger active style.
+ */
+fun highlightFindMatches(
+    text: String,
+    query: String,
+    activeRange: IntRange? = null,
+): AnnotatedString {
+    val trimmed = query.trim()
+    if (trimmed.isEmpty() || text.isEmpty()) return AnnotatedString(text)
+    val ranges = findLiteralRanges(text, trimmed)
+    if (ranges.isEmpty()) return AnnotatedString(text)
+    return buildAnnotatedString {
+        var cursor = 0
+        for (range in ranges) {
+            if (range.first > cursor) {
+                append(text.substring(cursor, range.first))
+            }
+            val active = activeRange != null && rangesOverlap(range, activeRange)
+            withStyle(
+                SpanStyle(
+                    background = if (active) ChatFindActiveMatchBackground else ChatFindMatchBackground,
+                    color = if (active) ChatFindActiveMatchForeground else Color.Unspecified,
+                ),
+            ) {
+                append(text.substring(range.first, range.last + 1))
+            }
+            cursor = range.last + 1
+        }
+        if (cursor < text.length) {
+            append(text.substring(cursor))
+        }
+    }
+}
+
+fun AnnotatedString.Builder.appendFindHighlighted(
+    text: String,
+    query: String,
+    activeRangeInText: IntRange? = null,
+) {
+    append(highlightFindMatches(text, query, activeRangeInText))
+}
+
+private fun rangesOverlap(a: IntRange, b: IntRange): Boolean =
+    a.first <= b.last && b.first <= a.last
+
+/** Map an active range in the full source string into a leaf substring's local coordinates. */
+fun activeRangeInLeaf(
+    leafStart: Int,
+    leafEnd: Int,
+    activeRange: IntRange?,
+): IntRange? {
+    if (activeRange == null) return null
+    val start = maxOf(activeRange.first, leafStart)
+    val endExclusive = minOf(activeRange.last + 1, leafEnd)
+    if (start >= endExclusive) return null
+    return (start - leafStart) until (endExclusive - leafStart)
+}

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatImageAttach.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/ChatImageAttach.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import app.andy.mergeChatImagePaths
+import app.andy.model.shouldAttachLargeText
 import app.andy.pickImageFiles
 import app.andy.readClipboardImagePaths
 import kotlinx.coroutines.CoroutineScope
@@ -38,6 +39,40 @@ suspend fun attachImagesFromPicker(onImagesAttached: (List<String>) -> Unit) {
     if (picked.isNotEmpty()) onImagesAttached(picked)
 }
 
+/**
+ * Intercepts Cmd/Ctrl+V before the TextField paste runs. Images take priority; otherwise plain
+ * text is routed to [onLargeTextPaste] or [onSmallTextPaste]. Returns true (consumes the event)
+ * once the shortcut is recognized — clipboard work runs on [scope].
+ */
+fun Modifier.onChatComposerPaste(
+    scope: CoroutineScope,
+    onImagesAttached: (List<String>) -> Unit,
+    onSmallTextPaste: (String) -> Unit,
+    onLargeTextPaste: (String) -> Unit,
+    readClipboardText: suspend () -> String? = { null },
+): Modifier = onPreviewKeyEvent { event ->
+    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+    if (event.key != Key.V || (!event.isMetaPressed && !event.isCtrlPressed)) return@onPreviewKeyEvent false
+    scope.launch {
+        val pastedImages = readClipboardImagePaths()
+        if (pastedImages.isNotEmpty()) {
+            onImagesAttached(pastedImages)
+            return@launch
+        }
+        val text = readClipboardText()?.takeIf { it.isNotEmpty() } ?: return@launch
+        if (shouldAttachLargeText(text)) {
+            onLargeTextPaste(text)
+        } else {
+            onSmallTextPaste(text)
+        }
+    }
+    true
+}
+
+/**
+ * Image-only paste hook for simple text fields. Does not consume Cmd/Ctrl+V, so plain-text
+ * paste still reaches the TextField. Prefer [onChatComposerPaste] when staging large text.
+ */
 fun Modifier.onChatImagePaste(
     scope: CoroutineScope,
     onImagesAttached: (List<String>) -> Unit,

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/CommandPalette.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/CommandPalette.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,6 +29,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +37,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -46,7 +50,6 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.andy.ui.theme.AndyColors
-import app.andy.ui.theme.AndyLayout
 import app.andy.ui.theme.AndyShape
 import app.andy.ui.theme.AndySpace
 import app.andy.ui.theme.DisplayFont
@@ -54,6 +57,8 @@ import app.andy.ui.theme.MonoFont
 import app.andy.ui.theme.PaneDividerTint
 import app.andy.ui.theme.TextPrimary
 import app.andy.ui.theme.TextSecondary
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 /** A searchable command-palette item. */
@@ -65,11 +70,20 @@ data class CommandPaletteItem(
     val keywords: List<String> = emptyList(),
 )
 
+/** Chat ids already covered by metadata results — skip duplicate transcript hits. */
+fun commandPaletteExcludedChatIds(syncItems: List<CommandPaletteItem>): Set<String> =
+    syncItems.mapNotNull { item ->
+        item.id.removePrefix("chat:").takeIf { item.id.startsWith("chat:") }
+    }.toSet()
+
 /**
  * Astryx CommandPalette — modal search with grouped results and keyboard footer.
  *
  * Visual markers: PowerSearch field chrome, popover surface, item overlay hover/selected,
  * footer `↑↓ Navigate · ↵ Select · Esc Close`.
+ *
+ * When [asyncSearch] is set, metadata [items] filter instantly and transcript hits stream
+ * into the list after a short debounce, with a bottom spinner while the Flow is active.
  */
 @Composable
 fun CommandPalette(
@@ -80,28 +94,25 @@ fun CommandPalette(
     modifier: Modifier = Modifier,
     placeholder: String = "Type to search",
     title: String? = null,
+    asyncSearch: ((query: String, excludeChatIds: Set<String>) -> Flow<CommandPaletteItem>)? = null,
 ) {
     if (!isOpen) return
     SuppressHeavyweightSurfacesWhileOpen()
     var query by remember { mutableStateOf("") }
     var highlighted by remember { mutableIntStateOf(0) }
+    var asyncItems by remember { mutableStateOf<List<CommandPaletteItem>>(emptyList()) }
+    var asyncSearching by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val filtered = remember(items, query) {
-        val trimmed = query.trim()
-        if (trimmed.isBlank()) {
-            items
-        } else {
-            items.filter { item ->
-                item.label.contains(trimmed, ignoreCase = true) ||
-                    item.supporting?.contains(trimmed, ignoreCase = true) == true ||
-                    item.group.contains(trimmed, ignoreCase = true) ||
-                    item.keywords.any { it.contains(trimmed, ignoreCase = true) }
-            }
-        }
+        filterCommandPaletteItems(items, query)
     }
-    val flat = remember(filtered) { filtered }
+    val excludeChatIds = remember(filtered) { commandPaletteExcludedChatIds(filtered) }
+    val flat = remember(filtered, asyncItems) { filtered + asyncItems }
+    // Parent screens (Actions) recompose often while a chat streams; never key the search
+    // effect on the lambda identity or each recomposition cancels before hits arrive.
+    val asyncSearchUpdated by rememberUpdatedState(asyncSearch)
     LaunchedEffect(flat) {
         highlighted = highlighted.coerceIn(0, (flat.size - 1).coerceAtLeast(0))
     }
@@ -109,7 +120,32 @@ fun CommandPalette(
         if (isOpen) {
             query = ""
             highlighted = 0
+            asyncItems = emptyList()
+            asyncSearching = false
             focusRequester.requestFocus()
+        }
+    }
+    LaunchedEffect(query, excludeChatIds) {
+        val search = asyncSearchUpdated
+        val trimmed = query.trim()
+        if (search == null || trimmed.length < 2) {
+            asyncItems = emptyList()
+            asyncSearching = false
+            return@LaunchedEffect
+        }
+        asyncItems = emptyList()
+        asyncSearching = true
+        try {
+            delay(150)
+            search(trimmed, excludeChatIds).collect { hit ->
+                val chatId = hit.id.removePrefix("chat:")
+                if (hit.id.startsWith("chat:") && chatId in excludeChatIds) return@collect
+                if (asyncItems.none { it.id == hit.id }) {
+                    asyncItems = asyncItems + hit
+                }
+            }
+        } finally {
+            asyncSearching = false
         }
     }
 
@@ -207,6 +243,17 @@ fun CommandPalette(
                     placeholder = {
                         Text(placeholder, color = TextSecondary.copy(alpha = 0.66f), fontFamily = DisplayFont, fontSize = 13.sp)
                     },
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        disabledContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent,
+                        cursorColor = TextPrimary,
+                        focusedTextColor = TextPrimary,
+                        unfocusedTextColor = TextPrimary,
+                    ),
                 )
             }
             Box(
@@ -214,7 +261,7 @@ fun CommandPalette(
                     .fillMaxWidth()
                     .heightIn(min = 120.dp, max = 360.dp),
             ) {
-                if (flat.isEmpty()) {
+                if (flat.isEmpty() && !asyncSearching) {
                     Text(
                         "No results",
                         color = TextSecondary,
@@ -261,11 +308,42 @@ fun CommandPalette(
                                 )
                             }
                         }
+                        if (asyncSearching) {
+                            item(key = "async-searching") {
+                                Row(
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = AndySpace.Space3, vertical = AndySpace.Space2),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
+                                ) {
+                                    Spinner(spinnerSize = SpinnerSize.Sm, shade = SpinnerShade.Subtle)
+                                    Text(
+                                        "Searching transcripts…",
+                                        color = TextSecondary,
+                                        fontFamily = DisplayFont,
+                                        fontSize = 12.sp,
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
             }
             CommandPaletteFooter()
         }
+    }
+}
+
+/** Sync metadata filter used by [CommandPalette] — extracted for tests. */
+fun filterCommandPaletteItems(items: List<CommandPaletteItem>, query: String): List<CommandPaletteItem> {
+    val trimmed = query.trim()
+    if (trimmed.isBlank()) return items
+    return items.filter { item ->
+        item.label.contains(trimmed, ignoreCase = true) ||
+            item.supporting?.contains(trimmed, ignoreCase = true) == true ||
+            item.group.contains(trimmed, ignoreCase = true) ||
+            item.keywords.any { it.contains(trimmed, ignoreCase = true) }
     }
 }
 

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/LucideIcon.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/LucideIcon.kt
@@ -14,8 +14,11 @@ import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
+import coil3.memory.MemoryCache
 import coil3.request.ImageRequest
 import coil3.svg.SvgDecoder
+
+private const val LUCIDE_MEMORY_CACHE_BYTES = 16L * 1024 * 1024
 
 private val lucideBytes = mutableMapOf<String, ByteArray>()
 private var sharedLoader: ImageLoader? = null
@@ -25,6 +28,13 @@ private fun lucideImageLoader(context: PlatformContext): ImageLoader {
     if (existing != null) return existing
     return ImageLoader.Builder(context)
         .components { add(SvgDecoder.Factory()) }
+        // Coil defaults this cache to 25% of max heap, which is ~190MB of Skia-backed native
+        // images. This loader only ever holds small bundled Lucide SVGs, so cap it outright.
+        .memoryCache {
+            MemoryCache.Builder()
+                .maxSizeBytes(LUCIDE_MEMORY_CACHE_BYTES)
+                .build()
+        }
         .build()
         .also { sharedLoader = it }
 }

--- a/ui/components/src/commonMain/kotlin/app/andy/ui/components/MarkdownPreview.kt
+++ b/ui/components/src/commonMain/kotlin/app/andy/ui/components/MarkdownPreview.kt
@@ -51,14 +51,16 @@ import com.mikepenz.markdown.compose.elements.MarkdownTable
 import com.mikepenz.markdown.compose.elements.MarkdownTableHeader
 import com.mikepenz.markdown.compose.elements.MarkdownTableRow
 import com.mikepenz.markdown.m3.Markdown
-import dev.snipme.highlights.Highlights
-import dev.snipme.highlights.model.SyntaxTheme
-import dev.snipme.highlights.model.SyntaxThemes
+import com.mikepenz.markdown.model.markdownAnnotator
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.model.markdownPadding
 import com.mikepenz.markdown.model.rememberMarkdownState
+import dev.snipme.highlights.Highlights
+import dev.snipme.highlights.model.SyntaxTheme
+import dev.snipme.highlights.model.SyntaxThemes
+import org.intellij.markdown.MarkdownTokenTypes
 
 /**
  * Ambient handler for markdown links that look like source-file references rather than web
@@ -219,6 +221,28 @@ private fun AndyMarkdown(
     val unwrapped = if (onTextChange == null) text.unwrapOuterMarkdownFence() else text
     val markdownState = rememberMarkdownState(unwrapped, retainState = true)
     val highlightsBuilder = rememberAndyHighlightsBuilder()
+    val findHighlight = LocalChatFindHighlight.current
+    val defaultAnnotator = remember { markdownAnnotator() }
+    val findAnnotator = remember(findHighlight?.trimmedQuery, findHighlight?.activeRange) {
+        val query = findHighlight?.trimmedQuery.orEmpty()
+        val activeRange = findHighlight?.activeRange
+        if (query.isEmpty()) {
+            null
+        } else {
+            markdownAnnotator { content, child ->
+                if (child.type != MarkdownTokenTypes.TEXT) return@markdownAnnotator false
+                val leaf = content.substring(child.startOffset, child.endOffset)
+                if (leaf.isEmpty()) return@markdownAnnotator false
+                val localActive = activeRangeInLeaf(
+                    leafStart = child.startOffset,
+                    leafEnd = child.endOffset,
+                    activeRange = activeRange,
+                )
+                appendFindHighlighted(leaf, query, localActive)
+                true
+            }
+        }
+    }
     val thinking = density == AndyMarkdownDensity.Thinking
     val body = MaterialTheme.typography.bodyMedium.copy(
         fontFamily = if (thinking) MonoFont else DisplayFont,
@@ -244,6 +268,7 @@ private fun AndyMarkdown(
     CompositionLocalProvider(LocalUriHandler provides uriHandler) {
     Markdown(
         markdownState = markdownState,
+        annotator = findAnnotator ?: defaultAnnotator,
         colors = markdownColor(
             text = if (thinking) TextSecondary else TextPrimary,
             // Thinking/tool rows sit on a near-black aside — keep code chrome strong enough that a

--- a/ui/components/src/commonTest/kotlin/app/andy/ui/components/ChatFindHighlightTest.kt
+++ b/ui/components/src/commonTest/kotlin/app/andy/ui/components/ChatFindHighlightTest.kt
@@ -1,0 +1,44 @@
+package app.andy.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChatFindHighlightTest {
+    @Test
+    fun findLiteralRangesIsCaseInsensitiveAndNonOverlapping() {
+        assertEquals(
+            listOf(0 until 3, 8 until 11),
+            findLiteralRanges("Foo bar foo", "foo"),
+        )
+        assertEquals(emptyList(), findLiteralRanges("hello", "xyz"))
+        assertEquals(emptyList(), findLiteralRanges("hello", "  "))
+    }
+
+    @Test
+    fun highlightFindMatchesMarksActiveRange() {
+        val annotated = highlightFindMatches(
+            text = "alpha beta alpha",
+            query = "alpha",
+            activeRange = 11 until 16,
+        )
+        assertEquals("alpha beta alpha", annotated.text)
+        assertEquals(2, annotated.spanStyles.size)
+        assertEquals(ChatFindMatchBackground, annotated.spanStyles[0].item.background)
+        assertEquals(ChatFindActiveMatchBackground, annotated.spanStyles[1].item.background)
+    }
+
+    @Test
+    fun activeRangeInLeafMapsSourceOffsets() {
+        val local = activeRangeInLeaf(leafStart = 10, leafEnd = 20, activeRange = 12 until 15)
+        assertEquals(2 until 5, local)
+        assertEquals(null, activeRangeInLeaf(0, 5, 10 until 12))
+    }
+
+    @Test
+    fun highlightFindMatchesNoQueryReturnsPlain() {
+        val annotated = highlightFindMatches("hello", "")
+        assertEquals("hello", annotated.text)
+        assertTrue(annotated.spanStyles.isEmpty())
+    }
+}

--- a/ui/components/src/commonTest/kotlin/app/andy/ui/components/FormLayoutTest.kt
+++ b/ui/components/src/commonTest/kotlin/app/andy/ui/components/FormLayoutTest.kt
@@ -23,4 +23,23 @@ class CommandPaletteItemTest {
         assertEquals("Projects", item.group)
         assertEquals("Andy", item.label)
     }
+
+    @Test
+    fun filterMatchesLabelAndKeywords() {
+        val items = listOf(
+            CommandPaletteItem("chat:1", "OAuth", "Chats", keywords = listOf("refresh token")),
+            CommandPaletteItem("chat:2", "Unrelated", "Chats"),
+        )
+        val filtered = filterCommandPaletteItems(items, "refresh")
+        assertEquals(listOf("chat:1"), filtered.map { it.id })
+    }
+
+    @Test
+    fun excludedChatIdsFromSyncResults() {
+        val sync = listOf(
+            CommandPaletteItem("project:p", "Proj", "Projects"),
+            CommandPaletteItem("chat:abc", "Title", "Chats"),
+        )
+        assertEquals(setOf("abc"), commandPaletteExcludedChatIds(sync))
+    }
 }

--- a/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/RemoteSessionSidebar.kt
+++ b/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/RemoteSessionSidebar.kt
@@ -14,10 +14,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,11 +28,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -76,7 +90,8 @@ internal fun hostPhaseOf(session: RemoteSessionState, busy: Boolean): HostPhase 
 /** Collapsed-header suffix — names the host, never the failure. */
 internal fun hostHeaderDetail(session: RemoteSessionState, phase: HostPhase): String = when {
     phase == HostPhase.Switching -> "Switching…"
-    session.status == RemoteSessionStatus.Connected -> session.target ?: "Remote"
+    session.status == RemoteSessionStatus.Connected ->
+        session.target?.let { session.displayNameFor(it) } ?: "Remote"
     session.status == RemoteSessionStatus.Error -> "Not connected"
     else -> "Local"
 }
@@ -133,7 +148,12 @@ internal fun RemoteSessionSidebarControls(
     val headerDetail = hostHeaderDetail(session, phase)
 
     if (!expanded) {
-        HostRail(phase = phase, target = session.target, modifier = modifier)
+        HostRail(
+            phase = phase,
+            target = session.target,
+            aliases = session.targetAliases,
+            modifier = modifier,
+        )
         return
     }
 
@@ -182,8 +202,10 @@ internal fun RemoteSessionSidebarControls(
 
         session.savedTargets.forEach { saved ->
             val selected = session.isRemote && session.target == saved
+            val alias = session.targetAliases[saved]?.takeIf { it.isNotBlank() }
             HostRow(
-                label = saved,
+                label = alias ?: saved,
+                supporting = alias?.let { saved },
                 selected = selected,
                 enabled = !switching,
                 // Removing the host you are sitting on would strand the panel mid-session.
@@ -191,6 +213,9 @@ internal fun RemoteSessionSidebarControls(
                     null
                 } else {
                     { scope.launch { remoteSession.removeSavedTarget(saved) } }
+                },
+                onRename = { next ->
+                    scope.launch { remoteSession.renameSavedTargetAlias(saved, next) }
                 },
                 onClick = {
                     if (!selected) {
@@ -283,9 +308,13 @@ private fun ConnectionCard(
         // While connected the header and the selected list row already name the host;
         // only the transitional states need it spelled out here.
         session.target?.takeIf { phase != HostPhase.Connected }?.let { target ->
-            Tooltip(target, modifier = Modifier.fillMaxWidth()) {
+            val display = session.displayNameFor(target)
+            Tooltip(
+                if (display != target) "$display · $target" else target,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 Text(
-                    target,
+                    display,
                     color = TextSecondary,
                     fontFamily = MonoFont,
                     fontSize = 11.sp,
@@ -442,16 +471,39 @@ private fun HostRow(
     selected: Boolean,
     enabled: Boolean,
     onClick: () -> Unit,
+    supporting: String? = null,
     onRemove: (() -> Unit)? = null,
+    onRename: ((String) -> Unit)? = null,
 ) {
     val tokens = andyTokens()
     val interaction = remember { MutableInteractionSource() }
     val hovered by interaction.collectIsHoveredAsState()
+    var editing by remember { mutableStateOf(false) }
+    var draft by remember(label) { mutableStateOf(TextFieldValue(label)) }
+    var editorHadFocus by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
     val background = when {
         selected -> tokens.accentMuted
         hovered && enabled -> AndyColors.SurfaceHover
         else -> Color.Transparent
     }
+
+    fun finishEditing(commit: Boolean) {
+        if (!editing) return
+        val updated = draft.text.trim()
+        if (commit) {
+            // Empty clears the alias so the raw SSH target shows again.
+            onRename?.invoke(updated)
+        }
+        draft = TextFieldValue(if (commit) updated.ifEmpty { supporting ?: label } else label)
+        editing = false
+        editorHadFocus = false
+    }
+
+    LaunchedEffect(editing) {
+        if (editing) focusRequester.requestFocus()
+    }
+
     Row(
         Modifier
             .fillMaxWidth()
@@ -459,7 +511,7 @@ private fun HostRow(
             .clip(AndyShape.Interactive)
             .background(background)
             .clickable(
-                enabled = enabled,
+                enabled = enabled && !editing,
                 interactionSource = interaction,
                 indication = null,
                 onClick = onClick,
@@ -469,33 +521,124 @@ private fun HostRow(
         horizontalArrangement = Arrangement.spacedBy(AndySpace.Space2),
     ) {
         HostDot(phase = if (selected) HostPhase.Connected else HostPhase.Local)
-        Text(
-            label,
-            color = if (selected) TextPrimary else TextSecondary,
-            fontFamily = MonoFont,
-            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-            fontSize = 11.sp,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
-        // Reserved so the label never reflows as the remove affordance fades in.
-        Box(Modifier.size(HostRowIconBox), contentAlignment = Alignment.Center) {
-            if (onRemove != null && hovered && enabled) {
-                Box(
-                    Modifier
-                        .size(HostRowIconBox)
-                        .clip(AndyShape.Interactive)
-                        .clickable(onClick = onRemove)
-                        .semantics { contentDescription = "Remove $label" },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    LucideIcon(
-                        path = Lucide.X,
-                        tint = AndyColors.TextTertiary,
-                        modifier = Modifier.size(HostRowIcon),
-                    )
+        if (editing) {
+            BasicTextField(
+                value = draft,
+                onValueChange = { draft = it },
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            editorHadFocus = true
+                        } else if (editorHadFocus) {
+                            finishEditing(commit = true)
+                        }
+                    }
+                    .onPreviewKeyEvent { event ->
+                        if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                        when (event.key) {
+                            Key.Enter, Key.NumPadEnter -> {
+                                finishEditing(commit = true)
+                                true
+                            }
+                            Key.Escape -> {
+                                finishEditing(commit = false)
+                                true
+                            }
+                            else -> false
+                        }
+                    },
+                textStyle = TextStyle(
+                    color = TextPrimary,
+                    fontFamily = MonoFont,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 11.sp,
+                ),
+                singleLine = true,
+                cursorBrush = SolidColor(tokens.accent),
+                decorationBox = { inner ->
+                    Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+                        if (draft.text.isEmpty()) {
+                            Text(
+                                supporting ?: "Alias",
+                                color = AndyColors.TextTertiary,
+                                fontFamily = MonoFont,
+                                fontSize = 11.sp,
+                                maxLines = 1,
+                            )
+                        }
+                        inner()
+                    }
+                },
+            )
+        } else {
+            val labelContent = @Composable {
+                Text(
+                    label,
+                    color = if (selected) TextPrimary else TextSecondary,
+                    fontFamily = MonoFont,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Box(Modifier.weight(1f)) {
+                if (supporting != null) {
+                    Tooltip(supporting, modifier = Modifier.fillMaxWidth()) { labelContent() }
+                } else {
+                    labelContent()
                 }
+            }
+        }
+        // Reserved so the label never reflows as rename / remove affordances fade in.
+        if (onRename != null) {
+            HostRowIconButton(
+                visible = (hovered || editing) && enabled,
+                path = Lucide.Pencil,
+                contentDescription = "Rename $label",
+                onClick = {
+                    draft = TextFieldValue(
+                        text = label,
+                        selection = TextRange(0, label.length),
+                    )
+                    editing = true
+                },
+            )
+        }
+        HostRowIconButton(
+            visible = onRemove != null && hovered && enabled && !editing,
+            path = Lucide.X,
+            contentDescription = "Remove $label",
+            onClick = { onRemove?.invoke() },
+        )
+    }
+}
+
+@Composable
+private fun HostRowIconButton(
+    visible: Boolean,
+    path: String,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    Box(Modifier.size(HostRowIconBox), contentAlignment = Alignment.Center) {
+        if (visible) {
+            Box(
+                Modifier
+                    .size(HostRowIconBox)
+                    .clip(AndyShape.Interactive)
+                    .clickable(onClick = onClick)
+                    .semantics { this.contentDescription = contentDescription },
+                contentAlignment = Alignment.Center,
+            ) {
+                LucideIcon(
+                    path = path,
+                    tint = AndyColors.TextTertiary,
+                    modifier = Modifier.size(HostRowIcon),
+                )
             }
         }
     }
@@ -581,9 +724,15 @@ private fun HostDot(phase: HostPhase, modifier: Modifier = Modifier) {
 
 /** Collapsed rail: one mark, full host in the tooltip. */
 @Composable
-private fun HostRail(phase: HostPhase, target: String?, modifier: Modifier = Modifier) {
+private fun HostRail(
+    phase: HostPhase,
+    target: String?,
+    aliases: Map<String, String>,
+    modifier: Modifier = Modifier,
+) {
+    val display = target?.let { aliases[it]?.takeIf { name -> name.isNotBlank() } ?: it }
     val tooltip = when (phase) {
-        HostPhase.Connected -> target?.let { "Connected · $it" } ?: "Connected"
+        HostPhase.Connected -> display?.let { "Connected · $it" } ?: "Connected"
         HostPhase.Switching -> "Switching host…"
         HostPhase.Failed -> "Not connected"
         HostPhase.Local -> "Local host"

--- a/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
+++ b/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
@@ -1406,8 +1406,8 @@ internal class ShellState(
             )
         }
         scope.launch {
-            // Preserve saved SSH targets written by RemoteSessionService so a sidebar toggle
-            // (or any other ShellState save) does not wipe the Host list.
+            // Preserve saved SSH targets / aliases written by RemoteSessionService so a sidebar
+            // toggle (or any other ShellState save) does not wipe the Host list.
             val committed = services.workspaceStore.update { current ->
                 val targets =
                     if (updated.savedSshTargets != previous.savedSshTargets) {
@@ -1415,10 +1415,21 @@ internal class ShellState(
                     } else {
                         current.savedSshTargets
                     }
-                updated.copy(savedSshTargets = targets)
+                val aliases =
+                    if (updated.sshTargetAliases != previous.sshTargetAliases) {
+                        updated.sshTargetAliases
+                    } else {
+                        current.sshTargetAliases
+                    }
+                updated.copy(savedSshTargets = targets, sshTargetAliases = aliases)
             }
-            if (workspaceState.savedSshTargets != committed.savedSshTargets) {
-                workspaceState = workspaceState.copy(savedSshTargets = committed.savedSshTargets)
+            if (workspaceState.savedSshTargets != committed.savedSshTargets ||
+                workspaceState.sshTargetAliases != committed.sshTargetAliases
+            ) {
+                workspaceState = workspaceState.copy(
+                    savedSshTargets = committed.savedSshTargets,
+                    sshTargetAliases = committed.sshTargetAliases,
+                )
             }
         }
     }

--- a/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
+++ b/ui/shell/src/commonMain/kotlin/app/andy/ui/shell/ShellState.kt
@@ -1421,7 +1421,19 @@ internal class ShellState(
                     } else {
                         current.sshTargetAliases
                     }
-                updated.copy(savedSshTargets = targets, sshTargetAliases = aliases)
+                // The remote project scanner writes the cache straight to the store; ShellState only
+                // holds a load-time snapshot, so preserve the store's copy unless this save changed it.
+                val remoteProjectCache =
+                    if (updated.remoteProjectCache != previous.remoteProjectCache) {
+                        updated.remoteProjectCache
+                    } else {
+                        current.remoteProjectCache
+                    }
+                updated.copy(
+                    savedSshTargets = targets,
+                    sshTargetAliases = aliases,
+                    remoteProjectCache = remoteProjectCache,
+                )
             }
             if (workspaceState.savedSshTargets != committed.savedSshTargets ||
                 workspaceState.sshTargetAliases != committed.sshTargetAliases

--- a/ui/shell/src/commonTest/kotlin/app/andy/ui/shell/RemoteSessionSidebarStateTest.kt
+++ b/ui/shell/src/commonTest/kotlin/app/andy/ui/shell/RemoteSessionSidebarStateTest.kt
@@ -27,6 +27,19 @@ class RemoteSessionSidebarStateTest {
     }
 
     @Test
+    fun connectedSessionPrefersAliasInHeader() {
+        val session = RemoteSessionState(
+            status = RemoteSessionStatus.Connected,
+            target = "ada@garden-box",
+            targetAliases = mapOf("ada@garden-box" to "Garden"),
+        )
+        val phase = hostPhaseOf(session, busy = false)
+        assertEquals("Garden", hostHeaderDetail(session, phase))
+        assertEquals("Garden", session.displayNameFor("ada@garden-box"))
+        assertEquals("ada@build-rack", session.displayNameFor("ada@build-rack"))
+    }
+
+    @Test
     fun localSwitchInFlightReadsAsSwitching() {
         val session = RemoteSessionState(status = RemoteSessionStatus.Local)
         val phase = hostPhaseOf(session, busy = true)


### PR DESCRIPTION
## Summary

Ships the current working tree as one PR. Main themes:

**Managed chat attachments** (domain + desktop + remote)
- Stage large pastes/uploads to Andy-managed disk, persist only descriptors (bodies never enter task JSON, transcripts, MCP payloads, or argv).
- Materialize into `<cwd>/.andy/<taskId>/attachments` at launch (hard link preferred); discard unbound staged drafts.
- Expire staged draft attachments at startup.
- New: `AgentAttachmentModels`, `ChatAttachmentService`, `DesktopChatAttachmentService`, `RemoteChatAttachmentUpload`, MCP `parseAttachmentsArg`.

**Transcript find**
- `ChatFind` matcher over transcript display items with tool/thinking expansion.
- `ChatFindBar` + `ChatFindHighlight` components, composer integration, and command-palette entry.

**Merged remote Projects list**
- `RemoteProjectScanner` reads `actions.toml` from saved SSH hosts without connecting (reuses warm ControlMaster; otherwise one-shot `BatchMode=yes`).
- Other-host project rows that switch hosts on open; sidebar reflects scan/selection state.

**Mobile**
- Concurrent loading of project/chat and chat-detail/settings.
- Attention push/startup, network access, voice defaults, widget, and shortcuts.

**Misc**
- Desktop transcript search index, voice JNI/global hotkey tweaks, settings/live/markdown/Lucide updates.

## Tests
- New: attachments (models, service, remote upload, startup expiry), transcript search index, ChatFind/Highlight, merged remote projects, remote project scanner, network access loading.
- Updated existing desktop/common suites.

CI (`pr-checks.yml`) will run desktop tests, screenshots, assemble, agent-store, web-launcher, and CLI across platforms.

## Risks / notes
- Large multi-feature changeset; review by area recommended.
- Screenshot baselines may need regeneration if any UI snapshot shifted; CI `verifyRoborazziDesktop` will flag it.